### PR TITLE
Extension of command-line autocompletion

### DIFF
--- a/librecad/src/ui/forms/qg_commandwidget.cpp
+++ b/librecad/src/ui/forms/qg_commandwidget.cpp
@@ -189,24 +189,16 @@ void QG_CommandWidget::setNormalMode() {
 }
 
 QString QG_CommandWidget::getRootCommand( const QStringList & cmdList ) {
-    QString longestString;
     QString shortestString;
     int lengthShortestString(0);
-    int lengthCmdList = cmdList.count();
 
-    // Finding which is the longest string
-    for(QStringList::const_iterator it = cmdList.begin(); it != cmdList.end(); ++it) {
-        if((*it).length() > longestString.length()) {
-            longestString = (*it);
-        }
-    }
-    int lengthLongestString = longestString.length();
+    shortestString = cmdList.at(0);
+    lengthShortestString = shortestString.length();
 
-    // Finding which is the shortest string
-    lengthShortestString = longestString.length();
     for(QStringList::const_iterator it = cmdList.begin(); it != cmdList.end(); ++it) {
         if((*it).length() < lengthShortestString) {
             shortestString = (*it);
+            lengthShortestString = shortestString.length();
         }
     }
     lengthShortestString = shortestString.length();
@@ -218,7 +210,7 @@ QString QG_CommandWidget::getRootCommand( const QStringList & cmdList ) {
 
     for(i = 0; i < lengthShortestString; ++i) {
         for(QStringList::const_iterator it = cmdList.begin(); it != cmdList.end(); ++it) {
-            if(longestString.at(i) != (*it).at(i)) {
+            if(shortestString.at(i) != (*it).at(i)) {
                 common = false;
                 break;
             }
@@ -227,7 +219,7 @@ QString QG_CommandWidget::getRootCommand( const QStringList & cmdList ) {
             ++pos;
         }
     }
-    return longestString.left(pos);
+    return shortestString.left(pos);
 
 }
 

--- a/librecad/src/ui/forms/qg_commandwidget.cpp
+++ b/librecad/src/ui/forms/qg_commandwidget.cpp
@@ -157,47 +157,7 @@ void QG_CommandWidget::tabPressed() {
             leCommand->setText(reducedChoice.first());
         }
         else if (reducedChoice.count()>0) {
-        //TODO: unix-like behaviour for autocompletion
-            QString longestString = "";
-            QString shortestString = "";
-            int lengthShortestString(0);
-            int lengthReducedChoice = reducedChoice.count();
-
-            // Finding which is the longest string
-            for(QStringList::Iterator it = reducedChoice.begin(); it != reducedChoice.end(); ++it) {
-                if((*it).length() > longestString.length()) {
-                    longestString = (*it);
-                }
-            }
-            int lengthLongestString = longestString.length();
-
-            // Finding which is the shortest string
-            lengthShortestString = longestString.length();
-            for(QStringList::Iterator it = reducedChoice.begin(); it != reducedChoice.end(); ++it) {
-                if((*it).length() < lengthShortestString) {
-                    shortestString = (*it);
-                }
-            }
-            lengthShortestString = shortestString.length();
-
-            // Now we parse the reducedChoice list, character of each item by character.
-            int i(0);
-            int pos(0);
-            bool common = true;
-
-            for(i = 0; i < lengthShortestString; ++i) {
-                for(QStringList::Iterator it = reducedChoice.begin(); it != reducedChoice.end(); ++it) {
-                    if(longestString.at(i) != (*it).at(i)) {
-                        common = false;
-                        break;
-                    }
-                }
-                if(common == true) {
-                    ++pos;
-                }
-            }
-
-            QString proposal = longestString.left(pos);
+            QString proposal = this->getRootCommand(reducedChoice);
             appendHistory(reducedChoice.join(", "));
             leCommand -> setText(proposal);
         }
@@ -227,3 +187,47 @@ void QG_CommandWidget::setNormalMode() {
     palette.setColor(lCommand->foregroundRole(), Qt::black);
     lCommand->setPalette(palette);
 }
+
+QString QG_CommandWidget::getRootCommand( const QStringList & cmdList ) {
+    QString longestString;
+    QString shortestString;
+    int lengthShortestString(0);
+    int lengthCmdList = cmdList.count();
+
+    // Finding which is the longest string
+    for(QStringList::const_iterator it = cmdList.begin(); it != cmdList.end(); ++it) {
+        if((*it).length() > longestString.length()) {
+            longestString = (*it);
+        }
+    }
+    int lengthLongestString = longestString.length();
+
+    // Finding which is the shortest string
+    lengthShortestString = longestString.length();
+    for(QStringList::const_iterator it = cmdList.begin(); it != cmdList.end(); ++it) {
+        if((*it).length() < lengthShortestString) {
+            shortestString = (*it);
+        }
+    }
+    lengthShortestString = shortestString.length();
+
+    // Now we parse the cmdList list, character of each item by character.
+    int i(0);
+    int pos(0);
+    bool common = true;
+
+    for(i = 0; i < lengthShortestString; ++i) {
+        for(QStringList::const_iterator it = cmdList.begin(); it != cmdList.end(); ++it) {
+            if(longestString.at(i) != (*it).at(i)) {
+                common = false;
+                break;
+            }
+        }
+        if(common == true) {
+            ++pos;
+        }
+    }
+    return longestString.left(pos);
+
+}
+

--- a/librecad/src/ui/forms/qg_commandwidget.cpp
+++ b/librecad/src/ui/forms/qg_commandwidget.cpp
@@ -157,7 +157,7 @@ void QG_CommandWidget::tabPressed() {
             leCommand->setText(reducedChoice.first());
         }
         else if (reducedChoice.count()>0) {
-            QString proposal = this->getRootCommand(reducedChoice);
+            QString proposal = this->getRootCommand(reducedChoice, typed);
             appendHistory(reducedChoice.join(", "));
             leCommand -> setText(proposal);
         }
@@ -188,7 +188,7 @@ void QG_CommandWidget::setNormalMode() {
     lCommand->setPalette(palette);
 }
 
-QString QG_CommandWidget::getRootCommand( const QStringList & cmdList ) {
+QString QG_CommandWidget::getRootCommand( const QStringList & cmdList, const QString & typed ) {
     QString shortestString;
     int lengthShortestString(0);
 
@@ -201,25 +201,36 @@ QString QG_CommandWidget::getRootCommand( const QStringList & cmdList ) {
             lengthShortestString = shortestString.length();
         }
     }
-    lengthShortestString = shortestString.length();
 
     // Now we parse the cmdList list, character of each item by character.
-    int i(0);
-    int pos(0);
     bool common = true;
+    int low = typed.length();
+    int high = lengthShortestString + 1;
+    int mid(0);
+    QString proposal;
 
-    for(i = 0; i < lengthShortestString; ++i) {
-        for(QStringList::const_iterator it = cmdList.begin(); it != cmdList.end(); ++it) {
-            if(shortestString.at(i) != (*it).at(i)) {
+    while(high > low + 1) {
+        mid = (high + low)/2;
+        common = true;
+        proposal = shortestString.left(mid);
+
+        for(auto const& substring: cmdList) {
+            if(!substring.startsWith(proposal)) {
                 common = false;
                 break;
             }
         }
-        if(common == true) {
-            ++pos;
+        if(common) {
+            low = mid;
+        }
+        else {
+            high = mid;
         }
     }
-    return shortestString.left(pos);
+
+    
+
+    return shortestString.left(mid);
 
 }
 

--- a/librecad/src/ui/forms/qg_commandwidget.cpp
+++ b/librecad/src/ui/forms/qg_commandwidget.cpp
@@ -29,6 +29,8 @@
 #include "qg_actionhandler.h"
 #include "rs_commands.h"
 #include "rs_commandevent.h"
+#include "rs_system.h"
+#include "rs_utility.h"
 
 /*
  *  Constructs a QG_CommandWidget as a child of 'parent', with the
@@ -155,7 +157,49 @@ void QG_CommandWidget::tabPressed() {
             leCommand->setText(reducedChoice.first());
         }
         else if (reducedChoice.count()>0) {
+        //TODO: unix-like behaviour for autocompletion
+            QString longestString = "";
+            QString shortestString = "";
+            int lengthShortestString(0);
+            int lengthReducedChoice = reducedChoice.count();
+
+            // Finding which is the longest string
+            for(QStringList::Iterator it = reducedChoice.begin(); it != reducedChoice.end(); ++it) {
+                if((*it).length() > longestString.length()) {
+                    longestString = (*it);
+                }
+            }
+            int lengthLongestString = longestString.length();
+
+            // Finding which is the shortest string
+            lengthShortestString = longestString.length();
+            for(QStringList::Iterator it = reducedChoice.begin(); it != reducedChoice.end(); ++it) {
+                if((*it).length() < lengthShortestString) {
+                    shortestString = (*it);
+                }
+            }
+            lengthShortestString = shortestString.length();
+
+            // Now we parse the reducedChoice list, character of each item by character.
+            int i(0);
+            int pos(0);
+            bool common = true;
+
+            for(i = 0; i < lengthShortestString; ++i) {
+                for(QStringList::Iterator it = reducedChoice.begin(); it != reducedChoice.end(); ++it) {
+                    if(longestString.at(i) != (*it).at(i)) {
+                        common = false;
+                        break;
+                    }
+                }
+                if(common == true) {
+                    ++pos;
+                }
+            }
+
+            QString proposal = longestString.left(pos);
             appendHistory(reducedChoice.join(", "));
+            leCommand -> setText(proposal);
         }
     }
 }

--- a/librecad/src/ui/forms/qg_commandwidget.cpp
+++ b/librecad/src/ui/forms/qg_commandwidget.cpp
@@ -212,8 +212,8 @@ QString QG_CommandWidget::getRootCommand( const QStringList & cmdList, const QSt
     while(high > low + 1) {
         mid = (high + low)/2;
         common = true;
-        proposal = shortestString.left(mid);
 
+        proposal = shortestString.left(mid);
         for(auto const& substring: cmdList) {
             if(!substring.startsWith(proposal)) {
                 common = false;
@@ -228,9 +228,12 @@ QString QG_CommandWidget::getRootCommand( const QStringList & cmdList, const QSt
         }
     }
 
+    // As we assign just before mid value to low (if strings are common), we can use it as parameter for left.
+    // If not common -> low value does not changes, even if escaping from the while. This avoids weird behaviors like continuing completion when pressing tab.
+    proposal = shortestString.left(low);
     
 
-    return shortestString.left(mid);
+    return proposal;
 
 }
 

--- a/librecad/src/ui/forms/qg_commandwidget.h
+++ b/librecad/src/ui/forms/qg_commandwidget.h
@@ -55,7 +55,7 @@ protected slots:
 
 private:
     QG_ActionHandler* actionHandler;
-    QString getRootCommand( const QStringList & cmdList );
+    QString getRootCommand( const QStringList & cmdList, const QString & typed );
 };
 
 #endif // QG_COMMANDWIDGET_H

--- a/librecad/src/ui/forms/qg_commandwidget.h
+++ b/librecad/src/ui/forms/qg_commandwidget.h
@@ -55,6 +55,7 @@ protected slots:
 
 private:
     QG_ActionHandler* actionHandler;
+    QString getRootCommand( const QStringList & cmdList );
 };
 
 #endif // QG_COMMANDWIDGET_H

--- a/librecad/src/ui/forms/qg_commandwidget.h
+++ b/librecad/src/ui/forms/qg_commandwidget.h
@@ -49,13 +49,13 @@ public slots:
     virtual void setActionHandler( QG_ActionHandler * ah );
     virtual void setCommandMode();
     virtual void setNormalMode();
+    QString getRootCommand( const QStringList & cmdList, const QString & typed );
 
 protected slots:
     virtual void languageChange();
 
 private:
     QG_ActionHandler* actionHandler;
-    QString getRootCommand( const QStringList & cmdList, const QString & typed );
 };
 
 #endif // QG_COMMANDWIDGET_H


### PR DESCRIPTION
Implemented bash-behavior for autocompletion : when typing 'sp<tab>', the CL will automatically prompt 'spline' (longest common root for commands starting with 'sp' -> 'spline' & 'spline2').

I would like to pack this piece of code into a function which would return a QString (it would seem more clean). May I use a QG_CommandWidget private method for this ? (e.g. QString autoCompletion(QStringList  const & shortCmdList);).
Rupi