### PR TITLE
Misc changes concerning keyboard shortcuts

### DIFF
--- a/librecad/src/cmd/rs_commands.cpp
+++ b/librecad/src/cmd/rs_commands.cpp
@@ -33,6 +33,10 @@
 
 RS_Commands* RS_Commands::uniqueInstance = NULL;
 
+const char* RS_Commands::FnPrefix = "Fn";
+const char* RS_Commands::AltPrefix = "Alt-";
+const char* RS_Commands::MetaPrefix = "Meta-";
+
 /**
  * Constructor. Initiates main command dictionary.
  * mainCommand keeps a map from translated commands to actionType
@@ -150,6 +154,24 @@ RS_Commands::RS_Commands() {
     // tools:
     cmdTranslation.insert("dimregen", tr("dimregen"));
     mainCommands.insert(tr("dimregen"), RS2::ActionToolRegenerateDimensions);
+
+	 // restrictions:
+    cmdTranslation.insert("rn", tr("rn", "restrict - nothing"));
+    mainCommands.insert(tr("rn", "restrict - nothing"), RS2::ActionRestrictNothing);
+    shortCommands.insert(tr("rn"), RS2::ActionRestrictNothing);
+
+    cmdTranslation.insert("rr", tr("rr", "restrict - orthogonal"));
+    mainCommands.insert(tr("rr", "restrict - orthogonal"), RS2::ActionRestrictOrthogonal);
+    shortCommands.insert(tr("rr"), RS2::ActionRestrictOrthogonal);
+
+    cmdTranslation.insert("rh", tr("rh", "restrict - horizontal"));
+    mainCommands.insert(tr("rh", "restrict - horizontal"), RS2::ActionRestrictHorizontal);
+    shortCommands.insert(tr("rh"), RS2::ActionRestrictHorizontal);
+
+    cmdTranslation.insert("rv", tr("rv", "restrict - vertical"));
+    mainCommands.insert(tr("rv", "restrict - vertical"), RS2::ActionRestrictVertical);
+    shortCommands.insert(tr("rv"), RS2::ActionRestrictVertical);
+
 
     // modify:
     cmdTranslation.insert("tm", tr("tm"));
@@ -498,11 +520,25 @@ RS2::ActionType RS_Commands::cmdToAction(const QString& cmd, bool verbose) {
  * of key-strokes that is entered like hotkeys.
  */
 RS2::ActionType RS_Commands::keycodeToAction(const QString& code) {
-    if(code.size()<1 || code.contains(QRegExp("^[a-z].*",Qt::CaseInsensitive)) == false ) return RS2::ActionNone;
-    QString c = code.toLower();
+	if(code.size() < 1)
+		return RS2::ActionNone;
+
+	QString c;
+
+	if(!(code.startsWith(RS_Commands::FnPrefix) || code.startsWith(RS_Commands::AltPrefix) || code.startsWith(RS_Commands::MetaPrefix))) {
+    	if(code.size() < 1 || code.contains(QRegExp("^[a-z].*",Qt::CaseInsensitive)) == false )
+			 return RS2::ActionNone;
+	    c = code.toLower();
+	} else {
+		c = code;
+	}
+
+
 //    std::cout<<"regex: "<<qPrintable(c)<<" matches: "<< c.contains(QRegExp("^[a-z].*",Qt::CaseInsensitive))<<std::endl;
 //    std::cout<<"RS2::ActionType RS_Commands::keycodeToAction("<<qPrintable(c)<<")"<<std::endl;
+
     QMultiHash<QString, RS2::ActionType>::iterator it = shortCommands.find(c);
+
     if( it == shortCommands.end() ) {
 
         //not found, searching for main commands

--- a/librecad/src/cmd/rs_commands.h
+++ b/librecad/src/cmd/rs_commands.h
@@ -70,6 +70,11 @@ public:
     static QString msgAvailableCommands();
     void updateAlias();
 
+	 // Prefixes for function-, Meta- and Alt- keys.
+	 static const char *FnPrefix;
+	 static const char *AltPrefix;
+	 static const char *MetaPrefix;
+
 protected:
     static RS_Commands* uniqueInstance;
 

--- a/librecad/src/ui/qg_actionhandler.cpp
+++ b/librecad/src/ui/qg_actionhandler.cpp
@@ -1590,21 +1590,21 @@ void QG_ActionHandler::slotSnapFree() {
 //    if ( snapFree == NULL) return;
 //    disableSnaps();
     RS_SnapMode s=getSnaps();
-    s.snapFree = true;
+    s.snapFree = !s.snapFree;
     slotSetSnaps(s);
 }
 
 void QG_ActionHandler::slotSnapGrid() {
 //    if(snapGrid==NULL) return;
     RS_SnapMode s=getSnaps();
-    s.snapGrid = true;
+    s.snapGrid = !s.snapGrid;
     slotSetSnaps(s);
 }
 
 void QG_ActionHandler::slotSnapEndpoint() {
 //    if(snapEndpoint==NULL) return;
     RS_SnapMode s=getSnaps();
-    s.snapEndpoint = true;
+    s.snapEndpoint = !s.snapEndpoint;
 
     slotSetSnaps(s);
 }
@@ -1612,7 +1612,7 @@ void QG_ActionHandler::slotSnapEndpoint() {
 void QG_ActionHandler::slotSnapOnEntity() {
 //    if(snapOnEntity==NULL) return;
     RS_SnapMode s=getSnaps();
-    s.snapOnEntity = true;
+    s.snapOnEntity = !s.snapOnEntity;
 
     slotSetSnaps(s);
 }
@@ -1621,27 +1621,27 @@ void QG_ActionHandler::slotSnapCenter() {
 //    std::cout<<" QG_ActionHandler::slotSnapCenter(): start"<<std::endl;
 //    if(snapCenter==NULL) return;
     RS_SnapMode s=getSnaps();
-    s.snapCenter = true;
+    s.snapCenter = !s.snapCenter;
     slotSetSnaps(s);
 }
 
 void QG_ActionHandler::slotSnapMiddle() {
     RS_SnapMode s=getSnaps();
-    s.snapMiddle = true;
+    s.snapMiddle = !s.snapMiddle;
 
     slotSetSnaps(s);
 }
 
 void QG_ActionHandler::slotSnapDist() {
     RS_SnapMode s=getSnaps();
-    s.snapDistance = true;
+    s.snapDistance = !s.snapDistance;
 
     slotSetSnaps(s);
 }
 
 void QG_ActionHandler::slotSnapIntersection() {
     RS_SnapMode s=getSnaps();
-    s.snapIntersection = true;
+    s.snapIntersection = !s.snapIntersection;
 
     slotSetSnaps(s);
 }
@@ -1663,26 +1663,26 @@ void QG_ActionHandler::disableSnaps() {
 }
 
 void QG_ActionHandler::slotRestrictNothing() {
-    RS_SnapMode s=getSnaps();
-    s.restriction=RS2::RestrictNothing;
+    RS_SnapMode s = getSnaps();
+    s.restriction = RS2::RestrictNothing;
     slotSetSnaps(s);
 }
 
 void QG_ActionHandler::slotRestrictOrthogonal() {
-    RS_SnapMode s=getSnaps();
-    s.restriction=RS2::RestrictOrthogonal;
+    RS_SnapMode s = getSnaps();
+    s.restriction = RS2::RestrictOrthogonal;
     slotSetSnaps(s);
 }
 
 void QG_ActionHandler::slotRestrictHorizontal() {
-    RS_SnapMode s=getSnaps();
-    s.restriction=getSnapRestriction();
+    RS_SnapMode s = getSnaps();
+    s.restriction = RS2::RestrictHorizontal;
     slotSetSnaps(s);
 }
 
 void QG_ActionHandler::slotRestrictVertical() {
-    RS_SnapMode s=getSnaps();
-    s.restriction=getSnapRestriction();
+    RS_SnapMode s = getSnaps();
+    s.restriction = RS2::RestrictVertical;
     slotSetSnaps(s);
 }
 


### PR DESCRIPTION
- Added 2 letter shortcuts for restrict horizontal (rh), vertical (rv),
  orthogonal (rr) and none (rn).
- In my opinion, the two-letter shortcuts for snapping
  should toggle and not just enable the corresponding function.
  Otherwise they can't be switched off with the shortcut. Changed the
  behaviour to toggle.
- actionHandler->keycode() should only be called in keyPressEvent,
  if there are really two letters in the buffer. Otherwise the
  double-letter shortcuts get mixed up with single letter short commands
  which start with the same letter (e.g. 'os' and 'o' will be mixed up if
  the user tries to type 'os' multiple times without waiting the timeout),
  because we violate the fano-condition. Fixed that.
    Note: This changes the user interface behaviour somewhat, because only
    two letter commands (and the newly implemented shortcuts mentioned below)
    now work. It is not valid to just type 'o' for offset anymore. But I think
    this change is justified, because the old behaviour gave inconsistent
    results.
- Added the possibility to assign actions to the function keys
  (F1, F2, ...) and key combination of "Alt" plus some key and "Meta"
  plus some key. Please note that Alt-keystrokes may interfere with
  the menu and GUI hotkeys.
  
  To use this feature, add an alias from e.g. Fn1, Alt-j or Meta-n
  to your desired function in your librecad.alias file (where '1', 'j'
  and 'n' are just examples here).
  
  Examples:
  To use F2 for lines, Alt-j for circles and Meta-x for 'extend' add:
  Fn2   line
  Alt-j circle
  Meta-x    xt
  
  to your alias file. Notice that the Alt- and Meta-modifiers respect
  are case sensitive. You may use different commands for upper- and lowercase
  letters here.
  
  Implementation details:
  The event handler keyPressEvent detects the modifier keys. If a key
  combination e.g. Meta-x. is pressed, the command string of the x key is
  just prefixed with the String "Meta-", resulting in "Meta-x". This way,
  no changes in the key processing code was needed to make this work.
  Side Effect: Typing "Meta-x" in the command line has the same Effect as
  pressing Meta+x.

_Note_: Changes are tested somewhat, but not heavily.
