### PR TITLE
Dongxu 

### DIFF
--- a/librecad/src/lib/engine/rs_graphic.cpp
+++ b/librecad/src/lib/engine/rs_graphic.cpp
@@ -339,7 +339,7 @@ bool RS_Graphic::save(bool isAutoSave)
                         RS_DEBUG->print("RS_Graphic::save: Format: %d", (int) actualType);
                         RS_DEBUG->print("RS_Graphic::save: Export...");
 
-                        ret = RS_FILEIO->fileExport(*this, *actualName, actualType);
+                        ret = RS_FileIO::instance()->fileExport(*this, *actualName, actualType);
                     QFileInfo	*finfo				= new QFileInfo(*actualName);
                     modifiedTime=finfo->lastModified();
                     currentFileName=*actualName;
@@ -513,7 +513,7 @@ bool RS_Graphic::open(const QString &filename, RS2::FormatType type) {
     newDoc();
 
     // import file:
-    ret = RS_FILEIO->fileImport(*this, filename, type);
+    ret = RS_FileIO::instance()->fileImport(*this, filename, type);
 
         setModified(false);
         layerList.setModified(false);

--- a/librecad/src/lib/engine/rs_pattern.cpp
+++ b/librecad/src/lib/engine/rs_pattern.cpp
@@ -94,7 +94,7 @@ bool RS_Pattern::loadPattern() {
 
             if (QFileInfo(*it).baseName().toLower()==fileName.toLower()) {
                 path = *it;
-                                RS_DEBUG->print("Pattern found: %s", path.toLatin1().data());
+                RS_DEBUG->print("Pattern found: %s", path.toLatin1().data());
                 break;
             }
         }
@@ -112,12 +112,7 @@ bool RS_Pattern::loadPattern() {
     }
 
     RS_Graphic* gr = new RS_Graphic();
-
-    // allow import patterns from all supported formats
-    // do not limit it to format dxf1
-//	RS_FILEIO->fileImport(*gr, path, RS2::FormatDXF1);
-    RS_FILEIO->fileImport(*gr, path);
-
+    RS_FileIO::instance()->fileImport(*gr, path);
     for (RS_Entity* e=gr->firstEntity(); e!=NULL; e=gr->nextEntity()) {
         if (e->rtti()==RS2::EntityLine || e->rtti()==RS2::EntityArc) {
             RS_Layer* l = e->getLayer();

--- a/librecad/src/lib/fileio/rs_fileio.cpp
+++ b/librecad/src/lib/fileio/rs_fileio.cpp
@@ -28,7 +28,9 @@
 #include <QTextStream>
 #include "rs_fileio.h"
 
-RS_FileIO* RS_FileIO::uniqueInstance = NULL;
+
+
+
 
 /**
  * Calls the import method of the filter responsible for the format
@@ -54,29 +56,12 @@ bool RS_FileIO::fileImport(RS_Graphic& graphic, const QString& file,
 		t = type;
 	}
 
-	filter = getImportFilter(t);
-
-	/*
-	switch (t) {
-	case RS2::FormatCXF:
-        filter = new RS_FilterCXF(graphic);
-		break;
-
-	case RS2::FormatDXF1:
-        filter = new RS_FilterDXF1(graphic);
-		break;
-
-	case RS2::FormatDXF:
-        filter = new RS_FilterDXF(graphic);
-		break;
-
-	default:
-		break;
-    }
-	*/
+	filter = getImportFilter(file, t);
 
     if (filter!=NULL) {
-        return filter->fileImport(graphic, file, t);
+        bool returned=filter->fileImport(graphic, file, t);
+        delete filter;
+        return returned;
     }
 	else {
 		RS_DEBUG->print(RS_Debug::D_WARNING,
@@ -113,9 +98,11 @@ bool RS_FileIO::fileExport(RS_Graphic& graphic, const QString& file,
 		}
 	}
 
-	RS_FilterInterface* filter = getExportFilter(type);
+	RS_FilterInterface* filter = getExportFilter(file, type);
 	if (filter!=NULL) {
-		return filter->fileExport(graphic, file, type);
+        bool returned=filter->fileExport(graphic, file, type);
+        delete filter;
+        return returned;
 	}
 	
     RS_DEBUG->print("RS_FileIO::fileExport: no filter found");

--- a/librecad/src/lib/filters/rs_filtercxf.cpp
+++ b/librecad/src/lib/filters/rs_filtercxf.cpp
@@ -43,12 +43,7 @@
 RS_FilterCXF::RS_FilterCXF() : RS_FilterInterface() {
 
     RS_DEBUG->print("Setting up CXF filter...");
-
-    addImportFormat(RS2::FormatCXF);
-    addExportFormat(RS2::FormatCXF);
 }
-
-
 
 /**
  * Implementation of the method used for RS_Import to communicate

--- a/librecad/src/lib/filters/rs_filtercxf.h
+++ b/librecad/src/lib/filters/rs_filtercxf.h
@@ -45,23 +45,21 @@ public:
 	/**
 	 * @return RS2::FormatCXF.
 	 */
-	//RS2::FormatType rtti() {
-	//	return RS2::FormatCXF;
-	//}
-	
-    /*virtual bool canImport(RS2::FormatType t) {
+	virtual bool canImport(const QString &fileName, RS2::FormatType t) const {
 		return (t==RS2::FormatCXF);
 	}
 	
-    virtual bool canExport(RS2::FormatType t) {
+	virtual bool canExport(const QString &fileName, RS2::FormatType t) const {
 		return (t==RS2::FormatCXF);
-	}*/
+    }
 
     virtual bool fileImport(RS_Graphic& g, const QString& file, RS2::FormatType /*type*/);
 
     virtual bool fileExport(RS_Graphic& g, const QString& file, RS2::FormatType /*type*/);
 
     void stream(std::ofstream& fs, double value);
+
+    static RS_FilterInterface* createFilter(){return new RS_FilterCXF();}
 };
 
 #endif

--- a/librecad/src/lib/filters/rs_filterdxf.cpp
+++ b/librecad/src/lib/filters/rs_filterdxf.cpp
@@ -57,10 +57,6 @@ RS_FilterDXF::RS_FilterDXF()
 
     RS_DEBUG->print("RS_FilterDXF::RS_FilterDXF()");
 
-    addImportFormat(RS2::FormatDXF);
-    addExportFormat(RS2::FormatDXF);
-    addExportFormat(RS2::FormatDXF12);
-
     mtext = "";
     polyline = NULL;
     leader = NULL;

--- a/librecad/src/lib/filters/rs_filterdxf.h
+++ b/librecad/src/lib/filters/rs_filterdxf.h
@@ -59,21 +59,13 @@ public:
     RS_FilterDXF();
     ~RS_FilterDXF();
 	
-	/**
-	 * @return RS2::FormatDXF.
-	 */
-	//RS2::FormatType rtti() {
-	//	return RS2::FormatDXF;
-	//}
-
-	/*
-    virtual bool canImport(RS2::FormatType t) {
+	virtual bool canImport(const QString &fileName, RS2::FormatType t) const {
 		return (t==RS2::FormatDXF);
 	}
 	
-    virtual bool canExport(RS2::FormatType t) {
+	virtual bool canExport(const QString &fileName, RS2::FormatType t) const {
 		return (t==RS2::FormatDXF || t==RS2::FormatDXF12);
-	}*/
+    }
 
     // Import:
     virtual bool fileImport(RS_Graphic& g, const QString& file, RS2::FormatType /*type*/);
@@ -193,6 +185,8 @@ public:
 	static int unitToNumber(RS2::Unit unit);
 	
         static bool isVariableTwoDimensional(const QString& var);
+
+    static RS_FilterInterface* createFilter(){return new RS_FilterDXF();}
 
 private:
     /** Pointer to the graphic we currently operate on. */

--- a/librecad/src/lib/filters/rs_filterdxf1.cpp
+++ b/librecad/src/lib/filters/rs_filterdxf1.cpp
@@ -50,11 +50,7 @@ RS_FilterDXF1::RS_FilterDXF1()
     RS_DEBUG->print("Setting up DXF 1 filter...");
 
 	graphic = NULL;
-
-    addImportFormat(RS2::FormatDXF1);
 }
