### PR TITLE
Fix cppcheck warnings:

### DIFF
--- a/libraries/libdxfrw/src/drw_objects.cpp
+++ b/libraries/libdxfrw/src/drw_objects.cpp
@@ -915,7 +915,7 @@ void DRW_Header::write(dxfWriter *writer, DRW::Version ver){
     }
 #ifdef DRW_DBG
     std::map<std::string,DRW_Variant *>::const_iterator it;
-    for ( it=vars.begin() ; it != vars.end(); it++ ){
+    for ( it=vars.begin() ; it != vars.end(); ++it ){
 //        QString key = QString::fromStdString((*it).first);
         std::cerr << (*it).first << std::endl;
     }

--- a/libraries/libdxfrw/src/intern/drw_textcodec.cpp
+++ b/libraries/libdxfrw/src/intern/drw_textcodec.cpp
@@ -150,7 +150,7 @@ std::string DRW_ConvTable::fromUtf8(std::string *s) {
 std::string DRW_ConvTable::toUtf8(std::string *s) {
     std::string res;
     std::string::iterator it;
-    for ( it=s->begin() ; it < s->end(); it++ ) {
+    for ( it=s->begin() ; it < s->end(); ++it ) {
         unsigned char c = *it;
         if (c < 0x80) {
             //check for \U+ encoded text
@@ -291,7 +291,7 @@ std::string DRW_ConvDBCSTable::fromUtf8(std::string *s) {
 std::string DRW_ConvDBCSTable::toUtf8(std::string *s) {
     std::string res;
     std::string::iterator it;
-    for ( it=s->begin() ; it < s->end(); it++ ) {
+    for ( it=s->begin() ; it < s->end(); ++it ) {
         bool notFound = true;
         unsigned char c = *it;
         if (c < 0x80) {
@@ -377,7 +377,7 @@ std::string DRW_Conv932Table::fromUtf8(std::string *s) {
 std::string DRW_Conv932Table::toUtf8(std::string *s) {
     std::string res;
     std::string::iterator it;
-    for ( it=s->begin() ; it < s->end(); it++ ) {
+    for ( it=s->begin() ; it < s->end(); ++it ) {
         bool notFound = true;
         unsigned char c = *it;
         if (c < 0x80) {
@@ -471,7 +471,7 @@ std::string DRW_TextCodec::correctCodePage(const std::string& s) {
         //Chinese PRC GBK (XGB) simplified
     } else if (cp=="ANSI_936" || cp=="GBK" || cp=="GB2312" || cp=="CHINESE" || cp=="CN-GB" ||
                cp=="CSGB2312" || cp=="CSGB231280" || cp=="CSISO58BG231280" ||
-               cp=="GB_2312-80" || cp=="GB231280" || cp=="GB2312-80" || cp=="GBK" ||
+               cp=="GB_2312-80" || cp=="GB231280" || cp=="GB2312-80" ||
                cp=="ISO-IR-58" || cp=="GB18030") {
         return "ANSI_936";
         //Korean

--- a/libraries/libdxfrw/src/libdxfrw.cpp
+++ b/libraries/libdxfrw/src/libdxfrw.cpp
@@ -1666,7 +1666,7 @@ bool dxfRW::writeObjects() {
     for (unsigned int i=0; i<imageDef.size(); i++) {
         DRW_ImageDef *id = imageDef.at(i);
         std::map<std::string, std::string>::iterator it;
-        for ( it=id->reactors.begin() ; it != id->reactors.end(); it++ ) {
+        for ( it=id->reactors.begin() ; it != id->reactors.end(); ++it ) {
             writer->writeString(0, "IMAGEDEF_REACTOR");
             writer->writeString(5, (*it).first);
             writer->writeString(330, (*it).second);
@@ -1699,7 +1699,7 @@ bool dxfRW::writeObjects() {
         }
         writer->writeString(102, "{ACAD_REACTORS");
         std::map<std::string, std::string>::iterator it;
-        for ( it=id->reactors.begin() ; it != id->reactors.end(); it++ ) {
+        for ( it=id->reactors.begin() ; it != id->reactors.end(); ++it ) {
             writer->writeString(330, (*it).first);
         }
         writer->writeString(102, "}");

--- a/librecad/src/lib/engine/rs_system.cpp
+++ b/librecad/src/lib/engine/rs_system.cpp
@@ -735,7 +735,7 @@ QString RS_System::getEncoding(const QString& str) {
         return "eucJP";
     } else if (l=="euckr") {
         return "eucKR";
-    } else if (l=="gb2312" || l=="gb2312" || l=="chinese" || l=="cn-gb" ||
+    } else if (l=="gb2312" || l=="chinese" || l=="cn-gb" ||
                l=="csgb2312" || l=="csgb231280" || l=="csiso58gb231280" ||
                l=="gb_2312-80" || l=="gb231280" || l=="gb2312-80" || l=="gbk" ||
                l=="iso-ir-58") {

--- a/librecad/src/lib/filters/rs_filterdxfrw.cpp
+++ b/librecad/src/lib/filters/rs_filterdxfrw.cpp
@@ -1217,7 +1217,7 @@ void RS_FilterDXFRW::addHeader(const DRW_Header* data){
     } else return;
 
     map<std::string,DRW_Variant *>::const_iterator it;
-    for ( it=data->vars.begin() ; it != data->vars.end(); it++ ){
+    for ( it=data->vars.begin() ; it != data->vars.end(); ++it ){
         QString key = QString::fromStdString((*it).first);
         DRW_Variant *var = (*it).second;
         switch (var->type) {

--- a/librecad/src/lib/filters/rs_filterjww.cpp
+++ b/librecad/src/lib/filters/rs_filterjww.cpp
@@ -1896,7 +1896,7 @@ void RS_FilterJWW::writeSplinePoints(DL_WriterA& dw,
 
 	// write spline control points:
 	QList<RS_Vector>::iterator it;
-	for(it = cp.begin(); it != cp.end(); it++)
+	for(it = cp.begin(); it != cp.end(); ++it)
 	{
 		jww.writeControlPoint(dw, DL_ControlPointData((*it).x, (*it).y, 0.0));
 	}

--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -1687,7 +1687,7 @@ bool RS_Modification::scale(RS_ScaleData& data) {
 
         for(QList<RS_Entity*>::iterator pe=selectedList.begin();
                 pe != selectedList.end();
-                pe++ ) {
+                ++pe ) {
             RS_Entity* e= *pe;
             //for (RS_Entity* e=container->firstEntity();
             //        e!=NULL;

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -243,7 +243,7 @@ QMenu *QC_ApplicationWindow::findMenu(const QString &searchMenu, const QObjectLi
                 return foundMenu;
             }
         }
-        i++;
+        ++i;
     }
     return 0;
 }

--- a/librecad/src/ui/forms/qg_cadtoolbarmodify.cpp
+++ b/librecad/src/ui/forms/qg_cadtoolbarmodify.cpp
@@ -91,7 +91,7 @@ void QG_CadToolBarModify::init() {
     bHidden->setMaximumSize(0,0); //zero size
     buttonList.push_back(bHidden);
     //set up auto-exclusive
-    for(QList<QToolButton*>::iterator it=buttonList.begin();it !=buttonList.end();it++){
+    for(QList<QToolButton*>::iterator it=buttonList.begin();it !=buttonList.end();++it){
         (*it)->setCheckable(true);
         (*it)->setAutoExclusive(true);
     }


### PR DESCRIPTION
- (style) Same expression on both sides of '||'
- (performance) Prefer prefix ++/-- operators for non-primitive types