### PR TITLE
Fixed regression of ellipse creation in MakerCamSVG arising from f123224

### DIFF
--- a/librecad/src/lib/generators/lc_makercamsvg.cpp
+++ b/librecad/src/lib/generators/lc_makercamsvg.cpp
@@ -422,7 +422,7 @@ void LC_MakerCamSVG::writeEllipse(RS_Ellipse* ellipse) {
 
         std::string path = "";
 
-        if (ellipse->isArc()) {
+        if (ellipse->isEllipticArc()) {
 
             const int segments = 4;
 
@@ -500,7 +500,7 @@ void LC_MakerCamSVG::writeEllipse(RS_Ellipse* ellipse) {
     }
     else {
 
-        if (ellipse->isArc()) {
+        if (ellipse->isEllipticArc()) {
 
             RS_DEBUG->print("RS_MakerCamSVG::writeEllipse: Writing ellipse arc as 'path' with arc segments ...");
 


### PR DESCRIPTION
After isArc() was renamed to isEllipticArc() in f123224, the generation of ellipses ia SVG elements failed in "Export to MakerCAM SVG".

This is a simple fix, that renames the function call also in lc_makercamsvg.cpp