### PR TITLE
Minor correction on libdxfrw.

### DIFF
--- a/libraries/libdxfrw/src/drw_base.h
+++ b/libraries/libdxfrw/src/drw_base.h
@@ -396,9 +396,9 @@ public:
         case width23:
             return 211;
         default:
-            return -3;
+            break;
         }
-        return static_cast<int> (lw);
+        return -3;
     }
 
     static int lineWidth2dwgInt(enum lineWidth lw){


### PR DESCRIPTION
libdxfrw: Removed unnecessary return statement from "lineWidth2dxfInt(enum lineWidth lw)".