### PR TITLE
Removed some harmless warnings

### DIFF
--- a/librecad/src/actions/rs_actiondrawcircletan2_1p.cpp
+++ b/librecad/src/actions/rs_actiondrawcircletan2_1p.cpp
@@ -144,7 +144,7 @@ bool RS_ActionDrawCircleTan2_1P::getCenters()
 
     auto&& list=LC_Quadratic::getIntersection(lc0,lc1);
     centers.clean();
-    for(int i=0;i<list.size();i++){
+    for(unsigned int i=0;i<list.size();i++){
         auto&& vp=list.get(i);
         auto&& ds=vp.distanceTo(point)-RS_TOLERANCE;
         bool validBranch(true);

--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -670,7 +670,7 @@ bool RS_Modification::splitPolyline(RS_Polyline& polyline,
     container->addEntity(pl2);
     //container->removeEntity(&polyline);
     polyline.changeUndoState();
-
+	Q_UNUSED( arc ); /* TNick: set but not used */
     return true;
 }
 

--- a/librecad/src/ui/qg_dialogfactory.cpp
+++ b/librecad/src/ui/qg_dialogfactory.cpp
@@ -205,7 +205,7 @@ RS_Layer* QG_DialogFactory::requestNewLayerDialog(RS_LayerList* layerList) {
             layer_name = "noname";
         }
         newLayerName = QString(layer_name);
-        while(layerList->find(newLayerName) > 0) {
+        while(layerList->find(newLayerName) != NULL) {
             newLayerName = QString("%1%2").arg(layer_name).arg(i);
         }
     }


### PR DESCRIPTION
Several warning are removed by this commit:
- librecad\src\lib\modification\rs_modification.cpp:612: warning: variable 'arc' set but not used [-Wunused-but-set-variable]
- librecad\src\actions\rs_actiondrawcircletan2_1p.cpp:147: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
- librecad\src\ui\qg_dialogfactory.cpp:208: warning: ordered comparison of pointer with integer zero [-Wextra] - the function returns a pointer but is compared as integer, the warning is right
