### PR TITLE
RS_ActionBlocksInsert: initialising member variables

### DIFF
--- a/librecad/src/actions/rs_actionblocksinsert.cpp
+++ b/librecad/src/actions/rs_actionblocksinsert.cpp
@@ -39,7 +39,11 @@
 RS_ActionBlocksInsert::RS_ActionBlocksInsert(RS_EntityContainer& container,
         RS_GraphicView& graphicView)
         :RS_PreviewActionInterface("Blocks Insert",
-                           container, graphicView) {}
+                           container, graphicView) {
+    block = NULL;
+    reset();    // init data Member
+    lastStatus = SetUndefined;
+}
 
 
 

--- a/librecad/src/actions/rs_actionblocksinsert.h
+++ b/librecad/src/actions/rs_actionblocksinsert.h
@@ -42,8 +42,9 @@ public:
     /**
      * Action States.
      */
-    enum Status {
-        SetTargetPoint,    /**< Setting the reference point. */
+	enum Status {
+		SetUndefined = -1, /**< Setting undefined for initialisation. */
+		SetTargetPoint = 0,/**< Setting the reference point. */
 		SetAngle,          /**< Setting angle in the command line. */
 		SetFactor,         /**< Setting factor in the command line. */
 		SetColumns,        /**< Setting columns in the command line. */


### PR DESCRIPTION
equivalent to https://sourceforge.net/p/librecad/bugs/396/
