### PR TITLE
dxfrw memory leak

### DIFF
--- a/libraries/libdxfrw/src/drw_entities.cpp
+++ b/libraries/libdxfrw/src/drw_entities.cpp
@@ -11,64 +11,10 @@
 ******************************************************************************/
 
 #include <cstdlib>
-#include <algorithm>
-#include <iterator>
 #include "drw_entities.h"
 #include "intern/dxfreader.h"
 #include "intern/dwgbuffer.h"
 #include "intern/drw_dbg.h"
-
-DRW_Entity::DRW_Entity(const DRW_Entity& e):
-	extData(e.extData.begin(), e.extData.end())
-{
-	init(e);
-}
-
-DRW_Entity& DRW_Entity::operator = (const DRW_Entity& e)
-{
-	std::copy(e.extData.begin(), e.extData.end(), std::back_inserter(extData));
-	init(e);
-	return *this;
-}
-
-DRW_Entity::DRW_Entity(DRW_Entity&& e):
-	extData(std::move(e.extData))
-{
-	init(e);
-}
-
-DRW_Entity& DRW_Entity::operator = (DRW_Entity&& e)
-{
-	init(e);
-	extData = std::move(e.extData);
-	return *this;
-}
-
-void DRW_Entity::init(DRW_Entity const& rhs)
-{
-	eType = rhs.eType;
-	handle = rhs.handle;
-	parentHandle = rhs.parentHandle; //no handle (0)
-	lineType = rhs.lineType;
-	color = rhs.color; // default BYLAYER (256)
-	ltypeScale = rhs.ltypeScale;
-	visible = rhs.visible;
-	layer = rhs.layer;
-	lWeight = rhs.lWeight;
-	space = rhs.space;
-	haveExtrusion = rhs.haveExtrusion;
-	color24 = rhs.color24; //default -1 not set
-	numProxyGraph = rhs.numProxyGraph;
-	shadow = rhs.shadow;
-	material = rhs.material;
-	plotStyle = rhs.plotStyle;
-	transparency = rhs.transparency;
-	nextEntLink = rhs.nextEntLink;
-	prevEntLink = rhs.prevEntLink;
-	numReactors = rhs.numReactors;
-	xDictFlag = rhs.xDictFlag;
-	curr.reset();
-}
 
 //! Calculate arbitary axis
 /*!

--- a/libraries/libdxfrw/src/drw_entities.cpp
+++ b/libraries/libdxfrw/src/drw_entities.cpp
@@ -1173,7 +1173,7 @@ void DRW_LWPolyline::applyExtrusion(){
     if (haveExtrusion) {
         calculateAxis(extPoint);
         for (unsigned int i=0; i<vertlist.size(); i++) {
-            DRW_Vertex2D *vert = vertlist.at(i);
+			auto& vert = vertlist.at(i);
             DRW_Coord v(vert->x, vert->y, elevation);
             extrudePoint(extPoint, &v);
             vert->x = v.x;
@@ -1185,24 +1185,24 @@ void DRW_LWPolyline::applyExtrusion(){
 void DRW_LWPolyline::parseCode(int code, dxfReader *reader){
     switch (code) {
     case 10: {
-        vertex = new DRW_Vertex2D();
+		vertex = std::make_shared<DRW_Vertex2D>();
         vertlist.push_back(vertex);
         vertex->x = reader->getDouble();
         break; }
     case 20:
-        if(vertex != NULL)
+		if(vertex)
             vertex->y = reader->getDouble();
         break;
     case 40:
-        if(vertex != NULL)
+		if(vertex)
             vertex->stawidth = reader->getDouble();
         break;
     case 41:
-        if(vertex != NULL)
+		if(vertex)
             vertex->endwidth = reader->getDouble();
         break;
     case 42:
-        if(vertex != NULL)
+		if(vertex)
             vertex->bulge = reader->getDouble();
         break;
     case 38:
@@ -1277,14 +1277,14 @@ bool DRW_LWPolyline::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
 
     if (vertexnum > 0) { //verify if is lwpol without vertex (empty)
         // add vertexs
-        vertex = new DRW_Vertex2D();
+		vertex = std::make_shared<DRW_Vertex2D>();
         vertex->x = buf->getRawDouble();
         vertex->y = buf->getRawDouble();
         vertlist.push_back(vertex);
-        DRW_Vertex2D* pv = vertex;
+		auto pv = vertex;
         for (int i = 1; i< vertexnum; i++){
-            vertex = new DRW_Vertex2D();
-            if (version < DRW::AC1015) {//14-
+			vertex = std::make_shared<DRW_Vertex2D>();
+			if (version < DRW::AC1015) {//14-
                 vertex->x = buf->getRawDouble();
                 vertex->y = buf->getRawDouble();
             } else {
@@ -1323,8 +1323,7 @@ bool DRW_LWPolyline::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
     }
     if (DRW_DBGGL == DRW_dbg::DEBUG){
         DRW_DBG("\nVertex list: ");
-        for (std::vector<DRW_Vertex2D *>::iterator it = vertlist.begin() ; it != vertlist.end(); ++it){
-            DRW_Vertex2D* pv = *it;
+		for (auto& pv: vertlist) {
             DRW_DBG("\n   x: "); DRW_DBG(pv->x); DRW_DBG(" y: "); DRW_DBG(pv->y); DRW_DBG(" bulge: "); DRW_DBG(pv->bulge);
             DRW_DBG(" stawidth: "); DRW_DBG(pv->stawidth); DRW_DBG(" endwidth: "); DRW_DBG(pv->endwidth);
         }
@@ -1843,12 +1842,12 @@ void DRW_Hatch::parseCode(int code, dxfReader *reader){
         looplist.reserve(loopsnum);
         break;
     case 92:
-        loop = new DRW_HatchLoop(reader->getInt32());
+		loop = std::make_shared<DRW_HatchLoop>(reader->getInt32());
         looplist.push_back(loop);
         if (reader->getInt32() & 2) {
             ispol = true;
             clearEntities();
-            pline = new DRW_LWPolyline;
+			pline = std::make_shared<DRW_LWPolyline>();
             loop->objlist.push_back(pline);
         } else ispol = false;
         break;
@@ -1920,7 +1919,7 @@ bool DRW_Hatch::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
 
     //read loops
     for (dint32 i = 0 ; i < loopsnum; ++i){
-        loop = new DRW_HatchLoop(buf->getBitLong());
+		loop = std::make_shared<DRW_HatchLoop>(buf->getBitLong());
         havePixelSize |= loop->type & 4;
         if (!(loop->type & 2)){ //Not polyline
             dint32 numPathSeg = buf->getBitLong();
@@ -1959,7 +1958,7 @@ bool DRW_Hatch::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
                     spline->ncontrol = buf->getBitLong();
                     spline->controllist.reserve(spline->ncontrol);
                     for (dint32 j = 0; j < spline->ncontrol;++j){
-                        DRW_Coord* crd = new DRW_Coord(buf->get3BitDouble());
+						std::shared_ptr<DRW_Coord> crd = std::make_shared<DRW_Coord>(buf->get3BitDouble());
                         spline->controllist.push_back(crd);
                         if(isRational)
                             crd->z =  buf->getBitDouble(); //RLZ: investigate how store weight
@@ -1969,8 +1968,8 @@ bool DRW_Hatch::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
                         spline->nfit = buf->getBitLong();
                         spline->fitlist.reserve(spline->nfit);
                         for (dint32 j = 0; j < spline->nfit;++j){
-                            DRW_Coord* crd = new DRW_Coord(buf->get3BitDouble());
-                            spline->fitlist.push_back (crd);
+							std::shared_ptr<DRW_Coord> crd = std::make_shared<DRW_Coord>(buf->get3BitDouble());
+							spline->fitlist.push_back(crd);
                         }
                         spline->tgStart = buf->get2RawDouble();
                         spline->tgEnd = buf->get2RawDouble();
@@ -1978,7 +1977,7 @@ bool DRW_Hatch::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
                 }
             }
         } else { //end not pline, start polyline
-            pline = new DRW_LWPolyline;
+			pline = std::make_shared<DRW_LWPolyline>();
             bool asBulge = buf->getBit();
             pline->flags = buf->getBit();//closed bit
             dint32 numVert = buf->getBitLong();
@@ -2106,29 +2105,29 @@ void DRW_Spline::parseCode(int code, dxfReader *reader){
         tolfit = reader->getDouble();
         break;
     case 10: {
-        controlpoint = new DRW_Coord();
+		controlpoint = std::make_shared<DRW_Coord>();
         controllist.push_back(controlpoint);
         controlpoint->x = reader->getDouble();
         break; }
     case 20:
-        if(controlpoint != NULL)
+		if(controlpoint)
             controlpoint->y = reader->getDouble();
         break;
     case 30:
-        if(controlpoint != NULL)
+		if(controlpoint)
             controlpoint->z = reader->getDouble();
         break;
     case 11: {
-        fitpoint = new DRW_Coord();
+		fitpoint = std::make_shared<DRW_Coord>();
         fitlist.push_back(fitpoint);
         fitpoint->x = reader->getDouble();
         break; }
     case 21:
-        if(fitpoint != NULL)
+		if(fitpoint)
             fitpoint->y = reader->getDouble();
         break;
     case 31:
-        if(fitpoint != NULL)
+		if(fitpoint)
             fitpoint->z = reader->getDouble();
         break;
     case 40:
@@ -2196,31 +2195,29 @@ bool DRW_Spline::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
         knotslist.push_back (buf->getBitDouble());
     }
     controllist.reserve(ncontrol);
-    for (dint32 i= 0; i<ncontrol; ++i){
-        DRW_Coord* crd = new DRW_Coord(buf->get3BitDouble());
-        controllist.push_back(crd);
-        if (weight){
+	for (dint32 i= 0; i<ncontrol; ++i){
+		controllist.push_back(std::make_shared<DRW_Coord>(buf->get3BitDouble()));
+		if (weight)
             DRW_DBG("\n w: "); DRW_DBG(buf->getBitDouble()); //RLZ Warning: D (BD or RD)
-        }
     }
     fitlist.reserve(nfit);
-    for (dint32 i= 0; i<nfit; ++i){
-        DRW_Coord* crd = new DRW_Coord(buf->get3BitDouble());
-        fitlist.push_back (crd);
-    }
+	for (dint32 i= 0; i<nfit; ++i)
+		fitlist.push_back(std::make_shared<DRW_Coord>(buf->get3BitDouble()));
+
     if (DRW_DBGGL == DRW_dbg::DEBUG){
-        DRW_DBG("\nknots list: ");
-        for (std::vector<double>::iterator it = knotslist.begin() ; it != knotslist.end(); ++it){
-            DRW_DBG("\n"); DRW_DBG(*it);
-        }
+		DRW_DBG("\nknots list: ");
+		for (auto const& v: knotslist) {
+			DRW_DBG("\n"); DRW_DBG(v);
+		}
         DRW_DBG("\ncontrol point list: ");
-        for (std::vector<DRW_Coord *>::iterator it = controllist.begin() ; it != controllist.end(); ++it){
-            DRW_DBG("\n"); DRW_DBGPT((*it)->x,(*it)->y,(*it)->z);
-        }
+		for (auto const& v: controllist) {
+			DRW_DBG("\n"); DRW_DBGPT(v->x, v->y, v->z);
+		}
         DRW_DBG("\nfit point list: ");
-        for (std::vector<DRW_Coord *>::iterator it = fitlist.begin() ; it != fitlist.end(); ++it){
-            DRW_DBG("\n"); DRW_DBGPT((*it)->x,(*it)->y,(*it)->z);
-        }
+		for (auto const& v: fitlist) {
+			DRW_DBG("\n"); DRW_DBGPT(v->x, v->y, v->z);
+		}
+
     }
 
     /* Common Entity Handle Data */

