### PR TITLE
MakerCamSVG to support splines

### DIFF
--- a/librecad/src/lib/generators/lc_makercamsvg.cpp
+++ b/librecad/src/lib/generators/lc_makercamsvg.cpp
@@ -581,7 +581,7 @@ void LC_MakerCamSVG::writeSplinepoints(LC_SplinePoints* splinepoints) {
     writeQuadraticBeziers(splinepoints->getControlPoints(), splinepoints->isClosed());
 }
 
-void LC_MakerCamSVG::writeCubicBeziers(std::vector<RS_Vector> control_points, bool is_closed) {
+void LC_MakerCamSVG::writeCubicBeziers(const std::vector<RS_Vector> &control_points, bool is_closed) {
 
     std::vector<RS_Vector> bezier_points = calcCubicBezierPoints(control_points, is_closed);
 
@@ -602,7 +602,7 @@ void LC_MakerCamSVG::writeCubicBeziers(std::vector<RS_Vector> control_points, bo
     xmlWriter->closeElement();
 }
 
-void LC_MakerCamSVG::writeQuadraticBeziers(std::vector<RS_Vector> control_points, bool is_closed) {
+void LC_MakerCamSVG::writeQuadraticBeziers(const std::vector<RS_Vector> &control_points, bool is_closed) {
 
     std::vector<RS_Vector> bezier_points = calcQuadraticBezierPoints(control_points, is_closed);
 
@@ -623,7 +623,7 @@ void LC_MakerCamSVG::writeQuadraticBeziers(std::vector<RS_Vector> control_points
     xmlWriter->closeElement();
 }
 
-std::vector<RS_Vector> LC_MakerCamSVG::calcCubicBezierPoints(std::vector<RS_Vector> control_points, bool is_closed) {
+std::vector<RS_Vector> LC_MakerCamSVG::calcCubicBezierPoints(const std::vector<RS_Vector> &control_points, bool is_closed) {
 
     std::vector<RS_Vector> bezier_points;
 
@@ -699,7 +699,7 @@ std::vector<RS_Vector> LC_MakerCamSVG::calcCubicBezierPoints(std::vector<RS_Vect
     return bezier_points;
 }
 
-std::vector<RS_Vector> LC_MakerCamSVG::calcQuadraticBezierPoints(std::vector<RS_Vector> control_points, bool is_closed) {
+std::vector<RS_Vector> LC_MakerCamSVG::calcQuadraticBezierPoints(const std::vector<RS_Vector> &control_points, bool is_closed) {
 
     std::vector<RS_Vector> bezier_points;
 

--- a/librecad/src/lib/generators/lc_makercamsvg.h
+++ b/librecad/src/lib/generators/lc_makercamsvg.h
@@ -85,6 +85,7 @@ private:
     void writeCircle(RS_Circle* circle);
     void writeArc(RS_Arc* arc);
     void writeEllipse(RS_Ellipse* ellipse);
+    void writeSpline(RS_Spline* spline);
 
     std::string numXml(double value);
     RS_Vector convertToSvg(RS_Vector vector);

--- a/librecad/src/lib/generators/lc_makercamsvg.h
+++ b/librecad/src/lib/generators/lc_makercamsvg.h
@@ -86,12 +86,20 @@ private:
     void writeArc(RS_Arc* arc);
     void writeEllipse(RS_Ellipse* ellipse);
     void writeSpline(RS_Spline* spline);
+    void writeSplinepoints(LC_SplinePoints* splinepoints);
+
+    void writeCubicBeziers(std::vector<RS_Vector> control_points, bool is_closed);
+    void writeQuadraticBeziers(std::vector<RS_Vector> control_points, bool is_closed);
+
+    std::vector<RS_Vector> calcCubicBezierPoints(std::vector<RS_Vector> control_points, bool is_closed);
+    std::vector<RS_Vector> calcQuadraticBezierPoints(std::vector<RS_Vector> control_points, bool is_closed);
 
     std::string numXml(double value);
     RS_Vector convertToSvg(RS_Vector vector);
 
     std::string svgPathClose();
     std::string svgPathCurveTo(RS_Vector point, RS_Vector controlpoint1, RS_Vector controlpoint2);
+    std::string svgPathQuadraticCurveTo(RS_Vector point, RS_Vector controlpoint);
     std::string svgPathLineTo(RS_Vector point);
     std::string svgPathMoveTo(RS_Vector point);
     std::string svgPathArc(RS_Arc* arc);

--- a/librecad/src/lib/generators/lc_makercamsvg.h
+++ b/librecad/src/lib/generators/lc_makercamsvg.h
@@ -88,11 +88,11 @@ private:
     void writeSpline(RS_Spline* spline);
     void writeSplinepoints(LC_SplinePoints* splinepoints);
 
-    void writeCubicBeziers(std::vector<RS_Vector> control_points, bool is_closed);
-    void writeQuadraticBeziers(std::vector<RS_Vector> control_points, bool is_closed);
+    void writeCubicBeziers(const std::vector<RS_Vector> &control_points, bool is_closed);
+    void writeQuadraticBeziers(const std::vector<RS_Vector> &control_points, bool is_closed);
 
-    std::vector<RS_Vector> calcCubicBezierPoints(std::vector<RS_Vector> control_points, bool is_closed);
-    std::vector<RS_Vector> calcQuadraticBezierPoints(std::vector<RS_Vector> control_points, bool is_closed);
+    std::vector<RS_Vector> calcCubicBezierPoints(const std::vector<RS_Vector> &control_points, bool is_closed);
+    std::vector<RS_Vector> calcQuadraticBezierPoints(const std::vector<RS_Vector> &control_points, bool is_closed);
 
     std::string numXml(double value);
     RS_Vector convertToSvg(RS_Vector vector);


### PR DESCRIPTION
This extends the MakerCamSVG exporter with spline support. It converts closed and open degree 2  and 3 splines to a series of quadratic resp. cubic bézier curves (the only thing supported by SVG). It is an exact, although not easily reversable, conversion.

Degree 1 splines are not supported because they aren't correctly displayed in LibreCAD anyways (it would just be polylines and not these strange chopped corners and it seems to me, that it would result in some confusion if they don't look the same.

The DXF format would allow to give weights to the different control points (DXF would allow NURBSs), which is not implemented in LibreCAD. This isn't a terribly bad thing for the SVG converter, because one cannot transform NURBS into bézier curves without loss.


It would be cool if at least one experienced developer could have a look at this, before I would push it to master.