### PR TITLE
Added void-type to signals

### DIFF
--- a/librecad/src/lib/gui/rs_graphicview.h
+++ b/librecad/src/lib/gui/rs_graphicview.h
@@ -464,8 +464,8 @@ private:
 	bool m_bIsCleanUp=false;
 
 signals:
-    relative_zero_changed(const RS_Vector&);
-    previous_zoom_state(bool);
+    void relative_zero_changed(const RS_Vector&);
+    void previous_zoom_state(bool);
 };
 
 #endif


### PR DESCRIPTION
Signals without void type was causing compilation failure.