--- a/libraries/libdxfrw/src/drw_entities.h
+++ b/libraries/libdxfrw/src/drw_entities.h
@@ -544,8 +544,7 @@ public:
         elevation = thickness = width = 0.0;
         flags = 0;
         extPoint.x = extPoint.y = 0;
-        extPoint.z = 1;
-        vertex = NULL;
+		extPoint.z = 1;
     }
     
     DRW_LWPolyline(const DRW_LWPolyline& p):DRW_Entity(p){
@@ -554,31 +553,21 @@ public:
         this->thickness = p.thickness;
         this->width = p.width;
         this->flags = p.flags;
-        this->extPoint = p.extPoint;
-        this->vertex = NULL;
+		this->extPoint = p.extPoint;
         for (unsigned i=0; i<p.vertlist.size(); i++)// RLZ ok or new
-          this->vertlist.push_back( new DRW_Vertex2D( *(p.vertlist.at(i)) ) );
-
-        this->vertex = NULL;
+		  this->vertlist.push_back(
+					std::make_shared<DRW_Vertex2D>(*p.vertlist.at(i))
+					);
     }
+	// TODO rule of 5
 
-    ~DRW_LWPolyline() {
-        while (!vertlist.empty()) {
-            vertlist.pop_back();
-        }
-    }
     virtual void applyExtrusion();
     void addVertex (DRW_Vertex2D v) {
-        DRW_Vertex2D *vert = new DRW_Vertex2D();
-        vert->x = v.x;
-        vert->y = v.y;
-        vert->stawidth = v.stawidth;
-        vert->endwidth = v.endwidth;
-        vert->bulge = v.bulge;
+		std::shared_ptr<DRW_Vertex2D> vert = std::make_shared<DRW_Vertex2D>(v);
         vertlist.push_back(vert);
     }
