### PR TITLE
Removed TRUE/FALSE preprocessor macros and replaced with true/false in a...

### DIFF
--- a/librecad/src/lib/gui/rs_painterqt.cpp
+++ b/librecad/src/lib/gui/rs_painterqt.cpp
@@ -396,7 +396,7 @@ void RS_PainterQt::drawImg(QImage& img, const RS_Vector& pos,
 
     // Render smooth only at close zooms
     if (factor.x < 1 || factor.y < 1) {
-       RS_PainterQt::setRenderHint(SmoothPixmapTransform , TRUE);
+       RS_PainterQt::setRenderHint(SmoothPixmapTransform , true);
     }
     else {
       RS_PainterQt::setRenderHint(SmoothPixmapTransform);

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -198,7 +198,7 @@ QC_ApplicationWindow::QC_ApplicationWindow()
     RS_SETTINGS->endGroup();
 
     // Disable menu and toolbar items
-    emit windowsChanged(FALSE);
+    emit windowsChanged(false);
 
     RS_COMMANDS->updateAlias();
     //plugin load

--- a/librecad/src/ui/forms/qg_layerdialog.cpp
+++ b/librecad/src/ui/forms/qg_layerdialog.cpp
@@ -84,7 +84,7 @@ void QG_LayerDialog::updateLayer() {
 
 void QG_LayerDialog::validate() {
 	if (layerList != NULL && 
-                (editLayer == FALSE || layerName != leName->text())) {
+                (editLayer == false || layerName != leName->text())) {
                 RS_Layer* l = layerList->find(leName->text());
 		if (l != NULL) {
 			QMessageBox::information(parentWidget(),
@@ -112,7 +112,7 @@ void QG_LayerDialog::init(){
 	layer = NULL;
 	layerList = NULL;
 	layerName = "";
-	editLayer = FALSE;
+	editLayer = false;
 }
 
 void QG_LayerDialog::setEditLayer( bool el ){

--- a/librecad/src/ui/qg_dialogfactory.cpp
+++ b/librecad/src/ui/qg_dialogfactory.cpp
@@ -319,7 +319,7 @@ RS_Layer* QG_DialogFactory::requestEditLayerDialog(RS_LayerList* layerList) {
         QG_LayerDialog dlg(parent, QMessageBox::tr("Layer Dialog"));
         dlg.setLayer(layer);
         dlg.setLayerList(layerList);
-        dlg.setEditLayer(TRUE);
+        dlg.setEditLayer(true);
         if (dlg.exec()) {
             dlg.updateLayer();
         } else {


### PR DESCRIPTION
Removed TRUE/FALSE preprocessor macros and replaced with true/false in a couple of places in the library; the rest of the project consistently uses true/false. Did not touch the files that define themselves the TRUE/FALSE constants.

At least one place in the source files gives me an error about TRUE not being defined. This occurred when trying to port to Qt5.
