### PR TITLE
Modified build scripts for OSX

### DIFF
--- a/CLEAN.SH
+++ b/CLEAN.SH
@@ -6,3 +6,4 @@ rm -rf `find . -type d -name generated`
 rm -rf LibreCAD.app
 rm -rf unix
 rm -f core *.core vgcore.* core.*
+rm *.dmg

--- a/common.pri
+++ b/common.pri
@@ -71,7 +71,8 @@ greaterThan( QT_MAJOR_VERSION, 4) {
 	QMAKE_CXXFLAGS_DEBUG += -std=c++11
 }
 
-macx{
-    QMAKE_CXXFLAGS_DEBUG += -mmacosx-version-min=10.8
-    QMAKE_CXXFLAGS += -mmacosx-version-min=10.8
-}
+# RVT July 12 2015, I believe we need these here
+#macx{
+#    QMAKE_CXXFLAGS_DEBUG += -mmacosx-version-min=10.8
+#    QMAKE_CXXFLAGS += -mmacosx-version-min=10.8
+#}

--- a/scripts/build-dmg-externalqt-clang.sh
+++ b/scripts/build-dmg-externalqt-clang.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -x
+
+#b uild dmg installers for OS/X
+#
+# Qt came from a external installation and can be found using the default path
+# You have to make sure it will find that version of qmake, and not the version of macports
+# Compilation will happen with clang, make sure it's your default compiler set : sudo port select gcc none and test with gcc --version
+# This will possible work without macports but I didn't test it (if you have boost installed somewhere)
+
+
+OSNAME[6]="SnowLeopard"
+OSNAME[7]="Lion"
+OSNAME[8]="MountainLion"
+OSNAME[9]="Mavericks"
+OSNAME[10]="Yosemite"
+
+OSSDK[6]="macosx10.6"
+OSSDK[7]="macosx10.7"
+OSSDK[8]="macosx10.8"
+OSSDK[9]="macosx10.9"
+OSSDK[10]="macosx10.10"
+
+#path of this script file
+SCRIPTPATH="$(dirname "$0")"
+
+for v in {6..10}
+do
+	"${SCRIPTPATH}"/build-osx.sh --no-qtpath -qmake_opts="QMAKE_MAC_SDK=${OSSDK[$v]}"
+	mv -v ${SCRIPTPATH}/../LibreCAD.dmg ${SCRIPTPATH}/../LibreCAD-${OSNAME[$v]}.dmg
+done
+

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -6,21 +6,21 @@ OSNAME[6]="SnowLeopard"
 OSNAME[7]="Lion"
 OSNAME[8]="MountainLion"
 OSNAME[9]="Mavericks"
+OSNAME[10]="Yosemite"
+
+OSSDK[6]="macosx10.6"
+OSSDK[7]="macosx10.7"
+OSSDK[8]="macosx10.8"
+OSSDK[9]="macosx10.9"
+OSSDK[10]="macosx10.10"
 
 #path of this script file
 SCRIPTPATH="$(dirname "$0")"
-cd "${SCRIPTPATH}"/..
+export PATH=/opt/local/bin:$PATH
 
-SETTINGSFILE=settings.pri
-
-for v in {6..9}
+for v in {6..10}
 do
-	if [ $v -gt 6 ]
-	then
-		sed -i'' -e '$d' $SETTINGSFILE
-	fi
-	echo "QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.$v" >> $SETTINGSFILE
-	"${SCRIPTPATH}"/build-osx.sh
-	mv -v LibreCAD.dmg "LibreCAD-${OSNAME[$v]}".dmg
+	"${SCRIPTPATH}"/build-osx.sh -qmake_opts="-spec mkspec/macports QMAKE_MAC_SDK=${OSSDK[$v]}"
+	mv -v ${SCRIPTPATH}/../LibreCAD.dmg ${SCRIPTPATH}/../LibreCAD-${OSNAME[$v]}.dmg
 done
 

--- a/scripts/build-osx.sh
+++ b/scripts/build-osx.sh
@@ -4,36 +4,73 @@
 # The dependency required to be able to build LibreCAD:
 # qt, boost, muparser
 
