### PR TITLE
travis-ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: cpp
+sudo: required
+dist: trusty
+compiler: gcc
+matrix:
+  fast_finish: true
+  include:
+    - compiler: gcc
+      secure: "TjkB5PJRwRdOAJhs1wp6kZrE6Pv5JrL8/lVWTlXqHtnruZZM8tE+sT79NnvgJSFmxLjBupbnddsNCAl43UCji5ZTRowhjrjrY1TLtbp5SO4YCmSDSF+14/vLBzqFxlDpKBrYrxhSG9wB4kDV5QKiZ/PcmYcsh+KtyNZsA/BOgMI="
+      env:
+        -  ANALYZE="scan-build-3.7 -o out "
+        -  GH_REF=github.com/LibreCAD/static-analyzer-reports.git
+  allow_failures:
+    - compiler: ANALYZE="scan-build-3.7 -o out "
+
+install:
+  - sudo apt-get -qq install qt5-default qtbase5-dev  libqt5svg5-dev qttools5-dev qttools5-dev-tools libmuparser-dev libboost-dev libfreetype6-dev libicu-dev pkg-config
+  - >
+    if [ "${ANALYZE}" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+      wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -;
+      echo "yes" | sudo apt-add-repository "deb http://llvm.org/apt/$(lsb_release -sc)/ llvm-toolchain-$(lsb_release -sc)-3.7 main";
+      sudo apt-get update;
+      sudo apt-get -qq install clang-3.7;
+    fi;
+
+script:
+  - >
+    if [ ! "${ANALYZE}" ] || [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+      ${ANALYZE}qmake -r librecad.pro CONFIG+=debug_and_release;
+      ${ANALYZE}make debug -j3;
+    fi;
+  - if [ "${ANALYZE}" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then ./CI/static-analyzer-reports.sh; fi

--- a/CI/static-analyzer-reports.sh
+++ b/CI/static-analyzer-reports.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e # exit with nonzero exit code if anything fails
+
+# https://gist.github.com/domenic/ec8b0fc8ab45f39403dd
+
+# go to the out directory and create a *new* Git repo
+cd out
+git init
+
+# inside this git repo we'll pretend to be a new user
+git config user.name "Travis CI"
+git config user.email "showard@debian.org"
+
+# The first and only commit to this new Git repo contains all the
+# files present with the commit message "Deploy to GitHub Pages".
+git add .
+git commit -m "Deploy to GitHub Pages"
+
+# Force push from the current repo's master branch to the remote
+# repo's gh-pages branch. (All previous history on the gh-pages branch
+# will be lost, since we are overwriting it.) We redirect any output to
+# /dev/null to hide any sensitive credential data that might otherwise be exposed.
+git push --force --quiet "https://${GH_TOKEN}@${GH_REF}" master:gh-pages > /dev/null 2>&1


### PR DESCRIPTION
this is to enable travis-ci for test building pull requests. In future this can also be used for daily builds.
https://travis-ci.org/LibreCAD/LibreCAD
(doesn't work yet because we don't have this pull request accepted yet)