### PR TITLE
Fixed bug in hatch dialog box

### DIFF
--- a/librecad/src/ui/qg_dialogfactory.cpp
+++ b/librecad/src/ui/qg_dialogfactory.cpp
@@ -1773,7 +1773,7 @@ bool QG_DialogFactory::requestTextDialog(RS_Text* text) {
  * Shows a dialog to edit pattern / hatch attributes of the given entity.
  */
 bool QG_DialogFactory::requestHatchDialog(RS_Hatch* hatch) {
-	if (hatch) return false;
+	if (hatch==nullptr) return false;
 
     RS_PATTERNLIST->init();
 


### PR DESCRIPTION
Bug introduced by commit 776c8ae4dbd86ae658202a2174895ce340b0b1dd (`git bisect` information)
Changing from `if(hatch==nullptr)` to `if(hatch)` caused the hatch
dialog box not to show when called.
It seems that this change fixed it... Will see.

Because I reverted a change which happened few times ago, I prefer asking : why was this line changed ? Does it have a goal in particular, that I would have broken by reverting ?