### PR TITLE
Added custom.pro to all project files via common.pro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ scripts/PWD
 #vim files
 *.swp
 *.orig
+custom.pro

--- a/common.pro
+++ b/common.pro
@@ -1,4 +1,6 @@
 
+# include user-defined things in every qmake project
+exists( custom.pro ):include( custom.pro )
 
 # Store intermedia stuff somewhere else
 isEmpty(GENERATED_DIR){


### PR DESCRIPTION
As per [this](http://forum.librecad.org/custom-pro-does-not-produces-effects-td5707720.html) discussion in the forum I edited common.pro to include custom.pro if it exists. Also, I've modified .gitignore so that custom.pro does not shows up each time you do a `git status`.