-    DRW_Vertex2D *addVertex () {
-        DRW_Vertex2D *vert = new DRW_Vertex2D();
+	std::shared_ptr<DRW_Vertex2D> addVertex () {
+		std::shared_ptr<DRW_Vertex2D> vert = std::make_shared<DRW_Vertex2D>();
         vert->stawidth = 0;
         vert->endwidth = 0;
         vert->bulge = 0;
@@ -597,8 +586,8 @@ public:
     double elevation;         /*!< elevation, code 38 */
     double thickness;         /*!< thickness, code 39 */
     DRW_Coord extPoint;       /*!<  Dir extrusion normal vector, code 210, 220 & 230 */
-    DRW_Vertex2D *vertex;       /*!< current vertex to add data */
-    std::vector<DRW_Vertex2D *> vertlist;  /*!< vertex list */
+	std::shared_ptr<DRW_Vertex2D> vertex;       /*!< current vertex to add data */
+	std::vector<std::shared_ptr<DRW_Vertex2D>> vertlist;  /*!< vertex list */
 };
 
 //! Class to handle insert entries
@@ -755,14 +744,9 @@ public:
         basePoint.x = basePoint.y = 0.0;
         flags = vertexcount = facecount = 0;
         smoothM = smoothN = curvetype = 0;
-    }
-    ~DRW_Polyline() {
-        while (!vertlist.empty()) {
-           vertlist.pop_back();
-         }
-    }
+	}
     void addVertex (DRW_Vertex v) {
-        DRW_Vertex *vert = new DRW_Vertex();
+		std::shared_ptr<DRW_Vertex> vert = std::make_shared<DRW_Vertex>();
         vert->basePoint.x = v.basePoint.x;
         vert->basePoint.y = v.basePoint.y;
         vert->basePoint.z = v.basePoint.z;
@@ -771,7 +755,7 @@ public:
         vert->bulge = v.bulge;
         vertlist.push_back(vert);
     }