-
-
 
 /**
  * Implementation of the method used for RS_Import to communicate

--- a/librecad/src/lib/filters/rs_filterdxf1.h
+++ b/librecad/src/lib/filters/rs_filterdxf1.h
@@ -46,21 +46,13 @@ public:
     RS_FilterDXF1();
     ~RS_FilterDXF1() {}
 
-	/**
-	 * @return RS2::FormatDXF1.
-	 */
-	//RS2::FormatType rtti() {
-	//	return RS2::FormatDXF1;
-	//}
-
-	/*
-    virtual bool canImport(RS2::FormatType t) {
+	virtual bool canImport(const QString &fileName, RS2::FormatType t) const {
 		return (t==RS2::FormatDXF1);
 	}
 	
-    virtual bool canExport(RS2::FormatType t) {
+	virtual bool canExport(const QString &fileName, RS2::FormatType t) const {
 		return false;
-	}*/
+    }
 
     virtual bool fileImport(RS_Graphic& g, const QString& file, RS2::FormatType /*type*/);
 
@@ -111,6 +103,8 @@ public:
 
     void     strDecodeDxfString(QString& str);
     bool     mtCompFloat(double _v1, double _v2, double _tol=1.0e-6);
+
+    static RS_FilterInterface* createFilter(){return new RS_FilterDXF1();}
 
 protected:
     /** Pointer to the graphic we currently operate on. */

