### PR TITLE
new feature; layer list filter

### DIFF
--- a/librecad/src/lib/engine/rs_layer.h
+++ b/librecad/src/lib/engine/rs_layer.h
@@ -72,6 +72,9 @@ public:
 
     //! Help Layer, a help layer has entities of infinite length, and will never be printed out
     bool helpLayer;
+
+    //! visible in layer list
+    bool visibleInLayerList;
 };
 
 
@@ -179,6 +182,21 @@ public:
      */
     bool isLocked() {
         return data.locked;
+    }
+    /**
+     * Locks/Unlocks this layer.
+     *
+     * @param l true: lock, false: unlock
+     */
+    void visibleInLayerList(bool l) {
+        data.visibleInLayerList = l;
+    }
+
+    /**
+  * return the LOCK state of the Layer
+     */
+    bool isVisibleInLayerList() {
+        return data.visibleInLayerList;
     }
     /**
       whether the layer is a help layer

--- a/librecad/src/lib/engine/rs_layerlist.cpp
+++ b/librecad/src/lib/engine/rs_layerlist.cpp
@@ -330,7 +330,9 @@ void RS_LayerList::toggleLock(RS_Layer* layer) {
 void RS_LayerList::freezeAll(bool freeze) {
 
     for (uint l=0; l<count(); l++) {
-        at(l)->freeze(freeze);
+        if (at(l)->isVisibleInLayerList()) {
+             at(l)->freeze(freeze);
+         }
     }
 
     for (int i=0; i<layerListListeners.size(); ++i) {

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -2736,6 +2736,8 @@ void QC_ApplicationWindow::
         // update recent files menu:
         recentFiles->add(fileName);
         openedFiles.append(fileName);
+        layerWidget->slotUpdateLayerList();
+
         RS_DEBUG->print("QC_ApplicationWindow::slotFileOpen: update recent file menu: 2");
         updateRecentFilesMenu();
 

--- a/librecad/src/ui/qg_layerwidget.cpp
+++ b/librecad/src/ui/qg_layerwidget.cpp
@@ -33,6 +33,7 @@
 #include <QMenu>
 #include <QBoxLayout>
 #include <QLabel>
+#include <QLineEdit>
 #include "qg_actionhandler.h"
 
 QG_LayerModel::QG_LayerModel(QObject * parent) : QAbstractTableModel(parent) {
@@ -204,12 +205,19 @@ QG_LayerWidget::QG_LayerWidget(QG_ActionHandler* ah, QWidget* parent,
             actionHandler, SLOT(slotLayersEdit()));
     layButtons->addWidget(but);
 
+    // lineEdit to filter layer list with RegEx
+    matchLayerName = new QLineEdit;
+    matchLayerName->setReadOnly(false);
+    //matchLayerName->setText("*");
+    matchLayerName->setToolTip(tr("Looking for matching layer names"));
+    connect(matchLayerName, SIGNAL( textChanged(QString) ), this, SLOT( slotUpdateLayerList() ) );
+
     //lay->addWidget(caption);
+    lay->addWidget(matchLayerName);
     lay->addLayout(layButtons);
     lay->addWidget(layerView);
 
     connect(layerView, SIGNAL(pressed(QModelIndex)), this, SLOT(slotActivated(QModelIndex)));
-
 }
 
 
@@ -329,6 +337,33 @@ void QG_LayerWidget::slotActivated(QModelIndex layerIdx /*const QString& layerNa
     }
 
     activateLayer(l);
+}
+
+/**
+ * Called when reg-expresion matchLayerName->text changed
+ */
+void QG_LayerWidget::slotUpdateLayerList() {
+    QRegExp rx("");
+    int pos=0, f;
+    QString  s, n;
+
+    n=matchLayerName->text();
+    rx.setPattern(n);
+    rx.setPatternSyntax(QRegExp::WildcardUnix);
+
+    for (unsigned int i=0; i<layerList->count() ; i++) {
+        s=layerModel->getLayer(i)->getName();
+        f=rx.indexIn(s, pos);
+        if ( f == 0 ) {
+            layerView->showRow(i);
+            layerModel->getLayer(i)->visibleInLayerList(true);
+        } else {
+            layerView->hideRow(i);
+            layerModel->getLayer(i)->visibleInLayerList(false);
+        }
+
+    }
+
 }
 
 /**

--- a/librecad/src/ui/qg_layerwidget.h
+++ b/librecad/src/ui/qg_layerwidget.h
@@ -36,6 +36,7 @@
 
 class QG_ActionHandler;
 class QTableView;
+class QLineEdit;
 
 /**
  * Implementation of a model to use in QG_LayerWidget
@@ -112,6 +113,7 @@ signals:
 
 public slots:
     void slotActivated(QModelIndex layerIdx);
+    void slotUpdateLayerList();
 
 protected:
     void contextMenuEvent(QContextMenuEvent *e);
@@ -120,9 +122,10 @@ protected:
 private:
     RS_LayerList* layerList;
     bool showByBlock;
+    QLineEdit* matchLayerName;
     QTableView* layerView;
     QG_LayerModel *layerModel;
-    RS_Layer* lastLayer;
+    RS_Layer* lastLayer;   
     QG_ActionHandler* actionHandler;
 };
 


### PR DESCRIPTION
Now in the window layer list you are able to filter the listed layers,
by input a reg-expression into the lineEdit object. Every changing
inside the lineEdit will renew the layer list.

The buttons hide and show all layers now have only affect to the shown
layers in the list box.

Known bugs:

At the moment editing, removing and adding a layer are not able to renew
the layer list box.

Workaround:

After using one of this option you have to change the reg-expression for
a renew.

Planed issue:

To solve this problem I plan to add the QG_LayerModel class
to the RS_LayerList class.
