### PR TITLE
Updated arc start and end angles for specific extrusion vectors

### DIFF
--- a/libraries/libdxfrw/src/drw_entities.h
+++ b/libraries/libdxfrw/src/drw_entities.h
@@ -223,7 +223,7 @@ public:
         isccw = 1;
     }
 
-    virtual void applyExtrusion(){DRW_Circle::applyExtrusion();}
+    virtual void applyExtrusion();
     void parseCode(int code, dxfReader *reader);
 
 public:


### PR DESCRIPTION
The start and end angle calculations for an arc were updated to handle the case where the arc had an extrusion vector in the negative z direction. The update was tested on a file that was produced with a commercial tool.