-    void appendVertex (DRW_Vertex *v) {
+	void appendVertex (std::shared_ptr<DRW_Vertex> const& v) {
         vertlist.push_back(v);
     }
 
@@ -789,7 +773,7 @@ public:
     int smoothN;             /*!< smooth surface M density, code 74, default 0 */
     int curvetype;           /*!< curves & smooth surface type, code 75, default 0 */
 
-    std::vector<DRW_Vertex *> vertlist;  /*!< vertex list */
+	std::vector<std::shared_ptr<DRW_Vertex>> vertlist;  /*!< vertex list */
 
 private:
     std::list<duint32>hadlesList; //list of handles, only in 2004+
@@ -812,15 +796,7 @@ public:
         flags = nknots = ncontrol = nfit = 0;
         tolknot = tolcontrol = tolfit = 0.0000001;
 
-    }
-    ~DRW_Spline() {
-        while (!controllist.empty()) {
-           controllist.pop_back();
-        }
-        while (!fitlist.empty()) {
-           fitlist.pop_back();
-        }
-    }
+	}
     virtual void applyExtrusion(){}
 
 protected:
@@ -850,12 +826,12 @@ public:
     double tolfit;            /*!< fit point tolerance, code 44, default 0.0000001 */
 
     std::vector<double> knotslist;           /*!< knots list, code 40 */
