### PR TITLE
Better zoom-field navigation through basic ZUI "flight" theory

### DIFF
--- a/librecad/src/actions/rs_actiondefault.cpp
+++ b/librecad/src/actions/rs_actiondefault.cpp
@@ -110,7 +110,7 @@ void RS_ActionDefault::keyReleaseEvent(QKeyEvent* e) {
 
 void RS_ActionDefault::mouseMoveEvent(QMouseEvent* e) {
 
-    RS_Vector mouse = graphicView->toGraph(RS_Vector(e->x(), e->y()));
+    RS_Vector mouse = graphicView->toGraph(e->x(), e->y());
     RS_Vector relMouse = mouse - graphicView->getRelativeZero();
 
     RS_DIALOGFACTORY->updateCoordinateWidget(mouse, relMouse);

--- a/librecad/src/lib/gui/rs_graphicview.cpp
+++ b/librecad/src/lib/gui/rs_graphicview.cpp
@@ -341,9 +341,9 @@ void RS_GraphicView::zoomIn(double f, const RS_Vector& center) {
     }
 
 	zoomWindow(
-				toGraph(RS_Vector(0,0))
+				toGraph(0, 0)
 				.scale(c, RS_Vector(1.0/f,1.0/f)),
-				toGraph(RS_Vector(getWidth(),getHeight()))
+				toGraph(getWidth(), getHeight())
 				.scale(c, RS_Vector(1.0/f,1.0/f)));
 
 	//adjustOffsetControls();

--- a/librecad/src/ui/qg_graphicview.cpp
+++ b/librecad/src/ui/qg_graphicview.cpp
@@ -333,7 +333,7 @@ bool QG_GraphicView::event(QEvent *event) {
 
             // It seems the NativeGestureEvent::pos() incorrectly reports global coordinates
             QPoint g = mapFromGlobal(nge->globalPos());
-            RS_Vector mouse = toGraph(RS_Vector(g.x(), g.y()));
+            RS_Vector mouse = toGraph(g.x(), g.y());
             setCurrentAction(new RS_ActionZoomIn(*container, *this, direction,
 												 RS2::Both, &mouse, factor));
         }
@@ -450,7 +450,7 @@ void QG_GraphicView::wheelEvent(QWheelEvent *e) {
         return;
     }
 
-    RS_Vector mouse = toGraph(RS_Vector(e->x(), e->y()));
+    RS_Vector mouse = toGraph(e->x(), e->y());
 
 #if QT_VERSION >= 0x050200
     QPoint numPixels = e->pixelDelta();
@@ -545,15 +545,12 @@ void QG_GraphicView::wheelEvent(QWheelEvent *e) {
     // zoom in / out:
     else if (e->modifiers()==0) {
 
-		/*
-		 * FIXME - there is surly a better way to get the center of the main view port. 
-		 */
-		RS_Vector mainViewCenter = toGraph(RS_Vector(getWidth()/2, getHeight()/2));
+		RS_Vector mainViewCenter = toGraph(getWidth()/2, getHeight()/2);
 
 		if (e->delta()>0) {
 			const double zoomInOvershoot=1.20;
 
-			RS_Vector effect=RS_Vector(mouse);
+			RS_Vector effect{mouse};
 			{
 				effect-=mainViewCenter;
 				effect.scale(zoomInOvershoot);
@@ -566,7 +563,7 @@ void QG_GraphicView::wheelEvent(QWheelEvent *e) {
 		} else {
 			const double zoomOutUndershoot=0.30;
 
-			RS_Vector effect=RS_Vector(mouse);
+			RS_Vector effect{mouse};
 			{
 				effect-=mainViewCenter;
 				effect.scale(zoomOutUndershoot);
@@ -788,7 +785,7 @@ RS_Vector QG_GraphicView::getMousePosition() const
     //if cursor is not on widget, return the widget center position
     if(!rect().contains(vp))
         vp=QPoint(width()/2, height()/2);
-    return toGraph(RS_Vector(vp.x(), vp.y()));
+    return toGraph(vp.x(), vp.y());
 }
 
 void QG_GraphicView::getPixmapForView(std::unique_ptr<QPixmap>& pm)

--- a/librecad/src/ui/qg_graphicview.cpp
+++ b/librecad/src/ui/qg_graphicview.cpp
@@ -544,14 +544,38 @@ void QG_GraphicView::wheelEvent(QWheelEvent *e) {
 
     // zoom in / out:
     else if (e->modifiers()==0) {
+
+		/*
+		 * FIXME - there is surly a better way to get the center of the main view port. 
+		 */
+		RS_Vector mainViewCenter = toGraph(RS_Vector(getWidth()/2, getHeight()/2));
+
 		if (e->delta()>0) {
+			const double zoomInOvershoot=1.20;
+
+			RS_Vector effect=RS_Vector(mouse);
+			{
+				effect-=mainViewCenter;
+				effect.scale(zoomInOvershoot);
+				effect+=mainViewCenter;
+			}
+
 			setCurrentAction(new RS_ActionZoomIn(*container, *this,
 												 RS2::In, RS2::Both,
-												 &mouse));
+												 &effect));
 		} else {
+			const double zoomOutUndershoot=0.30;
+
+			RS_Vector effect=RS_Vector(mouse);
+			{
+				effect-=mainViewCenter;
+				effect.scale(zoomOutUndershoot);
+				effect+=mainViewCenter;
+			}
+
 			setCurrentAction(new RS_ActionZoomIn(*container, *this,
 												 RS2::Out, RS2::Both,
-												 &mouse));
+												 &effect));
 		}
     }
 

--- a/librecad/src/ui/qg_graphicview.cpp
+++ b/librecad/src/ui/qg_graphicview.cpp
@@ -545,6 +545,20 @@ void QG_GraphicView::wheelEvent(QWheelEvent *e) {
     // zoom in / out:
     else if (e->modifiers()==0) {
 
+		/**
+		 * The zoomFactor effects how quickly the scroll wheel will zoom in & out.
+		 * 
+		 * Benchmarks:
+		 * 1.250 - the original; fast & usable, but seems a choppy & a bit 'jarring'
+		 * 1.175 - still a bit choppy
+		 * 1.150 - smoother than the original, but still 'quick' enough for good navigation.
+		 * 1.137 - seems to work well for me
+		 * 1.125 - about the lowest that would be acceptable and useful, a tad on the slow side for me
+		 * 1.100 - a very slow & deliberate zooming, but feels very "cautious", "controlled", "safe", and "precise".
+		 * 1.000 - goes nowhere. :)
+		 */
+		const double zoomFactor=1.137;
+
 		RS_Vector mainViewCenter = toGraph(getWidth()/2, getHeight()/2);
 
 		if (e->delta()>0) {
@@ -559,7 +573,9 @@ void QG_GraphicView::wheelEvent(QWheelEvent *e) {
 
 			setCurrentAction(new RS_ActionZoomIn(*container, *this,
 												 RS2::In, RS2::Both,
-												 &effect));
+												 &effect,
+												 zoomFactor
+												));
 		} else {
 			const double zoomOutUndershoot=0.30;
 
@@ -572,7 +588,9 @@ void QG_GraphicView::wheelEvent(QWheelEvent *e) {
 
 			setCurrentAction(new RS_ActionZoomIn(*container, *this,
 												 RS2::Out, RS2::Both,
-												 &effect));
+												 &effect,
+												 zoomFactor
+												));
 		}
     }
 


### PR DESCRIPTION
When scrolling with the mouse wheel, you should find:
+ Far less "inch worming" (e.g. mouse top-left, zoom in, mouse bottom-right, zoom out)
+ Zooming out tends to reveal more logical/useful canvas
+ Zooming in tends to center objects that were under the cursor
+ Zooming in on objects near the edge of the view port should now be in a useful position more often
- Seasoned veterans might need to get used to the "drift" or "not working around the old zoom mechanic".
- Not as effective for "just playing with the grid lines" [i.e. zoom_in != inverse(zoom_out)]

Relatedly:
- Zooming is still a bit too choppy, IMO.
- Snapper/Guides are still not redrawn after a zoom event.