### PR TITLE
Added (hopefully really needed) include of QObject

### DIFF
--- a/librecad/src/lib/actions/rs_actioninterface.h
+++ b/librecad/src/lib/actions/rs_actioninterface.h
@@ -28,6 +28,8 @@
 #ifndef RS_ACTIONINTERFACE_H
 #define RS_ACTIONINTERFACE_H
 
+#include <QObject>
+
 #include "rs_snapper.h"
 
 class QKeyEvent;


### PR DESCRIPTION
Hi,

I needed this fix in order to compile the project again, otherwise:

```
dinkel@dale:~/Development/LibreCAD (master)$ qmake -r linrecad.pro
[SNIP]
dinkel@dale:~/Development/LibreCAD (master)$ make
[SNIP]
g++ -c -m64 -pipe -g -std=c++11 -O2 -Wall -W -D_REENTRANT -DQC_APPKEY="/LibreCAD" -DQC_APPNAME="LibreCAD" -DQC_COMPANYNAME="LibreCAD" -DQC_COMPANYKEY="LibreCAD" -DQC_VERSION="master" -DQC_DELAYED_SPLASH_SCREEN=1 -DHAS_BOOST=1 -DDWGSUPPORT -DQC_SCMREVISION="2.0.7-162-g0de488c" -DQC_APPDIR="librecad" -DQINITIMAGES_LIBRECAD=qInitImages_librecad -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_SQL_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt4/mkspecs/linux-g++-64 -I. -I/usr/include/qt4/QtCore -I/usr/include/qt4/QtGui -I/usr/include/qt4/QtSql -I/usr/include/qt4/QtSvg -I/usr/include/qt4 -I/usr/include/qt4/QtHelp -I/usr/include -I../../libraries/libdxfrw/src -I../../libraries/jwwlib/src -Icmd -Ilib/actions -Ilib/creation -Ilib/debug -Ilib/engine -Ilib/fileio -Ilib/filters -Ilib/generators -Ilib/gui -Ilib/information -Ilib/math -Ilib/modification -Ilib/scripting -Iactions -Imain -Itest -Iplugins -Iui -Iui/forms -I../res -I../../generated/librecad/moc -I../../generated/librecad/ui -o ../../generated/librecad/obj/rs_previewactioninterface.o lib/actions/rs_previewactioninterface.cpp
In file included from lib/actions/rs_previewactioninterface.h:32:0,
                 from lib/actions/rs_previewactioninterface.cpp:28:
lib/actions/rs_actioninterface.h:49:51: error: invalid use of incomplete type ‘class QObject’
 class RS_ActionInterface : public QObject, public RS_Snapper {
                                                   ^
In file included from /usr/include/qt4/QtGui/qwindowdefs.h:45:0,
                 from /usr/include/qt4/QtGui/qpaintdevice.h:45,
                 from /usr/include/qt4/QtGui/qprinter.h:47,
                 from lib/engine/rs.h:35,
                 from lib/actions/rs_snapper.h:31,
                 from lib/actions/rs_actioninterface.h:31,
                 from lib/actions/rs_previewactioninterface.h:32,
                 from lib/actions/rs_previewactioninterface.cpp:28:
/usr/include/qt4/QtCore/qobjectdefs.h:249:7: error: forward declaration of ‘class QObject’
 class QObject;
       ^
Makefile:4991: recipe for target '../../generated/librecad/obj/rs_previewactioninterface.o' failed
make[2]: *** [../../generated/librecad/obj/rs_previewactioninterface.o] Error 1
make[2]: Leaving directory '/home/dinkel/Development/LibreCAD/librecad/src'
Makefile:39: recipe for target 'sub-src-make_default' failed
make[1]: *** [sub-src-make_default] Error 2
make[1]: Leaving directory '/home/dinkel/Development/LibreCAD/librecad'
Makefile:78: recipe for target 'sub-librecad-make_default-ordered' failed
make: *** [sub-librecad-make_default-ordered] Error 2
dinkel@dale:~/Development/LibreCAD (master)$ 
```