-    std::vector<DRW_Coord *> controllist;  /*!< control points list, code 10, 20 & 30 */
-    std::vector<DRW_Coord *> fitlist;      /*!< fit points list, code 11, 21 & 31 */
+	std::vector<std::shared_ptr<DRW_Coord>> controllist;  /*!< control points list, code 10, 20 & 30 */
+	std::vector<std::shared_ptr<DRW_Coord>> fitlist;      /*!< fit points list, code 11, 21 & 31 */
 
 private:
-    DRW_Coord *controlpoint;   /*!< current control point to add data */
-    DRW_Coord *fitpoint;       /*!< current fit point to add data */
+	std::shared_ptr<DRW_Coord> controlpoint;   /*!< current control point to add data */
+	std::shared_ptr<DRW_Coord> fitpoint;       /*!< current fit point to add data */
 };
 
 //! Class to handle hatch loop
@@ -870,15 +846,6 @@ public:
         numedges = 0;
     }
 
-    ~DRW_HatchLoop() {
-/*        while (!pollist.empty()) {
-           pollist.pop_back();
-         }*/
-        while (!objlist.empty()) {
-           objlist.pop_back();
-         }
-    }
-
     void update() {
         numedges = objlist.size();
     }
@@ -888,7 +855,7 @@ public:
     int numedges;           /*!< number of edges (if not a polyline), code 93 */
 //TODO: store lwpolylines as entities
 //    std::vector<DRW_LWPolyline *> pollist;  /*!< polyline list */
-    std::vector<DRW_Entity *> objlist;      /*!< entities list */
+	std::vector<std::shared_ptr<DRW_Entity>> objlist;      /*!< entities list */
 };
 
 //! Class to handle hatch entity
@@ -907,17 +874,10 @@ public:
         loopsnum = hstyle = associative = 0;
         solid = hpattern = 1;
         deflines = doubleflag = 0;
-        loop = NULL;
         clearEntities();
     }
 
