### PR TITLE
QFileDialog used setNameFilters instead of setFilters starting with 4.4

### DIFF
--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -101,6 +101,15 @@
 #include "qc_plugininterface.h"
 #include "rs_commands.h"
 
+#if QT_VERSION >= 0x040400
+/* starting with Qt 4.4 the name of the function changed; as the target
+ * of the project is Qt 4.3, we need too keep the old name, too
+ *
+ *	TNick <nicu.tofan@gmail.com>
+ */
+# define  selectedFilter	    selectedNameFilter
+# define  setFilters            setNameFilters
+#endif
 
 QC_ApplicationWindow* QC_ApplicationWindow::appWindow = NULL;
 

--- a/librecad/src/ui/qg_dialogfactory.cpp
+++ b/librecad/src/ui/qg_dialogfactory.cpp
@@ -108,6 +108,16 @@
 #include "emu_qt44.h"
 #endif
 
+#if QT_VERSION >= 0x040400
+/* starting with Qt 4.4 the name of the function changed; as the target
+ * of the project is Qt 4.3, we need too keep the old name, too
+ *
+ *	TNick <nicu.tofan@gmail.com>
+ */
+# define  selectedFilter	    selectedNameFilter
+# define  setFilters            setNameFilters
+#endif
+
 //QG_DialogFactory* QG_DialogFactory::uniqueInstance = NULL;
 
 /**

--- a/librecad/src/ui/qg_filedialog.cpp
+++ b/librecad/src/ui/qg_filedialog.cpp
@@ -39,6 +39,16 @@
 #include "emu_qt44.h"
 #endif
 
+#if QT_VERSION >= 0x040400
+/* starting with Qt 4.4 the name of the function changed; as the target
+ * of the project is Qt 4.3, we need too keep the old name, too
+ *
+ *	TNick <nicu.tofan@gmail.com>
+ */
+# define  selectedFilter	    selectedNameFilter
+# define  setFilters            setNameFilters
+#endif
+
 void QG_FileDialog::getType(const QString filter) {
     if (filter== fLff) {
         ftype = RS2::FormatLFF;


### PR DESCRIPTION
This commit only defines a replacement at the top of the affected files. Since there are a lot of instantiations I have no time to add a if / else for each. If/when the bottom limit will be raised from Qt 4.3 the definition may be removed and setFilters  simply replaced with setNameFilters.
