### PR TITLE
Corrected a comment's spelling in drawwllipseaxis.h

### DIFF
--- a/librecad/src/actions/rs_actiondrawellipseaxis.h
+++ b/librecad/src/actions/rs_actiondrawellipseaxis.h
@@ -42,7 +42,7 @@ public:
      * Action States.
      */
     enum Status {
-        SetCenter,   /**< Settinge the center.  */
+        SetCenter,   /**< Setting the center.  */
         SetMajor,    /**< Setting endpoint of major axis. */
         SetMinor,    /**< Setting minor/major ratio. */
         SetAngle1,   /**< Setting start angle. */


### PR DESCRIPTION
Was reading through the rs_actiondrawellipse* files two days back and saw this spelling error in rs_actiondrawellipseaxis.h. I've just fixed it.