### PR TITLE
Draw MetaGrid after Grid - ID: 3311956

### DIFF
--- a/src/lib/gui/rs_graphicview.cpp
+++ b/src/lib/gui/rs_graphicview.cpp
@@ -990,8 +990,10 @@ void RS_GraphicView::drawLayer1(RS_Painter *painter) {
 
     // drawing meta grid:
     if (!isPrintPreview()) {
+
+        //only drawGrid updates the grid layout (updatePointArray())
+        drawGrid(painter);
         drawMetaGrid(painter);
-		drawGrid(painter);
 
     }
 


### PR DESCRIPTION
This fixes two issues
- Make sure the metagrid is shown right after startup
- issue with the metagrid not updating properly when zooming in/out too a point where the gridscale changes

Thanks to Alek900
