### PR TITLE
added link to wiki

### DIFF
--- a/librecad/src/main/helpbrowser.cpp
+++ b/librecad/src/main/helpbrowser.cpp
@@ -45,6 +45,7 @@
 HelpBrowser::HelpBrowser(QHelpEngine *helpEngine, QWidget *parent)
     : QTextBrowser(parent), helpEngine(helpEngine)
 {
+    setOpenExternalLinks(true);
 }
 
 QVariant HelpBrowser::loadResource(int type, const QUrl &url)

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -3673,5 +3673,5 @@ void QC_ApplicationWindow::updateWindowTitle(QWidget *w)
 
 void QC_ApplicationWindow::goto_wiki()
 {
-    QDesktopServices::openUrl(QUrl("http://wiki.librecad.org/index.php/Main_Page"));
+    QDesktopServices::openUrl(QUrl("http://wiki.librecad.org/"));
 }

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -3409,6 +3409,7 @@ void QC_ApplicationWindow::slotHelpManual() {
 
             helpWindow = new QDockWidget(tr("Help"), this);
             helpWindow->setWidget(splitter);
+            helpWindow->setObjectName("HelpWindow");
 
             // Enable single clicking of the index
             connect(helpEngine->contentWidget(), SIGNAL(clicked(QModelIndex)), helpEngine->contentWidget(), SLOT(showLink(QModelIndex)));

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -28,6 +28,8 @@
 #include <QStatusBar>
 #include <QMenuBar>
 #include <QDockWidget>
+#include <QDesktopServices>
+#include <QUrl>
 
 #if QT_VERSION < 0x040400
 #include <QtAssistant/QAssistantClient>
@@ -1151,9 +1153,13 @@ void QC_ApplicationWindow::initMenuBar() {
 
     menuBar()->addSeparator();
     // menuBar entry helpMenu
+    QAction* wiki_link = new QAction(tr("Online (Wiki)"), this);
+    connect(wiki_link, SIGNAL(triggered()), this, SLOT(goto_wiki()));
+
     helpMenu = menuBar()->addMenu(tr("&Help"));
     helpMenu->setObjectName("Help");
     helpMenu->addAction(helpManual);
+    helpMenu->addAction(wiki_link);
     helpMenu->addSeparator();
     helpMenu->addAction(helpAboutApp);
 
@@ -3663,4 +3669,9 @@ void QC_ApplicationWindow::updateWindowTitle(QWidget *w)
         if(w->windowTitle().lastIndexOf(m_qDraftModeTitle))
         w->setWindowTitle(w->windowTitle()+m_qDraftModeTitle);
     }
+}
+
+void QC_ApplicationWindow::goto_wiki()
+{
+    QDesktopServices::openUrl(QUrl("http://wiki.librecad.org/index.php/Main_Page"));
 }

--- a/librecad/src/main/qc_applicationwindow.h
+++ b/librecad/src/main/qc_applicationwindow.h
@@ -188,6 +188,8 @@ public slots:
     void slotUpdateActiveLayer();
 	void execPlug();
 
+    void goto_wiki();
+
 signals:
     void gridChanged(bool on);
     void draftChanged(bool on);

--- a/librecad/support/doc/index.html
+++ b/librecad/support/doc/index.html
@@ -13,7 +13,7 @@
     </table>
     <hr >
     <p>OOPS NO MANUAL!</p>
-    <p>We are working to create a new manual specially for LibreCAD. The current version of our work-in-progress user manual is online at <a href="http://wiki.librecad.org/index.php/LibreCAD_users_Manual">LibreCAD User Manual</a>, which was originally created by Bob Woltz. Following Bob's initiative, many members of our user community have been helping to improve and update this user manual. Please share your knowledge and skills on LibreCAD at <a href="http://wiki.librecad.org/index.php/Main_Page">LibreCAD wiki </a>.</p>
+    <p>We are working to create a new manual specially for LibreCAD. The current version of our work-in-progress user manual is online at <a href="http://wiki.librecad.org/index.php/LibreCAD_users_Manual">LibreCAD User Manual</a>, which was originally created by Bob Woltz. Following Bob's initiative, many members of our user community have been helping to improve and update this user manual. Please share your knowledge and skills on LibreCAD at <a href="http://wiki.librecad.org/">LibreCAD wiki</a>.</p>
     
     <p>In the mean time, to get specific help on LibreCAD, please visit the following link: <a href="http://librecad.org/cms/home/get-help.html">http://librecad.org/cms/home/get-help.html</a></p>
     <p>There are some wonderfull people on the <a href="http://forum.librecad.org">LibreCAD forums</a> and <a href="irc://irc.freenode.net/#librecad">#librecad IRC channel</a> that can give you a hand to get going.</p>


### PR DESCRIPTION
This launches the default browser and goes to our wiki.
The links under Help → Manual do not work.