### PR TITLE
Removed <unused> warnings from some plug-in files

### DIFF
--- a/plugins/align/align.cpp
+++ b/plugins/align/align.cpp
@@ -32,6 +32,7 @@ void LC_Align::execComm(Document_Interface *doc,
                              QWidget *parent, QString cmd)
 {
     Q_UNUSED(parent);
+    Q_UNUSED(cmd);
     QPointF base1, base2, target1, target2;
     QList<Plug_Entity *> obj;
     bool yes  = doc->getSelect(&obj);

--- a/plugins/sameprop/sameprop.cpp
+++ b/plugins/sameprop/sameprop.cpp
@@ -33,6 +33,7 @@ void LC_SameProp::execComm(Document_Interface *doc,
                              QWidget *parent, QString cmd)
 {
     Q_UNUSED(parent);
+    Q_UNUSED(cmd);
     QHash<int, QVariant> data, moddata;
     QList<Plug_Entity *> obj;
     QVariant lay, col, ltype, lwidth;

--- a/plugins/sample/sample.cpp
+++ b/plugins/sample/sample.cpp
@@ -38,6 +38,7 @@ void LC_Sample::execComm(Document_Interface *doc,
                              QWidget *parent, QString cmd)
 {
     Q_UNUSED(doc);
+    Q_UNUSED(cmd);
     lc_Sampledlg pdt(parent);
     int result =  pdt.exec();
     if (result == QDialog::Accepted)


### PR DESCRIPTION
This concludes my series of commits that helped porting to Qt 5. It just  removes some warnings from plug-in files.
