### PR TITLE
QDesktopServices::storageLocation is no longer provided in Qt5

### DIFF
--- a/librecad/src/lib/engine/rs_system.cpp
+++ b/librecad/src/lib/engine/rs_system.cpp
@@ -39,6 +39,10 @@
 #include "emu_qt44.h"
 #endif
 
+#if QT_VERSION > 0x050000
+#include <QStandardPaths>
+#endif
+
 RS_System* RS_System::uniqueInstance = NULL;
 
 
@@ -449,7 +453,12 @@ bool RS_System::createPaths(const QString& directory) {
  * @return Application data directory.
  */
 QString RS_System::getAppDataDir() {
-    QString appData = QDesktopServices::storageLocation(QDesktopServices::DataLocation) ;
+    QString appData = 
+#if QT_VERSION >= 0x050000
+			QStandardPaths::writableLocation(QStandardPaths::DataLocation);
+#else
+			QDesktopServices::storageLocation(QDesktopServices::DataLocation) ;
+#endif 
     QDir dir(appData);
     if (!dir.exists()) {
         if (!dir.mkpath(appData))
@@ -518,13 +527,24 @@ QStringList RS_System::getDirectoryList(const QString& _subDirectory) {
         dirList.append(emu_qt44_storageLocationDocuments() + "/" + 
                        appDirName + "/" + 
                        subDirectory);
-#else
+#else // QT_VERSION > 0x040400 or _MSC_VER not defined (!)
+	
 #ifdef Q_OS_MAC
-        dirList.append(QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation) + "/" + appDirName + "/" + subDirectory);
-#endif
+#if QT_VERSION >= 0x050000
+    dirList.append(QStandardPaths::writableLocation(QStandardPaths::DataLocation) + "/" + appDirName + "/" + subDirectory);
+#else
+    dirList.append(QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation) + "/" + appDirName + "/" + subDirectory);
+#endif 
+#endif  // Q_OS_MAC
+	
 #ifdef Q_OS_WIN32
+#if QT_VERSION >= 0x050000
+        dirList.append(QStandardPaths::writableLocation(QStandardPaths::DataLocation) + "/" + appDirName + "/" + subDirectory);
+#else
         dirList.append(QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation) + "/" + appDirName + "/" + subDirectory);
-#endif
+#endif 
+#endif // Q_OS_WIN32
+    
     // Unix home directory, it's old style but some people might have stuff there.
     dirList.append(getHomeDir() + "/." + appDirName + "/" + subDirectory);
 #endif // QT_VERSION < 0x040400 && defined(_MSC_VER)

--- a/librecad/src/ui/qg_librarywidget.cpp
+++ b/librecad/src/ui/qg_librarywidget.cpp
@@ -377,6 +377,8 @@ QString QG_LibraryWidget::getPathToPixmap(const QString& dir,
     // the thumbnail must be created in the user's home.
 #if QT_VERSION < 0x040400
     QString iconCacheLocation = emu_qt44_storageLocationData() + QDir::separator() + "iconCache" + QDir::separator();
+#elif QT_VERSION >= 0x050000
+    QString iconCacheLocation=QStandardPaths::writableLocation(QStandardPaths::DataLocation) + QDir::separator() + "iconCache" + QDir::separator();
 #else
     QString iconCacheLocation=QDesktopServices::storageLocation(QDesktopServices::DataLocation) + QDir::separator() + "iconCache" + QDir::separator();
 #endif


### PR DESCRIPTION
QDesktopServices::storageLocation is no longer provided; QStandardPaths::writableLocation() may be used instead for our purposes