--- a/librecad/src/lib/filters/rs_filterdxfrw.cpp
+++ b/librecad/src/lib/filters/rs_filterdxfrw.cpp
@@ -53,16 +53,10 @@ RS_FilterDXFRW::RS_FilterDXFRW()
 
     RS_DEBUG->print("RS_FilterDXFRW::RS_FilterDXFRW()");
 
-    addImportFormat(RS2::FormatDXFRW);
-    addExportFormat(RS2::FormatDXFRW);
-//    addExportFormat(RS2::FormatDXF12);
-
     currentContainer = NULL;
     graphic = NULL;
     RS_DEBUG->print("RS_FilterDXFRW::RS_FilterDXFRW(): OK");
 }
-
-
 
 /**
  * Destructor.

--- a/librecad/src/lib/filters/rs_filterdxfrw.h
+++ b/librecad/src/lib/filters/rs_filterdxfrw.h
@@ -57,21 +57,13 @@ public:
     RS_FilterDXFRW();
     ~RS_FilterDXFRW();
 	
-	/**
-	 * @return RS2::FormatDXF.
-	 */
-	//RS2::FormatType rtti() {
-	//	return RS2::FormatDXF;
-	//}
-
-	/*
-    virtual bool canImport(RS2::FormatType t) {
-		return (t==RS2::FormatDXF);
+	virtual bool canImport(const QString &fileName, RS2::FormatType t) const {
+        return (t==RS2::FormatDXFRW);
 	}
 	
-    virtual bool canExport(RS2::FormatType t) {
-		return (t==RS2::FormatDXF || t==RS2::FormatDXF12);
-	}*/
+	virtual bool canExport(const QString &fileName, RS2::FormatType t) const {
+        return (t==RS2::FormatDXFRW || t==RS2::FormatDXF12);
+    }
 
     // Import:
     virtual bool fileImport(RS_Graphic& g, const QString& file, RS2::FormatType /*type*/);
@@ -178,6 +170,8 @@ public:
 	static int unitToNumber(RS2::Unit unit);
 	
         static bool isVariableTwoDimensional(const QString& var);
+
+    static RS_FilterInterface* createFilter(){return new RS_FilterDXFRW();}
 
 private:
     /** Pointer to the graphic we currently operate on. */

