### PR TITLE
QDir - replace convertSeparators with toNativeSeparators

### DIFF
--- a/librecad/src/main/main.cpp
+++ b/librecad/src/main/main.cpp
@@ -235,7 +235,7 @@ int main(int argc, char** argv) {
 #ifdef QSPLASHSCREEN_H
                         if (splash) {
                                 splash->showMessage(QObject::tr("Loading File %1..")
-                                        .arg(QDir::convertSeparators(*it)),
+                                        .arg(QDir::toNativeSeparators(*it)),
                                 Qt::AlignRight|Qt::AlignBottom, QC_SPLASH_TXTCOL);
                                 qApp->processEvents();
                         }
@@ -294,7 +294,7 @@ QStringList handleArgs(int argc, char** argv) {
 
         for (int i=1; i<argc; i++) {
                 if (QString(argv[i]).startsWith("-")==false) {
-                        QString fname = QDir::convertSeparators(
+                        QString fname = QDir::toNativeSeparators(
                                 QFileInfo(QFile::decodeName(argv[i])).absoluteFilePath() );
                         ret.append(fname);
                 }

--- a/librecad/src/ui/qg_filedialog.cpp
+++ b/librecad/src/ui/qg_filedialog.cpp
@@ -155,7 +155,7 @@ QString QG_FileDialog::getOpenFile(RS2::FormatType* type){
         if (!fl.isEmpty()) {
             fn = fl[0];
         }
-        fn = QDir::convertSeparators( QFileInfo(fn).absoluteFilePath() );
+        fn = QDir::toNativeSeparators( QFileInfo(fn).absoluteFilePath() );
 
         if (type!=NULL) {
                 getType(selectedFilter());
@@ -235,7 +235,7 @@ QString QG_FileDialog::getSaveFile(RS2::FormatType* type){
         return QString("");
 
     QFileInfo fi = QFileInfo( fl[0] );
-    fn = QDir::convertSeparators( fi.absoluteFilePath() );
+    fn = QDir::toNativeSeparators( fi.absoluteFilePath() );
 
     getType(selectedFilter());
     if (type!=NULL)
@@ -305,7 +305,7 @@ QString QG_FileDialog::getSaveFileName(QWidget* parent, RS2::FormatType* type) {
             QStringList fl = fileDlg->selectedFiles();
             if (!fl.isEmpty())
                 fn = fl[0];
-            fn = QDir::convertSeparators( QFileInfo(fn).absoluteFilePath() );
+            fn = QDir::toNativeSeparators( QFileInfo(fn).absoluteFilePath() );
             cancel = false;
 
             // append default extension:
@@ -455,7 +455,7 @@ QString QG_FileDialog::getOpenFileName(QWidget* parent, RS2::FormatType* type) {
         QStringList fl = fileDlg->selectedFiles();
         if (!fl.isEmpty())
             fn = fl[0];
-        fn = QDir::convertSeparators( QFileInfo(fn).absoluteFilePath() );
+        fn = QDir::toNativeSeparators( QFileInfo(fn).absoluteFilePath() );
         if (type!=NULL) {
             if (fileDlg->selectedNameFilter()==fDxf1) {
                 *type = RS2::FormatDXF1;


### PR DESCRIPTION
QDir nolonger has `convertSeparator()``s in Qt5;`toNativeSeparators()``` is present since 4.2; this commit replaces the former with the latter
