### PR TITLE
In Qt4 Qt::WFlags has been replaced by the Qt::WindowFlags

### DIFF
--- a/librecad/src/ui/qg_blockwidget.cpp
+++ b/librecad/src/ui/qg_blockwidget.cpp
@@ -117,7 +117,7 @@ QVariant QG_BlockModel::data ( const QModelIndex & index, int role ) const {
  * Constructor.
  */
 QG_BlockWidget::QG_BlockWidget(QG_ActionHandler* ah, QWidget* parent,
-                               const char* name, Qt::WFlags f)
+                               const char* name, Qt::WindowFlags f)
         : QWidget(parent, f) {
 
     setObjectName(name);

--- a/librecad/src/ui/qg_blockwidget.h
+++ b/librecad/src/ui/qg_blockwidget.h
@@ -76,7 +76,7 @@ class QG_BlockWidget: public QWidget, public RS_BlockListListener {
 
 public:
     QG_BlockWidget(QG_ActionHandler* ah, QWidget* parent,
-                   const char* name=0, Qt::WFlags f = 0);
+                   const char* name=0, Qt::WindowFlags f = 0);
     ~QG_BlockWidget();
 
     void setBlockList(RS_BlockList* blockList) {

--- a/librecad/src/ui/qg_graphicview.cpp
+++ b/librecad/src/ui/qg_graphicview.cpp
@@ -50,7 +50,7 @@
 /**
  * Constructor.
  */
-QG_GraphicView::QG_GraphicView(QWidget* parent, const char* name, Qt::WFlags f)
+QG_GraphicView::QG_GraphicView(QWidget* parent, const char* name, Qt::WindowFlags f)
         : QWidget(parent, f), RS_GraphicView() {
 
     setObjectName(name);

--- a/librecad/src/ui/qg_graphicview.h
+++ b/librecad/src/ui/qg_graphicview.h
@@ -51,7 +51,7 @@ class QG_GraphicView: public QWidget,
     Q_OBJECT
 
 public:
-    QG_GraphicView(QWidget* parent=0, const char* name=0, Qt::WFlags f=0);
+    QG_GraphicView(QWidget* parent=0, const char* name=0, Qt::WindowFlags f=0);
     virtual ~QG_GraphicView();
 
     virtual int getWidth();

--- a/librecad/src/ui/qg_layerwidget.cpp
+++ b/librecad/src/ui/qg_layerwidget.cpp
@@ -134,7 +134,7 @@ QVariant QG_LayerModel::data ( const QModelIndex & index, int role ) const {
  * Constructor.
  */
 QG_LayerWidget::QG_LayerWidget(QG_ActionHandler* ah, QWidget* parent,
-                               const char* name, Qt::WFlags f)
+                               const char* name, Qt::WindowFlags f)
         : QWidget(parent, f) {
 
     setObjectName(name);

--- a/librecad/src/ui/qg_layerwidget.h
+++ b/librecad/src/ui/qg_layerwidget.h
@@ -82,7 +82,7 @@ class QG_LayerWidget: public QWidget, public RS_LayerListListener {
 
 public:
     QG_LayerWidget(QG_ActionHandler* ah, QWidget* parent,
-                   const char* name=0, Qt::WFlags f = 0);
+                   const char* name=0, Qt::WindowFlags f = 0);
     ~QG_LayerWidget();
 
     void setLayerList(RS_LayerList* layerList, bool showByBlock);


### PR DESCRIPTION
In Qt4 Qt::WFlags has been replaced by the Qt::WindowFlags. The sources were updated to reflect that.
