### PR TITLE
Enable smooth scrolling and zooming on platforms that supports this

### DIFF
--- a/librecad/src/actions/rs_actionzoomin.cpp
+++ b/librecad/src/actions/rs_actionzoomin.cpp
@@ -40,9 +40,11 @@ RS_ActionZoomIn::RS_ActionZoomIn(RS_EntityContainer& container,
                                  RS_GraphicView& graphicView,
                                  RS2::ZoomDirection direction,
                                  RS2::Axis axis,
-                                 const RS_Vector& center)
+                                 const RS_Vector& center,
+                                 double factor)
         :RS_ActionInterface("Zoom in", container, graphicView) {
 
+    this->zoom_factor = factor;
     this->direction = direction;
     this->axis = axis;
     this->center = center;
@@ -101,9 +103,9 @@ void RS_ActionZoomIn::trigger() {
 
     case RS2::Both:
         if (direction==RS2::In) {
-            graphicView->zoomIn(1.25, center);
+            graphicView->zoomIn(zoom_factor, center);
         } else {
-            graphicView->zoomOut(1.25, center);
+            graphicView->zoomOut(zoom_factor, center);
         }
         break;
     }

--- a/librecad/src/actions/rs_actionzoomin.h
+++ b/librecad/src/actions/rs_actionzoomin.h
@@ -42,7 +42,8 @@ public:
                     RS_GraphicView& graphicView,
                     RS2::ZoomDirection direction = RS2::In,
                     RS2::Axis axis = RS2::Both,
-					const RS_Vector& center = RS_Vector(false));
+                    const RS_Vector& center = RS_Vector(false),
+                    double factor = 1.25);
     ~RS_ActionZoomIn() {}
 
 	static QAction* createGUIAction(RS2::ActionType type, QObject* /*parent*/);
@@ -51,6 +52,7 @@ public:
     virtual void trigger();
 
 protected:
+    double zoom_factor;
     RS2::ZoomDirection direction;
     RS2::Axis axis;
 	RS_Vector center;

--- a/librecad/src/actions/rs_actionzoomscroll.cpp
+++ b/librecad/src/actions/rs_actionzoomscroll.cpp
@@ -35,12 +35,26 @@ RS_ActionZoomScroll::RS_ActionZoomScroll(RS2::Direction direction,
         :RS_ActionInterface("Zoom scroll", container, graphicView) {
 
     this->direction = direction;
+    this->hasOffset = false;
+}
+
+RS_ActionZoomScroll::RS_ActionZoomScroll(int offsetX, int offsetY,
+                                         RS_EntityContainer& container,
+                                         RS_GraphicView& graphicView)
+:RS_ActionInterface("Zoom scroll", container, graphicView) {
+
+    this->hasOffset = true;
+    this->offsetX = offsetX;
+    this->offsetY = offsetY;
 }
 
 
-
 void RS_ActionZoomScroll::trigger() {
-    graphicView->zoomScroll(direction);
+    if (hasOffset) {
+        graphicView->zoomPan(offsetX, offsetY);
+    } else {
+        graphicView->zoomScroll(direction);
+    }
     finish(false);
 }
 

--- a/librecad/src/actions/rs_actionzoomscroll.h
+++ b/librecad/src/actions/rs_actionzoomscroll.h
@@ -41,6 +41,9 @@ public:
     RS_ActionZoomScroll(RS2::Direction direction,
                         RS_EntityContainer& container,
                         RS_GraphicView& graphicView);
+    RS_ActionZoomScroll(int offsetX, int offsetY,
+                        RS_EntityContainer& container,
+                        RS_GraphicView& graphicView);
     ~RS_ActionZoomScroll() {}
 
     virtual void init(int status=0);
@@ -48,6 +51,8 @@ public:
 
 protected:
     RS2::Direction direction;
+    bool hasOffset;
+    int offsetX, offsetY;
 };
 
 #endif

--- a/librecad/src/ui/qg_graphicview.cpp
+++ b/librecad/src/ui/qg_graphicview.cpp
@@ -29,6 +29,9 @@
 #include <QGridLayout>
 #include <QLabel>
 #include <QDebug>
+#if QT_VERSION >= 0x050200
+#include <QNativeGestureEvent>
+#endif
 
 #include "rs_actionzoomin.h"
 #include "rs_actionzoompan.h"
