### PR TITLE
Added Backspace as shortcut for Delete. 

### DIFF
--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -1470,10 +1470,6 @@ void QC_ApplicationWindow::
         QMdiSubWindow* old=activedMdiSubWindow;
         QRect geo;
         bool maximized=false;
-        if(old) {//save old geometry
-            geo=activedMdiSubWindow->geometry();
-            maximized=activedMdiSubWindow->isMaximized();
-        }
 
         QC_MDIWindow* w = slotFileNew();
         // RVT_PORT qApp->processEvents(1000);
@@ -1490,6 +1486,11 @@ void QC_ApplicationWindow::
         RS_DEBUG->print("QC_ApplicationWindow::slotFileOpen: open file");
 
         qApp->processEvents(QEventLoop::AllEvents, 1000);
+
+        if(old) {//save old geometry
+            geo=activedMdiSubWindow->geometry();
+            maximized=activedMdiSubWindow->isMaximized();
+        }
 
         // open the file in the new view:
         bool success=false;

--- a/librecad/src/ui/lc_actionfactory.cpp
+++ b/librecad/src/ui/lc_actionfactory.cpp
@@ -1035,7 +1035,7 @@ void LC_ActionFactory::fillActionContainer(QMap<QString, QAction*>& a_map)
 
     action = new QAction(tr("&Delete selected"), disable_group);
     action->setIcon(QIcon(":/extui/modifydelete.png"));
-    action->setShortcut(QKeySequence::Delete);
+    action->setShortcuts(QList<QKeySequence>() << QKeySequence::Delete << QKeySequence(Qt::Key_Backspace));
     connect(action, SIGNAL(triggered()),
     action_handler, SLOT(slotModifyDeleteQuick()));
     action->setObjectName("ModifyDeleteQuick");


### PR DESCRIPTION
A tiny change to add a Backspace together with Delete as shortcuts for deleting.
Useful for mac keyboards (like on my linux) without a delete button.

Get the geometry from the activedMdiSubWindow before it is created was generating a coredump