### PR TITLE
- ID: 3088777: Implemented snapping to 15 deg if shift key is pressed.

### DIFF
--- a/librecad/src/actions/rs_actiondrawline.h
+++ b/librecad/src/actions/rs_actiondrawline.h
@@ -83,7 +83,8 @@ public:
         void redo();
 
 protected:
-    /**
+    RS_Vector snapToAngle(const RS_Vector& currentCoord);
+     /**
     * Line data defined so far.
     */
     RS_LineData data;


### PR DESCRIPTION
When drawing a line and shift key is pressed(but neither vertical/horizontal/orthogonal restriction nor grid snap is enabled) snapping to 15 degrees occurs.