--- a/librecad/src/lib/filters/rs_filterinterface.h
+++ b/librecad/src/lib/filters/rs_filterinterface.h
@@ -44,8 +44,6 @@ public:
      * Constructor.
      */
     RS_FilterInterface() {
-		//std::cout << "RS_FilterInterface\n";
-        //graphic = NULL;
     }
 
     /**
@@ -59,9 +57,7 @@ public:
      * @retval true if the filter can import the file type 
      * @retval false otherwise.
      */
-    virtual bool canImport(RS2::FormatType t) {
-        return importFormats.contains(t);
-    }
+    virtual bool canImport(const QString &fileName, RS2::FormatType t) const = 0;
 
     /**
      * Checks if this filter can export the given file type.
@@ -69,9 +65,7 @@ public:
      * @return true if the filter can export the file type, 
      *         false otherwise.
      */
-    virtual bool canExport(RS2::FormatType t) {
-        return exportFormats.contains(t);
-    }
+    virtual bool canExport(const QString &fileName, RS2::FormatType t) const = 0;
 
     /**
      * The implementation of this method in a inherited format
@@ -87,32 +81,7 @@ public:
      */
     virtual bool fileExport(RS_Graphic& g, const QString& file, RS2::FormatType type) = 0;
 
-protected:
-    /**
-     * Adds a file extension which can be imported by this filter.
-     */
-    void addImportFormat(RS2::FormatType type) {
-        RS_DEBUG->print("Filter can import %d", (int)type);
-        importFormats += type;
-    }
-
-    /**
-     * Adds a file extension which can be exported by this filter.
-     */
-    void addExportFormat(RS2::FormatType type) {
-        RS_DEBUG->print("Filter can export %d", (int)type);
-        exportFormats += type;
-    }
-
-protected:
-    //! Pointer to the graphic we currently operate on.
-    //RS_Graphic* graphic;
-
-    //! Vector of file extensions this filter can import.
-    QList<RS2::FormatType> importFormats;
-
-    //! Vector of file extensions this filter can export.
-    QList<RS2::FormatType> exportFormats;
+    static RS_FilterInterface * createFilter(){return NULL;}
 };
 
 #endif

--- a/librecad/src/lib/filters/rs_filterjww.cpp
+++ b/librecad/src/lib/filters/rs_filterjww.cpp
@@ -54,10 +54,6 @@ RS_FilterJWW::RS_FilterJWW()
 
         RS_DEBUG->print("RS_FilterJWW::RS_FilterJWW()");
 
-        addImportFormat(RS2::FormatJWW);
-        addExportFormat(RS2::FormatJWW);
-//	addExportFormat(RS2::FormatJWC);
-
         mtext = "";
         polyline = NULL;
         leader = NULL;
@@ -69,8 +65,6 @@ RS_FilterJWW::RS_FilterJWW()
         //systemVariables.setAutoDelete(true);
         RS_DEBUG->print("RS_FilterJWW::RS_FilterJWW(): OK");
 }
-
-
 
 /**
  * Destructor.

--- a/librecad/src/lib/filters/rs_filterjww.h
+++ b/librecad/src/lib/filters/rs_filterjww.h
@@ -196,6 +196,15 @@ public:
 	
 	static bool isVariableTwoDimensional(const QString& var);
 
+    virtual bool canImport(const QString &fileName, RS2::FormatType t) const {
+        return (t==RS2::FormatJWW);
+    }
+
+    virtual bool canExport(const QString &fileName, RS2::FormatType t) const {
+        return (t==RS2::FormatJWW);
+    }
+
+    static RS_FilterInterface *createFilter() {return new RS_FilterJWW();}
 private:
     /** Pointer to the graphic we currently operate on. */
     RS_Graphic* graphic;