-    ~DRW_Hatch() {
-        while (!looplist.empty()) {
-           looplist.pop_back();
-         }
-    }
-
-    void appendLoop (DRW_HatchLoop *v) {
+	void appendLoop (std::shared_ptr<DRW_HatchLoop> const& v) {
         looplist.push_back(v);
     }
 
@@ -939,22 +899,23 @@ public:
     double scale;              /*!< hatch pattern scale, code 41 */
     int deflines;              /*!< number of pattern definition lines, code 78 */
 
-    std::vector<DRW_HatchLoop *> looplist;  /*!< polyline list */
+	std::vector<std::shared_ptr<DRW_HatchLoop>> looplist;  /*!< polyline list */
 
 private:
     void clearEntities(){
-        pt = line = NULL;
-        pline = NULL;
-        arc = NULL;
-        ellipse = NULL;
-        spline = NULL;
-        plvert = NULL;
+		pt.reset();
+		line.reset();
+		pline.reset();
+		arc.reset();
+		ellipse.reset();
+		spline.reset();
+		plvert.reset();
     }
 
     void addLine() {
         clearEntities();
         if (loop) {
-            pt = line = new DRW_Line;
+			pt = line = std::make_shared<DRW_Line>();
             loop->objlist.push_back(line);
         }
     }
@@ -962,7 +923,7 @@ private:
     void addArc() {
         clearEntities();
         if (loop) {
-            pt = arc = new DRW_Arc;
+			pt = arc = std::make_shared<DRW_Arc>();
             loop->objlist.push_back(arc);
         }
     }
@@ -970,7 +931,7 @@ private:
     void addEllipse() {
         clearEntities();
         if (loop) {
-            pt = ellipse = new DRW_Ellipse;
+			pt = ellipse = std::make_shared<DRW_Ellipse>();
             loop->objlist.push_back(ellipse);
         }
     }
@@ -978,20 +939,20 @@ private:
     void addSpline() {
         clearEntities();
         if (loop) {
-            pt = NULL;
-            spline = new DRW_Spline;
+			pt.reset();
+			spline = std::make_shared<DRW_Spline>();
             loop->objlist.push_back(spline);
         }
     }
 
-    DRW_HatchLoop *loop;       /*!< current loop to add data */
-    DRW_Line *line;
-    DRW_Arc *arc;
-    DRW_Ellipse *ellipse;
-    DRW_Spline *spline;
-    DRW_LWPolyline *pline;
-    DRW_Point *pt;
-    DRW_Vertex2D *plvert;
+	std::shared_ptr<DRW_HatchLoop> loop;       /*!< current loop to add data */
+	std::shared_ptr<DRW_Line> line;
+	std::shared_ptr<DRW_Arc> arc;
+	std::shared_ptr<DRW_Ellipse> ellipse;
+	std::shared_ptr<DRW_Spline> spline;
+	std::shared_ptr<DRW_LWPolyline> pline;
+	std::shared_ptr<DRW_Point> pt;
+	std::shared_ptr<DRW_Vertex2D> plvert;
     bool ispol;
 };
 

--- a/libraries/libdxfrw/src/drw_entities.h
+++ b/libraries/libdxfrw/src/drw_entities.h
@@ -101,16 +101,15 @@ class DRW_Entity {
 public:
     //initializes default values
 	DRW_Entity() = default;
-	~DRW_Entity() = default;
 
-	DRW_Entity(const DRW_Entity& e);
-	DRW_Entity& operator = (const DRW_Entity& e);
-	DRW_Entity(DRW_Entity&& e);
-	DRW_Entity& operator = (DRW_Entity&& e);
+	//removed copy/move ctors
+	// looks like the potential issue is the "curr" pointer is reset in previous
+	// versions during copy ctor
 
 	void reset() {
-        extData.clear();
-    }
+		extData.clear();
+		curr.reset();
+	}
 
     virtual void applyExtrusion() = 0;
 


### PR DESCRIPTION
Raw pointer usage in dxfrw seems to be causing lots of memory leak

here's one attempt to avoid memory leak by switching to shared_ptr

please review, but do not merge this one:

* the fix might contain errors
* the fix is still incomplete