### PR TITLE
Fixed 'File -> Export' icon

### DIFF
--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -54,7 +54,7 @@
 #else
 # include <QPrinter>
 # include <QPrintDialog>
-#endif 
+#endif
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -697,7 +697,7 @@ void QC_ApplicationWindow::initActions(void)
 
     // Import Block:
     actionFactory.addGUI(subMenu, this, RS2::ActionBlocksImport);
-	subMenu = menu->addMenu( QIcon(":/actions/fileimport.png"), tr("Export"));
+	subMenu = menu->addMenu( QIcon(":/actions/fileexport.png"), tr("Export"));
 	subMenu->setObjectName("Export");
 	actionFactory.addGUI(subMenu, actionHandler, RS2::ActionFileExportMakerCam);
 	actionFactory.addGUI(subMenu, this, {RS2::ActionFilePrintPDF


### PR DESCRIPTION
A wrong icon was used for the 'File -> Export' menu item.

Btw: My editor by default deletes trailing whitespace and so another change in the diff is shown. 