-# the LibreCAD source folder 
+# Options
+# -p=|--qtpath= : Set's a specific path where to startqmake from example : build-osx.sh -p=/opt/Qt5.2.1/5.2.1/clang_64/bin
+# default is set to /opt/local/bin/ for backwards compatibility of this script
+#
+# -q=|-qmake_opts= : Set's additional qmake options exaomple : -qmake_opts="QMAKE_MAC_SDK=macosx10.9"
+# default is set to "-spec mkspec/macports" for backwards compatibility reasons of this script
+#
+# -no-p|--no-qtpath : Removes the default qtpath, this makes the defaukt search path take over to find qmake
 
-SCRIPTPATH="$(dirname "$0")"
+
+# the LibreCAD source folder 
 
 #use default gcc from MacPorts
 # port install gcc49
 # port select gcc mp-gcc49
+# To use the default clang use teh below
+# port select gcc none
 
-export PATH=/opt/local/bin:$PATH
-
+#export PATH=/opt/local/bin:$PATH
 #default qt from MacPorts
 # specify QT_PATH to customize
-QT_PATH=/opt/local/bin
-QMAKE_CMD=$QT_PATH/qmake
+SCRIPTPATH="$(dirname "$0")"
+QT_PATH=/opt/local/bin/
+QMAKE_OPTS="-spec mkspec/macports"
+
+for i in "$@"
+do
+case $i in
+    -q=*|-qmake_opts=*)
+    QMAKE_OPTS="${i#*=}"
+    ;;
+    -p=*|--qtpath*=)
+    QT_PATH="${i#*=}"
+    QT_PATH=${QT_PATH%/}/
+    ;;
+    -no-p|--no-qtpath)
+    QT_PATH=
+    ;;
+    *)
+            # unknown option
+    ;;
+esac
+done
+
+QMAKE_CMD=${QT_PATH}qmake
 
 $QMAKE_CMD -v
 
 cd "${SCRIPTPATH}"/..
+
 # have to clean up any existing binary files to avoid crashes of bug#422
 rm -rf LibreCAD.app
 
-$QMAKE_CMD -r -spec mkspec/macports
-make distclean
+# Run distclean if a previous version of Makefile exists
+if [ -f Makefile ]; then
+    make distclean
+fi
+
 rm -rf generated
-$QMAKE_CMD -r -spec mkspec/macports
+$QMAKE_CMD $QMAKE_OPTS -r
+
 #undefined symbol x86_64: https://qt-project.org/forums/viewthread/35646
-find . -iname makefile -exec sed -i '' \
-	-e 's:mmacosx-version-min=10.[1-9]:mmacosx-version-min=10.8:g' \
-	-e 's:MacOSX10.[1-9].sdk:MacOSX10.8.sdk:g'  \
-	'{}' ';'
+# RVT July 12 2015, this is now controlled with QMAKE_MAC_SDK
+#find . -iname makefile -exec sed -i '' \
+#	-e 's:mmacosx-version-min=10.[1-9]:mmacosx-version-min=10.8:g' \
+#	-e 's:MacOSX10.[1-9].sdk:MacOSX10.8.sdk:g'  \
+#	'{}' ';'
 
 #to make it auto, use "make -j"
 #hardcoded to 4 jobs, because "make -j" crashes our mac building box
@@ -42,7 +79,7 @@ make -j4
 APP_FILE=LibreCAD
 OUTPUT_DMG=${APP_FILE}.dmg
 rm -f "${OUTPUT_DMG}"
-$QT_PATH/macdeployqt ${APP_FILE}.app -verbose=2 -dmg
+${QT_PATH}macdeployqt ${APP_FILE}.app -verbose=2 -dmg
 
 TMP_DMG=$(mktemp temp-DMG.XXXXXXXXXX)
 


### PR DESCRIPTION
Dli,

this are some new build scripts for OSX. 
The goal was to get rid of the modification for settings.pri for the various OSX environments. I also added build-dmg-externalqt-clang.sh for a build with clang and tested with a external version of Qt.
Let me know what you thing.