### PR TITLE
RS_Commands needs QObject

### DIFF
--- a/librecad/src/cmd/rs_commands.h
+++ b/librecad/src/cmd/rs_commands.h
@@ -30,6 +30,7 @@
 #define RS_COMMANDS_H
 
 #include <QMultiHash>
+#include <QObject>
 
 #include "rs.h"
 

--- a/librecad/src/ui/forms/qg_dlghatch.cpp
+++ b/librecad/src/ui/forms/qg_dlghatch.cpp
@@ -208,5 +208,5 @@ void QG_DlgHatch::updatePreview(RS_Pattern* ) {
     }
 
     gvPreview->zoomAuto();
-
+	Q_UNUSED( prevSize ); // the variable is set but never used
 }


### PR DESCRIPTION
RS_Commands will not compile with Qt5 without an additional include for QObject.

I also sneaked in a warning about a variable (prevSize in QG_DlgHatch::updatePreview() that's only set not used.