@@ -359,6 +362,36 @@ void QG_GraphicView::mouseMoveEvent(QMouseEvent* e) {
     //RS_DEBUG->print("QG_GraphicView::mouseMoveEvent end");
 }
 
+bool QG_GraphicView::event(QEvent *event) {
+#if QT_VERSION >= 0x050200
+    if (event->type() == QEvent::NativeGesture) {
+        QNativeGestureEvent *nge = static_cast<QNativeGestureEvent *>(event);
+
+        if (nge->gestureType() == Qt::ZoomNativeGesture) {
+            double v = nge->value();
+            RS2::ZoomDirection direction;
+            double factor;
+
+            if (v < 0) {
+                direction = RS2::Out;
+                factor = 1-v;
+            } else {
+                direction = RS2::In;
+                factor = 1+v;
+            }
+
+            // It seems the NativeGestureEvent::pos() incorrectly reports global coordinates
+            QPoint g = mapFromGlobal(nge->globalPos());
+            RS_Vector mouse = toGraph(RS_Vector(g.x(), g.y()));
+            setCurrentAction(new RS_ActionZoomIn(*container, *this, direction,
+                                                 RS2::Both, mouse, factor));
+        }
+
+        return true;
+    }
+#endif
+	return QWidget::event(event);
+}
 
 /**
  * support for the wacom graphic tablet.
@@ -466,7 +499,49 @@ void QG_GraphicView::wheelEvent(QWheelEvent *e) {
         return;
     }
 
-        RS_Vector mouse = toGraph(RS_Vector(e->x(), e->y()));
+    RS_Vector mouse = toGraph(RS_Vector(e->x(), e->y()));
+
+    QPoint numPixels = e->pixelDelta();
+
+    if (!numPixels.isNull()) {
+        // high-resolution scrolling triggers Pan instead of Zoom logic
+        isSmoothScrolling = true;
+    }
+
+    if (isSmoothScrolling) {
+        if (e->phase() == Qt::ScrollEnd) isSmoothScrolling = 0;
+
+        if (!numPixels.isNull()) {
+            if (e->modifiers()==Qt::ControlModifier) {
+                // Hold ctrl to zoom. 1 % per pixel
+                double v = -numPixels.y() / 100.;
+                RS2::ZoomDirection direction;
+                double factor;
+
+                if (v < 0) {
+                    direction = RS2::Out; factor = 1-v;
+                } else {
+                    direction = RS2::In;  factor = 1+v;
+                }
+
+                setCurrentAction(new RS_ActionZoomIn(*container, *this, direction,
+                                                     RS2::Both, mouse, factor));
+            } else {
+                // otherwise, scroll
+                setCurrentAction(new RS_ActionZoomScroll(numPixels.x(), numPixels.y(),
+                                                         *container, *this));
+            }
+            redraw();
+        }
+        e->accept();
+        return;
+    }
+
+    if (e->delta() == 0) {
+        // A zero delta event occurs when smooth scrolling is ended. Ignore this
+        e->accept();
+        return;
+    }
 
     bool scroll = false;
     RS2::Direction direction = RS2::Up;

--- a/librecad/src/ui/qg_graphicview.h
+++ b/librecad/src/ui/qg_graphicview.h
@@ -98,6 +98,8 @@ protected:
     virtual void keyPressEvent(QKeyEvent* e);
     virtual void keyReleaseEvent(QKeyEvent* e);
 
+    virtual bool event(QEvent * e);
+
     void paintEvent(QPaintEvent *);
     virtual void resizeEvent(QResizeEvent* e);
 
@@ -137,6 +139,8 @@ protected:
      */
     bool m_bUpdateLayer;
 		
+    //! Keep tracks of if we are currently doing a high-resolution scrolling
+    bool isSmoothScrolling;
 };
 
 #endif


### PR DESCRIPTION
On platforms that support smooth (high-resolution) scrolling, zooming in LibreCAD is almost impossible. For each pixel the cursor moves, the view is zoomed 25 %. This patch enables native zoom events (pinch zoom) on supported platforms as well as swapping pan and zoom functionality for input devices supplying high resolution 2D scrolling inputs.

Note: Has only been tested on Mac with a multi-touch trackpad where it makes the scrolling and zooming paradigm match the OS conventions.
