### PR TITLE
Fixing issue #500. Setting the checkbox for the Statusbar option in the view menu.

### DIFF
--- a/librecad/src/ui/qg_actionfactory.cpp
+++ b/librecad/src/ui/qg_actionfactory.cpp
@@ -345,6 +345,8 @@ QAction* QG_ActionFactory::createAction(	RS2::ActionType id, QObject* obj,
         action = new QAction(tr("&Statusbar"), mw);
         //action->zetStatusTip(tr("Enables/disables the statusbar"));
         action->setCheckable(true);
+        // StatusBar is displayed by default
+        action->setChecked(true);
 
         connect(action, SIGNAL(toggled(bool)),
                 obj, SLOT(slotViewStatusBar(bool)));


### PR DESCRIPTION
The Statusbar option in the View menu is now checked by default to reflect that the status bar is displayed by default. This should fix issue #500.