### PR TITLE
In Qt5 toAscii() no longer exists; this commit replaces it with toLatin1 method

### DIFF
--- a/librecad/src/lib/engine/rs_units.cpp
+++ b/librecad/src/lib/engine/rs_units.cpp
@@ -1401,7 +1401,7 @@ void RS_Units::test() {
             s = RS_Units::formatLinear(v, RS2::Inch, RS2::Architectural,
                                        prec, true);
                         // RVT_PORT changed  << s to s.ascii()
-            std::cout << "prec: " << prec << " v: " << v << " s: " << s.toAscii().data() << "\n";
+            std::cout << "prec: " << prec << " v: " << v << " s: " << s.toLatin1().data() << "\n";
         }
     }
 

--- a/librecad/src/lib/filters/rs_filtercxf.cpp
+++ b/librecad/src/lib/filters/rs_filtercxf.cpp
@@ -178,11 +178,11 @@ bool RS_FilterCXF::fileExport(RS_Graphic& g, const QString& file, RS2::FormatTyp
                 RS_DEBUG->print("006a");
                 a = QString(*it2);
                 RS_DEBUG->print("006b");
-                RS_DEBUG->print("string is: %s", a.toAscii().data());
+                RS_DEBUG->print("string is: %s", a.toLatin1().data());
                 RS_DEBUG->print("006b0");
                 fprintf(fp, "# Author:            ");
                 RS_DEBUG->print("006b1");
-                fprintf(fp, "%s\n", a.toAscii().data());
+                fprintf(fp, "%s\n", a.toLatin1().data());
                 //fout << "# Author:            " << a.ascii() << "\n";
             }
             RS_DEBUG->print("007");

--- a/librecad/src/lib/filters/rs_filterjww.cpp
+++ b/librecad/src/lib/filters/rs_filterjww.cpp
@@ -3020,7 +3020,7 @@ QString RS_FilterJWW::toNativeString(const char* data, const QString& encoding) 
      *	  the string through a textcoder.
      *	--------------------------------------------------------------------- */
     if (!res.contains("\\U+")) {
-        QTextCodec *codec = QTextCodec::codecForName(encoding.toAscii());
+        QTextCodec *codec = QTextCodec::codecForName(encoding.toLatin1());
         if (codec)
             res = codec->toUnicode(data);
     }

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -3219,7 +3219,7 @@ bool QC_ApplicationWindow::slotFileExport(const QString& name,
         QImage img = picture->toImage();
         // RVT_PORT iio.setImage(img);
         iio.setFileName(name);
-        iio.setFormat(format.toAscii());
+        iio.setFormat(format.toLatin1());
         // RVT_PORT if (iio.write()) {
         if (iio.write(img)) {
             ret = true;
@@ -3946,7 +3946,7 @@ void QC_ApplicationWindow::slotTestDumpEntities(RS_EntityContainer* d) {
                 lay = e->getLayer()->getName();
             }
             dumpFile
-            << "<td>Layer: " << lay.toAscii().data() << "</td>"
+            << "<td>Layer: " << lay.toLatin1().data() << "</td>"
             << "<td>Width: " << (int)e->getPen(false).getWidth() << "</td>"
             << "<td>Parent: " << e->getParent()->getId() << "</td>"
             << "</tr></table>";
@@ -4084,10 +4084,10 @@ void QC_ApplicationWindow::slotTestDumpEntities(RS_EntityContainer* d) {
                     << d->getExtensionPoint2()
                     << "</td>"
                     << "<td>Text: "
-                    << d->getText().toAscii().data()
+                    << d->getText().toLatin1().data()
                     << "</td>"
                     << "<td>Label: "
-                    << d->getLabel().toAscii().data()
+                    << d->getLabel().toLatin1().data()
                     << "</td>"
                     << "</tr></table>";
                 }


### PR DESCRIPTION
In Qt5 toAscii() no longer exists; this commit defines the toAscii macro at the beginning of each file and replaces it with the toLatin1 method.

This commit replaces toAscii() by the modern toLatin1() method of the QString class