--- a/librecad/src/lib/filters/rs_filterlff.cpp
+++ b/librecad/src/lib/filters/rs_filterlff.cpp
@@ -43,14 +43,8 @@
  * Default constructor.
  */
 RS_FilterLFF::RS_FilterLFF() : RS_FilterInterface() {
-
     RS_DEBUG->print("Setting up LFF filter...");
-
-    addImportFormat(RS2::FormatLFF);
-    addExportFormat(RS2::FormatLFF);
 }
-
-
 
 /**
  * Implementation of the method used for RS_Import to communicate
@@ -112,6 +106,7 @@ bool RS_FilterLFF::fileImport(RS_Graphic& g, const QString& file, RS2::FormatTyp
     g.addBlockNotification();
 	return true;
 }
+
 
 QString clearZeros(double num, int prec){
     QString str = QString::number(num, 'f', prec);

--- a/librecad/src/lib/filters/rs_filterlff.h
+++ b/librecad/src/lib/filters/rs_filterlff.h
@@ -49,11 +49,11 @@ RS2::FormatType rtti() {
         return RS2::FormatLFF;
 }
 	
-    virtual bool canImport(RS2::FormatType t) {
+	virtual bool canImport(const QString &fileName, RS2::FormatType t) const {
         return (t==RS2::FormatLFF);
     }
 	
-    virtual bool canExport(RS2::FormatType t) {
+	virtual bool canExport(const QString &fileName, RS2::FormatType t) const {
         return (t==RS2::FormatLFF);
     }
 
@@ -62,6 +62,10 @@ RS2::FormatType rtti() {
     virtual bool fileExport(RS_Graphic& g, const QString& file, RS2::FormatType /*type*/);
 
     void stream(std::ofstream& fs, double value);
+
+    static RS_FilterInterface *createFilter() {return new RS_FilterLFF();}
 };
+
+
 
 #endif

--- a/librecad/src/main/main.cpp
+++ b/librecad/src/main/main.cpp
@@ -109,14 +109,14 @@ int main(int argc, char** argv) {
     RS_SETTINGS->init(XSTR(QC_COMPANYKEY), XSTR(QC_APPKEY));
     RS_SYSTEM->init(XSTR(QC_APPNAME), XSTR(QC_VERSION), XSTR(QC_APPDIR), prgDir);
 
-        RS_FILEIO->registerFilter(new RS_FilterLFF());
-        RS_FILEIO->registerFilter(new RS_FilterCXF());
-        RS_FILEIO->registerFilter(new RS_FilterDXF());
+        RS_FileIO::instance()->registerFilter( (createFilter*)RS_FilterLFF::createFilter);
 #ifdef USE_DXFRW
-        RS_FILEIO->registerFilter(new RS_FilterDXFRW());
+        RS_FileIO::instance()->registerFilter( (createFilter*)RS_FilterDXFRW::createFilter);
 #endif
-        RS_FILEIO->registerFilter(new RS_FilterJWW());
-        RS_FILEIO->registerFilter(new RS_FilterDXF1());
+        RS_FileIO::instance()->registerFilter( (createFilter*)RS_FilterCXF::createFilter);
+        RS_FileIO::instance()->registerFilter( (createFilter*)RS_FilterDXF::createFilter);
+        RS_FileIO::instance()->registerFilter( (createFilter*)RS_FilterJWW::createFilter);
+        RS_FileIO::instance()->registerFilter( (createFilter*)RS_FilterDXF1::createFilter);
 
         // parse command line arguments that might not need a launched program:
         QStringList fileList = handleArgs(argc, argv);


### PR DESCRIPTION
This patch will prevent the filter to be re-used.

The way a filter can decide if it supports a format by inspecting the file is changed and moved into the filter, but need to be filled in at some point so a filter will inspect a file rather decide on the type/extenion. I think we should even at some point remove the complete type based in the canImport/canExport functions..... Essentially we need to get rid of detectFormat in rs_fileio also, it doesn't belong there and let each filter decide if it can handle the type and version.  Should we do this right away?

It also prevents adding filters to the heap when they are not needed in main, only a pointer to a filter function is added, this function will just create a new filter object, that's all.

Dongxu, please check if may way of using function pointers is correct..
