### PR TITLE
Patch for set polyline closed flag

### DIFF
--- a/src/actions/rs_actiondrawpolyline.cpp
+++ b/src/actions/rs_actiondrawpolyline.cpp
@@ -422,6 +422,7 @@ void RS_ActionDrawPolyline::close() {
 			RS_CoordinateEvent e(polyline->getStartpoint());
 			coordinateEvent(&e);
 		}
+        polyline->setClosed(true);
 		trigger();
         setStatus(SetStartpoint);
         graphicView->moveRelativeZero(start);


### PR DESCRIPTION
Draw a polyline:
From point: 0,0
to point: 10,0
to point: 5,5
press the button close
save the file

The polyline is saved with code 70 = 0 (opened polyline)
and vertex:
1=> 0,0
2=>10,0
3=>5,5
4=>0,0

A closed polyline have different start/end vertex and code 70=1.

Pressing the "close" button add the closing segment, but not set the closed flag.

This patch correct it
