### PR TITLE
Edit box in Dimlinear dialog does not retain angle setting. - ID: 3109338

### DIFF
--- a/src/ui/forms/qg_dimlinearoptions.ui.h
+++ b/src/ui/forms/qg_dimlinearoptions.ui.h
@@ -35,7 +35,7 @@ void QG_DimLinearOptions::setAction(RS_ActionInterface* a, bool update) {
         action = (RS_ActionDimLinear*)a;
 
         QString sa;
-        if (update) {
+        if (!update) {
             sa = QString("%1").arg(RS_Math::rad2deg(action->getAngle()));
         } else {
             RS_SETTINGS->beginGroup("/Dimension");


### PR DESCRIPTION
Edit box in Dimlinear dialog does not retain angle setting. - ID: 3109338
Thanks to AdamZ for providing the sugegstion how to fix
