### PR TITLE
- Removed return statement at the end of…

### DIFF
--- a/libraries/libdxfrw/src/drw_base.h
+++ b/libraries/libdxfrw/src/drw_base.h
@@ -398,7 +398,6 @@ public:
         default:
             return -3;
         }
-        return static_cast<int> (lw);
     }
 
     static int lineWidth2dwgInt(enum lineWidth lw){


### PR DESCRIPTION
…lineWidth2dxfInt(enum lineWidth lw). All cases are covered in the switch construct, and also a default return value was specified.