### PR TITLE
The printing in Qt5 needs to be included specifying QtPrintSupport

### DIFF
--- a/librecad/src/lib/engine/rs.h
+++ b/librecad/src/lib/engine/rs.h
@@ -28,7 +28,12 @@
 #define RS_H
 
 #include <qnamespace.h>
-#include <qprinter.h>
+#include <qglobal.h>
+#if QT_VERSION >= 0x050000
+# include <QtPrintSupport/QPrinter>
+#else
+# include <qprinter.h>
+#endif 
 
 #define RS_TEST
 

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -49,8 +49,15 @@
 
 #include <fstream>
 
-#include <QPrinter>
-#include <QPrintDialog>
+
+#if QT_VERSION >= 0x050000
+# include <QtPrintSupport/QPrinter>
+# include <QtPrintSupport/QPrintDialog>
+#else
+# include <QPrinter>
+# include <QPrintDialog>
+#endif 
+
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QTimer>

--- a/librecad/src/main/qc_mdiwindow.cpp
+++ b/librecad/src/main/qc_mdiwindow.cpp
@@ -26,14 +26,19 @@
 
 #include "qc_mdiwindow.h"
 
-#include <QPrinter>
+#if QT_VERSION >= 0x050000
+# include <QtPrintSupport/QPrinter>
+# include <QtPrintSupport/QPrintDialog>
+#else
+# include <QPrinter>
+# include <QPrintDialog>
+#endif 
 //Added by qt3to4:
 #include <QCloseEvent>
 
 #include <QMainWindow>
 #include <QCursor>
 #include <QMessageBox>
-#include <QPrintDialog>
 #include <QFileInfo>
 #include <QMdiArea>
 #include <QPainter>


### PR DESCRIPTION
`#include <QPrinter>`
is no longer enough. With Qt5 one needs:
`#include <QtPrintSupport/QPrinter>`
