### PR TITLE
Added ability to use only one generated dir

### DIFF
--- a/common.pro
+++ b/common.pro
@@ -1,12 +1,16 @@
 
 
 # Store intermedia stuff somewhere else
-OBJECTS_DIR = generated/obj
-MOC_DIR = generated/moc
-RCC_DIR = generated/rcc
-UI_DIR = generated/ui
-UI_HEADERS_DIR = generated/ui
-UI_SOURCES_DIR = generated/ui
+isEmpty(GENERATED_DIR){
+ GENERATED_DIR = generated
+}
+ # Store intermedia stuff somewhere else
+OBJECTS_DIR = $${GENERATED_DIR}/obj
+MOC_DIR = $${GENERATED_DIR}/moc
+RCC_DIR = $${GENERATED_DIR}/rcc
+UI_DIR = $${GENERATED_DIR}/ui
+UI_HEADERS_DIR = $${GENERATED_DIR}/ui
+UI_SOURCES_DIR = $${GENERATED_DIR}/ui
 
 
 # Copy command

--- a/libraries/dxflib/dxflib.pro
+++ b/libraries/dxflib/dxflib.pro
@@ -16,6 +16,7 @@ VERSION = 2.2.0.0
 DLL_NAME = dxflib
 TARGET = $$DLL_NAME
 
+GENERATED_DIR = ../../generated/lib/dxflib
 # Use common project definitions.
 include(../../settings.pro)
 include(../../common.pro)

--- a/libraries/fparser/fparser.pro
+++ b/libraries/fparser/fparser.pro
@@ -16,6 +16,7 @@ VERSION = 4.3
 DLL_NAME = fparser
 TARGET = $$DLL_NAME
 
+GENERATED_DIR = ../../generated/lib/fparser
 # Use common project definitions.
 include(../../settings.pro)
 include(../../common.pro)

--- a/libraries/jwwlib/jwwlib.pro
+++ b/libraries/jwwlib/jwwlib.pro
@@ -16,6 +16,7 @@ VERSION = 0.0.1
 DLL_NAME = jwwlib
 TARGET = $$DLL_NAME
 
+GENERATED_DIR = ../../generated/lib/jwwlib
 # Use common project definitions.
 include(../../settings.pro)
 include(../../common.pro)

--- a/libraries/libdxfrw/libdxfrw.pro
+++ b/libraries/libdxfrw/libdxfrw.pro
@@ -16,6 +16,7 @@ VERSION = 0.0.1
 DLL_NAME = dxfrw
 TARGET = $$DLL_NAME
 
+GENERATED_DIR = ../../generated/lib/libdxfrw
 # Use common project definitions.
 include(../../settings.pro)
 include(../../common.pro)

--- a/librecad/src/src.pro
+++ b/librecad/src/src.pro
@@ -18,6 +18,8 @@ SCMREVISION="2.0.0alpha2"
 
 DEFINES += USE_DXFRW=1
 
+# Store intermedia stuff somewhere else
+GENERATED_DIR = ../../generated/librecad
 # Use common project definitions.
 include(../../settings.pro)
 include(../../common.pro)

--- a/plugins/align/align.pro
+++ b/plugins/align/align.pro
@@ -10,6 +10,8 @@ CONFIG += plugin
 VERSION = 1.0.1
 PLUGIN_NAME=align
 
+# Store intermedia stuff somewhere else
+GENERATED_DIR = ../../generated/plugin/align
 # Use common project definitions.
 include(../../common.pro)
 

--- a/tools/ttf2lff/ttf2lff.pro
+++ b/tools/ttf2lff/ttf2lff.pro
@@ -13,6 +13,7 @@ CONFIG   -= app_bundle
 TEMPLATE = app
 DEFINES += VERSION="\"0.0.0.2\""
 
+GENERATED_DIR = ../../generated/tools/ttf2lff
 # Use common project definitions.
 include(../../settings.pro)
 include(../../common.pro)


### PR DESCRIPTION
Ries,
With this patch all the generated files are set in a tree inside "generated" dir, instead of using a different "generated" directory for each part.
if in a module is preferred to allow the generated files in its own tree just does not define "GENERATED_DIR"
