### PR TITLE
Keyboard changes

### DIFF
--- a/src/actions/rs_actionselectall.cpp
+++ b/src/actions/rs_actionselectall.cpp
@@ -47,7 +47,8 @@ QAction* RS_ActionSelectAll::createGUIAction(RS2::ActionType type, QObject* pare
 	} else {
 		// tr("Deselect all")
 		action = new QAction(tr("Deselect &all"), parent);
-                action->setShortcut(QKeySequence(tr("Ctrl+K")));
+                // RVT April 29, 2011 - Added esc key to de-select all entities
+                action->setShortcuts(QList<QKeySequence>() << QKeySequence(Qt::Key_Escape) << QKeySequence(tr("Ctrl+K")));
                 action->setIcon(QIcon(":/extui/selectnothing.png"));
                 //action->zetStatusTip(tr("Deselects all Entities"));
     }


### PR DESCRIPTION
Use the escape key to de-select all entities, ctrl-l will stay as a backup for the old rods used to working with ctrl-k.
