### PR TITLE
Helper, shortcut & bug correction for "Circle with center & radius" tool

### DIFF
--- a/librecad/src/actions/rs_actiondrawcirclecr.cpp
+++ b/librecad/src/actions/rs_actiondrawcirclecr.cpp
@@ -73,7 +73,15 @@ void RS_ActionDrawCircleCR::trigger() {
 									  *data);
     circle->setLayerToActive();
     circle->setPenToActive();
-    container->addEntity(circle);
+
+    switch(getStatus()) {
+    	case SetCenter:
+    		container->addEntity(circle);
+		graphicView->moveRelativeZero(circle->getCenter());
+		break;
+	case SetRadius:
+		break;
+    }
 
     // upd. undo list:
     if (document) {
@@ -82,7 +90,6 @@ void RS_ActionDrawCircleCR::trigger() {
         document->endUndoCycle();
     }
         graphicView->redraw(RS2::RedrawDrawing);
-    graphicView->moveRelativeZero(circle->getCenter());
 
     setStatus(SetCenter);
 

--- a/librecad/src/cmd/rs_commands.cpp
+++ b/librecad/src/cmd/rs_commands.cpp
@@ -202,6 +202,15 @@ RS_Commands::RS_Commands() {
             {{"c3", QObject::tr("c3", "circle 3 points")}},
             RS2::ActionDrawCircle3P
         },
+<<<<<<< HEAD
+=======
+	//draw circle with point and radius
+	{
+		{{"circlecr", QObject::tr("circlepr", "circle with center and radius")}},
+		{{"cc", QObject::tr("cc", "circle with center and radius")}},
+		RS2::ActionDrawCircleCR
+	},
+>>>>>>> 20d9ab4... Added help tip, shortcut command & corrected bug
         //draw circle tangent to 3 objects
         {
             {{"tan3", QObject::tr("tan3", "circle tangent to 3")}},

--- a/librecad/src/cmd/rs_commands.cpp
+++ b/librecad/src/cmd/rs_commands.cpp
@@ -202,15 +202,12 @@ RS_Commands::RS_Commands() {
             {{"c3", QObject::tr("c3", "circle 3 points")}},
             RS2::ActionDrawCircle3P
         },
-<<<<<<< HEAD
-=======
 	//draw circle with point and radius
 	{
-		{{"circlecr", QObject::tr("circlepr", "circle with center and radius")}},
+		{{"circlecr", QObject::tr("circlecr", "circle with center and radius")}},
 		{{"cc", QObject::tr("cc", "circle with center and radius")}},
 		RS2::ActionDrawCircleCR
 	},
->>>>>>> 20d9ab4... Added help tip, shortcut command & corrected bug
         //draw circle tangent to 3 objects
         {
             {{"tan3", QObject::tr("tan3", "circle tangent to 3")}},


### PR DESCRIPTION
##### Help tip
When in mode "circle with center and radius", typing "radius"
in the command-line allow the user to set the radius without moving
hands off the keyboard, but the helper message didn't mentionned that
possibility.

##### Bug
When setting radius from commandline, pressing enter to validate
causes LibreCAD to draw a circle of selected radius at relative zero
position (if no mouse activity into the container) or crosshair
position (if mouse activity into the container).
I added a `switch` test to the `trigger()` method to test the mode, and
if the user is in mode "SetRadius", circle is not drawn & relative zero
is not moved.

##### Command shortcuts
`circlecr` and `cc`