### PR TITLE
Added new command shortcuts 

### DIFF
--- a/librecad/src/cmd/rs_commands.cpp
+++ b/librecad/src/cmd/rs_commands.cpp
@@ -304,6 +304,12 @@ RS_Commands::RS_Commands() {
              {"dr", QObject::tr("dr", "dimension - linear")}},
             RS2::ActionDimLinear
         },
+	//dimension angular
+	{
+		{{"dimangular", QObject::tr("dimangular", "dimension - angular")}},
+		{{"an", QObject::tr("an", "dimension - angular")}},
+		RS2::ActionDimAngular
+	},
         //dimension leader
         {
             {{"dimleader", QObject::tr("dimleader", "dimension - leader")}},

--- a/librecad/src/cmd/rs_commands.cpp
+++ b/librecad/src/cmd/rs_commands.cpp
@@ -307,8 +307,21 @@ RS_Commands::RS_Commands() {
 	//dimension angular
 	{
 		{{"dimangular", QObject::tr("dimangular", "dimension - angular")}},
-		{{"an", QObject::tr("an", "dimension - angular")}},
+		{{"dan", QObject::tr("dan", "dimension - angular")}},
 		RS2::ActionDimAngular
+	},
+	//dimension radius
+	{
+		{{"dimradial", QObject::tr("dimradial", "dimension - radial")}},
+		{{"dimradius", QObject::tr("dimradius", "dimension - radius")}},
+		RS2::ActionDimRadial
+	},
+	//dimension diameter
+	{
+		{{"dimdiametric", QObject::tr("dimdiametric", "dimension - diametric")}},
+		{{"dimdiameter", QObject::tr("dimdiameter", "dimension - diametric")},
+		 {"dd", QObject::tr("dd", "dimension - diametric")}},
+		RS2::ActionDimDiametric
 	},
         //dimension leader
         {


### PR DESCRIPTION
For "dimension - angular",  "dimension - radial" and "dimension - diametric".
I duplicated dim* commands for "radial" and "diametric", as "radius" and "diameter" may seem more obvious.