### PR TITLE
Fixing grammar in the donation string

### DIFF
--- a/src/main/qc_applicationwindow.cpp
+++ b/src/main/qc_applicationwindow.cpp
@@ -3176,7 +3176,7 @@ void QC_ApplicationWindow::slotHelpAbout() {
                        "</font></p>" +
                        "<br>" +
                        "<center>" +
-                       tr("Please donate to LibreCAD to help maintain the sourcecode and it's website.") +
+                       tr("Please consider donating to LibreCAD to help maintain the source code and website.") +
                        "<br>" +
                        "<br>" +
                        "<a href=\"http://librecad.org/donate.html\" alt=\"Donate to LibreCAD\">" +


### PR DESCRIPTION
make it a little more professional, cleaner. Suggested by a user (dg1727)
