### PR TITLE
In Qt5 toAscii() no longer exists; this commit replaces it with toLatin1 mathod

### DIFF
--- a/librecad/src/lib/engine/rs_units.cpp
+++ b/librecad/src/lib/engine/rs_units.cpp
@@ -32,6 +32,13 @@
 #include "rs_math.h"
 #include "rs_debug.h"
 
+#if QT_VERSION >= 0x050000
+/* QString::toAscii() no longer exists in Qt5*/
+# ifndef toAscii
+#  define toLatin1
+# endif
+#endif
+
 /**
  * Converts a DXF integer () to a Unit enum.
  */

--- a/librecad/src/lib/filters/rs_filtercxf.cpp
+++ b/librecad/src/lib/filters/rs_filtercxf.cpp
@@ -36,6 +36,12 @@
 #include "rs_block.h"
 #include <QStringList>
 
+#if QT_VERSION >= 0x050000
+/* QString::toAscii() no longer exists in Qt5*/
+# ifndef toAscii
+#  define toLatin1
+# endif
+#endif
 
 /**
  * Default constructor.

--- a/librecad/src/lib/filters/rs_filterjww.cpp
+++ b/librecad/src/lib/filters/rs_filterjww.cpp
@@ -45,6 +45,13 @@
 
 #include <qtextcodec.h>
 
+#if QT_VERSION >= 0x050000
+/* QString::toAscii() no longer exists in Qt5*/
+# ifndef toAscii
+#  define toLatin1
+# endif
+#endif
+
 /**
  * Default constructor.
  *

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -28,6 +28,7 @@
 #include <QMenuBar>
 #include <QDockWidget>
 
+
 #if QT_VERSION < 0x040400
 #include <QtAssistant/QAssistantClient>
 #include <QTime>
@@ -94,6 +95,12 @@
 #include "qc_plugininterface.h"
 #include "rs_commands.h"
 
+#if QT_VERSION >= 0x050000
+/* QString::toAscii() no longer exists in Qt5*/
+# ifndef toAscii
+#  define toLatin1
+# endif
+#endif
 
 QC_ApplicationWindow* QC_ApplicationWindow::appWindow = NULL;
 


### PR DESCRIPTION
In Qt5 toAscii() no longer exists; this commit defines the toAscii macro at the beginning of each file and replaces it with the toLatin1 method.
