### PR TITLE
Add full circle area function

### DIFF
--- a/librecad/src/lib/engine/rs_circle.cpp
+++ b/librecad/src/lib/engine/rs_circle.cpp
@@ -743,6 +743,21 @@ LC_Quadratic RS_Circle::getQuadratic() const
     return ret;
 }
 
+
+/**
+* @brief Returns area of full circle
+* Note: Circular arcs are handled separately by RS_Arc (areaLIneIntegral) 
+* However, full ellipses and ellipse arcs are handled by RS_Ellipse
+* @return \pi r^2
+*/
+double RS_Circle::areaLineIntegral() const
+{
+	const double r = getRadius();
+	
+	return M_PI*r*r;
+}
+
+
 /**
  * Dumps the circle's data to stdout.
  */

--- a/librecad/src/lib/engine/rs_circle.h
+++ b/librecad/src/lib/engine/rs_circle.h
@@ -208,6 +208,14 @@ for linear:
 m0 x + m1 y + m2 =0
 **/
     virtual LC_Quadratic getQuadratic() const;
+    
+/**
+* @brief Returns area of full circle
+* Note: Circular arcs are handled separately by RS_Arc (areaLIneIntegral) 
+* However, full ellipses and ellipse arcs are handled by RS_Ellipse
+* @return \pi r^2
+*/
+    virtual double areaLineIntegral() const;
 
     friend std::ostream& operator << (std::ostream& os, const RS_Circle& a);
 


### PR DESCRIPTION
*Side note*: `RS_Ellipse` handles full ellipses and ellipse arcs, but for circles we have `RS_Circle` for full circles only and `RS_Arc` for circular arcs. Is there any reason to keep these as separate classes? Why not add `angle1` and `angle2` to `RS_Circle` like in `RS_Ellipse`?
