### PR TITLE
Committer: Equoda <Equoda@users.noreply.github.com>

### DIFF
--- a/librecad/src/lib/engine/rs_layerlist.cpp
+++ b/librecad/src/lib/engine/rs_layerlist.cpp
@@ -54,6 +54,27 @@ void RS_LayerList::clear() {
 }
 
 
+QList<RS_Layer*>::iterator RS_LayerList::begin()
+{
+    return layers.begin();
+}
+
+QList<RS_Layer*>::iterator RS_LayerList::end()
+{
+    return layers.end();
+}
+
+QList<RS_Layer*>::const_iterator RS_LayerList::begin()const
+{
+    return layers.begin();
+}
+
+QList<RS_Layer*>::const_iterator RS_LayerList::end()const
+{
+    return layers.end();
+}
+
+
 
 /**
  * Activates the given layer.

--- a/librecad/src/lib/engine/rs_layerlist.h
+++ b/librecad/src/lib/engine/rs_layerlist.h
@@ -60,6 +60,10 @@ public:
     RS_Layer* at(unsigned int i) {
         return layers.at(i);
     }
+    QList<RS_Layer*>::iterator begin();
+    QList<RS_Layer*>::iterator end();
+    QList<RS_Layer*>::const_iterator begin()const;
+    QList<RS_Layer*>::const_iterator end()const;
 
     void activate(const QString& name, bool notify = false);
     void activate(RS_Layer* layer, bool notify = false);

--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -89,9 +89,11 @@ RS_Modification::RS_Modification(RS_EntityContainer& container,
  * Deletes all selected entities.
  */
 void RS_Modification::remove() {
+
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::remove");
+
 	if (!container) {
-        RS_DEBUG->print(RS_Debug::D_WARNING,
-                        "RS_Modification::remove: no valid container");
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::remove: no valid container");
         return;
     }
 
@@ -100,14 +102,20 @@ void RS_Modification::remove() {
     }
 
 	// not safe (?)
-	for(auto e: *container){
-
+    for(auto e: *container) {
         if (e && e->isSelected()) {
-            e->setSelected(false);
-            e->changeUndoState();
-            if (document) {
-                document->addUndoable(e);
+            try {
+                e->setSelected(false);
+                e->changeUndoState();
+                if (document) {
+                    document->addUndoable(e);
+                }
             }
+            catch (...) {
+                RS_DEBUG->print(RS_Debug::D_WARNING, "RS_Modification::remove: unable to remove selected entity");
+            }
+        } else {
+            RS_DEBUG->print(RS_Debug::D_WARNING, "RS_Modification::remove: no valid container is selected");
         }
     }
 
@@ -116,16 +124,21 @@ void RS_Modification::remove() {
     }
 
     graphicView->redraw(RS2::RedrawDrawing);
+
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::remove: OK");
 }
+
+
 
 /**
  * Revert direction of selected entities.
  */
-void RS_Modification::revertDirection()
-{
+void RS_Modification::revertDirection() {
+
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::revertDirection");
+
 	if (!container) {
-		RS_DEBUG->print("RS_Modification::revertDirection: no valid container",
-						RS_Debug::D_WARNING);
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::revertDirection: no valid container");
 		return;
 	}
 
@@ -134,12 +147,14 @@ void RS_Modification::revertDirection()
 	}
 
 	std::vector<RS_Entity*> addList;
-	for(auto e: *container){
+    for(auto e: *container) {
 		if (e && e->isSelected()) {
 			RS_Entity* ec = e->clone();
 			ec->revertDirection();
 			addList.push_back(ec);
-		}
+        } else {
+        RS_DEBUG->print(RS_Debug::D_WARNING, "RS_Modification::revertDirection: no valid container is selected");
+        }
 	}
 	deselectOriginals(true);
 	addNewEntities(addList);
@@ -151,38 +166,41 @@ void RS_Modification::revertDirection()
 	if (graphicView) {
 		graphicView->redraw(RS2::RedrawDrawing);
 	}
+
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::revertDirection: OK");
 }
+
 
 
 /**
  * Changes the attributes of all selected
  */
 bool RS_Modification::changeAttributes(RS_AttributesData& data) {
-	if (!container) {
-        RS_DEBUG->print(RS_Debug::D_WARNING,
-                        "RS_Modification::changeAttributes: no valid container");
+
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::changeAttributes");
+
+    if (!container) {
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::changeAttributes: no valid container");
         return false;
     }
-
-	std::vector<RS_Entity*> addList;
 
     if (document) {
         document->startUndoCycle();
     }
 
-	for(auto e: *container){
-        //for (unsigned i=0; i<container->count(); ++i) {
-        //RS_Entity* e = container->entityAt(i);
+    std::vector<RS_Entity*> addList;
+    for(auto e: *container) {
+//        for (unsigned i=0; i<container->count(); ++i) {
+//        RS_Entity* e = container->entityAt(i);
         if (e && e->isSelected()) {
+
             RS_Entity* ec = e->clone();
             ec->setSelected(false);
-
             RS_Pen pen = ec->getPen(false);
 
             if (data.changeLayer==true) {
                 ec->setLayer(data.layer);
             }
-
             if (data.changeColor==true) {
                 pen.setColor(data.pen.getColor());
             }
@@ -206,6 +224,8 @@ bool RS_Modification::changeAttributes(RS_AttributesData& data) {
             //}
             ec->update();
 			addList.push_back(ec);
+        } else {
+            RS_DEBUG->print(RS_Debug::D_NOTICE, "RS_Modification::changeAttributes: no valid container is selected");
         }
     }
 
@@ -220,8 +240,10 @@ bool RS_Modification::changeAttributes(RS_AttributesData& data) {
         graphicView->redraw(RS2::RedrawDrawing);
     }
 
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::changeAttributes: OK");
     return true;
 }
+
 
 
 /**
@@ -235,9 +257,10 @@ bool RS_Modification::changeAttributes(RS_AttributesData& data) {
  */
 void RS_Modification::copy(const RS_Vector& ref, const bool cut) {
 
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::copy");
+
 	if (!container) {
-        RS_DEBUG->print(RS_Debug::D_WARNING,
-                        "RS_Modification::copy: no valid container");
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::copy: no valid container");
         return;
     }
 
@@ -257,15 +280,18 @@ void RS_Modification::copy(const RS_Vector& ref, const bool cut) {
 	for(auto e: *container){
         //for (unsigned i=0; i<container->count(); ++i) {
         //RS_Entity* e = container->entityAt(i);
-
         if (e && e->isSelected()) {
             copyEntity(e, ref, cut);
+        } else {
+            RS_DEBUG->print(RS_Debug::D_NOTICE, "RS_Modification::copy: no valid container is selected");
         }
     }
 
     if (cut && document) {
         document->endUndoCycle();
     }
+
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::copy: OK");
 }
 
 
@@ -279,51 +305,62 @@ void RS_Modification::copy(const RS_Vector& ref, const bool cut) {
  * @param ref Reference point. The entities will be moved by -ref.
  * @param cut true: cut instead of copying, false: copy
  */
-void RS_Modification::copyEntity(RS_Entity* e, const RS_Vector& ref,
-                                 const bool cut) {
+void RS_Modification::copyEntity(RS_Entity* e, const RS_Vector& ref, const bool cut) {
 
-    if (e && e->isSelected()) {
-        // delete entity in graphic view:
-        if (cut) {
-            if (graphicView) {
-                graphicView->deleteEntity(e);
-            }
-            e->setSelected(false);
-        } else {
-            if (graphicView) {
-                graphicView->deleteEntity(e);
-            }
-            e->setSelected(false);
-            if (graphicView) {
-                graphicView->drawEntity(e);
-            }
-        }
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::copyEntity");
 
-        // add entity to clipboard:
-        RS_Entity* c = e->clone();
+    if (!e || !e->isSelected()) {
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::copyEntity: no entity is selected");
+        return;
+    }
+
+    // add entity to clipboard:
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::copyEntity: to clipboard: %d/%d", e->getId(), e->rtti());
+    RS_Entity* c = e->clone();
+    try {
         c->move(-ref);
-        RS_CLIPBOARD->addEntity(c);
+    }
+    catch (...) {
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::copyEntity: unable to move entity");
+        return;
+    }
 
-        copyLayers(e);
-        //call copyBlocks only if entity are insert
-        if (e->rtti()==RS2::EntityInsert) {
-            copyBlocks(e);
+    RS_CLIPBOARD->addEntity(c);
+    copyLayers(e);
+    copyBlocks(e);
+
+    // set layer to the layer clone:
+    try {
+        c->setLayer(e->getLayer()->getName());
+    }
+    catch (...) {
+        RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::copyEntity: unable to set layer for entity ID/flag: %d/%d", c->getId(), c->rtti());
+    }
+
+    if (cut) {
+        RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::copyEntity: cut ID/flag: %d/%d", e->getId(), e->rtti());
+        e->changeUndoState();
+        if (document) {
+            document->addUndoable(e);
         }
-
-        // set layer to the layer clone:
-        RS_Layer* l = e->getLayer();
-        if (l) {
-            c->setLayer(l->getName());
+        // delete entity in graphic view:
+        if (graphicView) {
+            graphicView->deleteEntity(e);
         }
-
-        if (cut) {
-            e->changeUndoState();
-            if (document) {
-                document->addUndoable(e);
-            }
+        e->setSelected(false);
+    } else {
+        RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::copyEntity: delete in view ID/flag: %d/%d", e->getId(), e->rtti());
+        // delete entity in graphic view:
+        if (graphicView) {
+            graphicView->deleteEntity(e);
+        }
+        e->setSelected(false);
+        if (graphicView) {
+            graphicView->drawEntity(e);
         }
     }
 
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::copyEntity: OK");
 }
 
 
@@ -333,30 +370,43 @@ void RS_Modification::copyEntity(RS_Entity* e, const RS_Vector& ref,
  */
 void RS_Modification::copyLayers(RS_Entity* e) {
 
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::copyLayers");
+
 	if (!e) {
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::copyLayers: no entity is selected");
         return;
     }
 
-    // add layer(s) of the entity insert can also be into any layer:
+    // add layer(s) of the entity insert can also be into any layer
     RS_Layer* l = e->getLayer();
-    if (l) {
-        if (!RS_CLIPBOARD->hasLayer(l->getName())) {
-            RS_CLIPBOARD->addLayer(l->clone());
-        }
+    if (!l) {
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::copyLayers: no valid layer found");
+        return;
+    }
+
+    if (!RS_CLIPBOARD->hasLayer(l->getName())) {
+        RS_CLIPBOARD->addLayer(l->clone());
     }
 
     // special handling of inserts:
     if (e->rtti()==RS2::EntityInsert) {
         // insert: add layer(s) of subentities:
+        RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::copyLayers: copy insert entity ID/flag layers: %d/%d", e->getId(), e->rtti());
         RS_Block* b = ((RS_Insert*)e)->getBlockForInsert();
-		if (b) {
-			for(auto e2: *b){
-                //for (unsigned i=0; i<b->count(); ++i) {
-                //RS_Entity* e2 = b->entityAt(i);
-                copyLayers(e2);
-            }
+        if (!b) {
+            RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::copyLayers: could not find block for insert entity");
+            return;
         }
+        for(auto e2: *b) {
+            //for (unsigned i=0; i<b->count(); ++i) {
+            //RS_Entity* e2 = b->entityAt(i);
+            copyLayers(e2);
+        }
+    } else {
+        RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::copyLayers: skip noninsert entity");
     }
+
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::copyLayers: OK");
 }
 
 
@@ -366,27 +416,41 @@ void RS_Modification::copyLayers(RS_Entity* e) {
  */
 void RS_Modification::copyBlocks(RS_Entity* e) {
 
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::copyBlocks");
+
 	if (!e) {
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::copyBlocks: no entity to process");
         return;
     }
 
-    // add block of the entity if it's an insert
-    if (e->rtti()==RS2::EntityInsert) {
-        RS_Block* b = ((RS_Insert*)e)->getBlockForInsert();
-        if (b) {
-            // add block of an insert:
-            if (!RS_CLIPBOARD->hasBlock(b->getName())) {
-                RS_CLIPBOARD->addBlock((RS_Block*)b->clone());
-            }
-			//find insert into insert
-			for(auto e2: *b){
-                //call copyBlocks only if entity are insert
-                if (e->rtti()==RS2::EntityInsert) {
-                    copyBlocks(e2);
-                }
-            }
+    // add block of the entity only if it's an insert
+    if (e->rtti()!=RS2::EntityInsert) {
+        RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::copyBlocks: skip non-insert entity");
+        return;
+    }
+
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::copyBlocks: get insert entity ID/flag block: %d/%d", e->getId(), e->rtti());
+    RS_Block* b = ((RS_Insert*)e)->getBlockForInsert();
+    if (!b) {
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::copyBlocks: could not find block for insert entity");
+        return;
+    }
+    // add block of an insert
+    QString bn = b->getName();
+    if (!RS_CLIPBOARD->hasBlock(bn)) {
+        RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::copyBlocks: add block name: %s", bn.toLatin1().data());
+        RS_CLIPBOARD->addBlock((RS_Block*)b->clone());
+    }
+    //find insert into insert
+    for(auto e2: *b) {
+        //call copyBlocks only if entity are insert
+        if (e2->rtti()==RS2::EntityInsert) {
+            RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::copyBlocks: process insert-into-insert blocks for %d/%d", e2->getId(), e2->rtti());
+            copyBlocks(e2);
         }
     }
+
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::copyBlocks: OK");
 }
 
 
@@ -402,203 +466,288 @@ void RS_Modification::copyBlocks(RS_Entity* e) {
  */
 void RS_Modification::paste(const RS_PasteData& data, RS_Graphic* source) {
 
+    RS_DEBUG->print(RS_Debug::D_INFORMATIONAL, "RS_Modification::paste");
+
 	if (!graphic) {
-        RS_DEBUG->print(RS_Debug::D_WARNING,
-						"RS_Modification::paste: Graphic is nullptr");
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::paste: source is nullptr");
         return;
     }
 
+    try {
+        data.asInsert;
+    }
+    catch (...) {
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::paste: data is nullptr");
+        return;
+    }
+
+    // adjust scaling factor for units conversion in case of clipboard paste
     double factor = 1.0;
-
+    // scale factor as vector
+    RS_Vector vfactor = RS_Vector(factor, factor);
+    // select source for paste
 	if (!source) {
+        RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::paste: add graphic source from clipboard");
         source = RS_CLIPBOARD->getGraphic();
-
-        // graphics from the clipboard need to be scaled. from the part lib not:
+        // graphics from the clipboard need to be scaled. From the part lib not:
         RS2::Unit sourceUnit = source->getUnit();
         RS2::Unit targetUnit = graphic->getUnit();
         factor = RS_Units::convert(1.0, sourceUnit, targetUnit);
+        vfactor = RS_Vector(factor, factor);
+    } else {
+        RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::paste: add graphic source from parts library");
     }
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::paste: pasting scale factor: %d", factor);
+
+    // default insertion point for container
+    RS_Vector ip = data.insertionPoint;
 
     if (document) {
         document->startUndoCycle();
     }
 
+    // insert absent layers from source to graphic
+    if (!pasteLayers(source)) {
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::paste: unable to copy due to absence of needed layers");
+        return;
+    }
 
-    // insert layers:
-    if (graphic) {
-        RS_Layer* layer = graphic->getActiveLayer();
-        for(unsigned i=0; i<source->countLayers(); ++i) {
-            RS_Layer* l = source->layerAt(i);
-            if (l) {
-				if (!graphic->findLayer(l->getName())) {
-                    graphic->addLayer(l->clone());
-                }
-            }
-        }
+    // select the same layer in graphic as in source
+    try {
+        RS_Layer* layer = source->getActiveLayer();
         graphic->activateLayer(layer);
+        RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::paste: selected layer: %s", layer->getName().toLatin1().data());
+    }
+    catch (...) {
+        RS_DEBUG->print(RS_Debug::D_WARNING, "RS_Modification::paste: unable to select layer to paste in");
+        return;
     }
 
-    //hash to store pairs af block name & newname even if it is the same
-	QHash<QString, QString>blocksDict;
-    // find block names and rename if it exist:
-    if (graphic) {
-		RS_BlockList* blks=source->getBlockList();
-		for(RS_Block* b: *blks){
-			if(!b) continue;
-			QString name = b->getName();
-			while (true) {
-				RS_Block* pb = graphic->findBlock(name);
-				if (!pb) break;
-				name=pb->getBlockList()->newName(name);
-			}
-			blocksDict[b->getName()] = name;
-			b->setName(name);
-		}
+    // hash for renaming duplicated blocks
+    QHash<QString, QString> blocksDict;
 
-        //add new blocks with new names
-        for(unsigned i=0; i<source->countBlocks(); ++i) {
-            RS_Block* b = source->blockAt(i);
-            if (b) {
-                    RS_Block* bc = (RS_Block*)b->clone();
-                    //bc->scale(bc->getBasePoint(), RS_Vector(factor, factor));
-                    // scale block but don't scale inserts in block
-                    //  (they already scale with their block)
-                    for(unsigned i2=0; i2<bc->count(); ++i2) {
-                        RS_Entity* e = bc->entityAt(i2);
-                        if (e) {
-                            if (e->rtti()==RS2::EntityInsert) {
-                                RS_Insert *in = (RS_Insert*)e;
-                                QString bkName = in->getName();
-                                if (blocksDict.contains(bkName))
-                                    bkName = blocksDict.value(bkName);
-                                in->setName( bkName );
-                                RS_Vector ip = in->getInsertionPoint();
-                                ip.scale(bc->getBasePoint(),
-                                         RS_Vector(factor, factor));
-                                in->setInsertionPoint(ip);
-                                e->update();
-                            } else {
-                                e->scale(bc->getBasePoint(),
-                                         RS_Vector(factor, factor));
-                            }
-                        }
-                    }
-                    //reparent after rename inserts
-                    bc->reparent(container);
-                    graphic->addBlock(bc);
+    // create block to paste entities as a whole
+    QString name_old = "paste-block";
+    if (data.blockName != NULL) {
+        name_old = data.blockName;
+    }
+    QString name_new = name_old;
+    if (graphic->findBlock(name_old)) {
+        name_new = graphic->getBlockList()->newName(name_old);
+        RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::paste: paste block name: %s", name_new.toLatin1().data());
+    }
+    blocksDict[name_old] = name_new;
+
+    // create block
+    RS_BlockData db = RS_BlockData(name_new, RS_Vector(0.0, 0.0), false);
+    RS_Block* b = new RS_Block(graphic, db);
+    b->reparent(graphic);
+    graphic->addBlock(b);
+
+    // create insert object for the paste block
+    RS_InsertData di = RS_InsertData(b->getName(), ip, vfactor, data.angle, 1, 1, RS_Vector(0.0,0.0));
+    RS_Insert* i = new RS_Insert(graphic, di);
+    i->setLayerToActive();
+    i->setPenToActive();
+    i->reparent(graphic);
+    graphic->addEntity(i);
+
+    // copy sub- blocks, inserts and entities from source to the paste block
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::paste: copy content to the paste block");
+    for(auto e: * static_cast<RS_EntityContainer*>(source)) {
+
+        if (!e) {
+            RS_DEBUG->print(RS_Debug::D_WARNING, "RS_Modification::paste: nullptr entity in source");
+            continue;
+        }
+
+        // paste subcontainers
+        if (e->rtti() == RS2::EntityInsert) {
+            if (!pasteContainer(e, b, blocksDict, RS_Vector(0.0, 0.0))) {
+                RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::paste: unable to paste due to subcontainer paste error");
+                return;
             }
+            // clear selection due to the following processing of selected entities
+            e->setSelected(false);
+        } else {
+            // paste individual entities including Polylines, etc.
+            if (!pasteEntity(e, b)) {
+                RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::paste: unable to paste due to entity paste error");
+                return;
+            }
+            // clear selection due to the following processing of selected entities
+            e->setSelected(false);
         }
     }
 
-    // add entities to this host (graphic or a new block)
-    RS_EntityContainer* host = container;
-    QString blockName;
+    // update insert
+    i->update();
+    i->setSelected(false);
 
-    // create new block:
-    if (graphic) {
-		if (data.asInsert) {
-            RS_BlockList* blkList = graphic->getBlockList();
-            if (blkList) {
-                blockName = blkList->newName(data.blockName);
-
-                RS_Block* blk =  new RS_Block(graphic, RS_BlockData(blockName,
-                                              RS_Vector(0.0,0.0), false));
-                graphic->addBlock(blk);
-
-                host = blk;
-            }
-        }
-    }
-
-    int noBlockIndex = 0;
-    // insert entities:
-	for(auto e: * static_cast<RS_EntityContainer*>(source)){
-
-		if (e) {
-
-            QString layerName = "0";
-            RS_Layer* layer = e->getLayer();
-            if (layer) {
-                layerName = layer->getName();
-            }
-            RS_Entity* e2 = e->clone();
-			if (!data.asInsert) {
-                e2->move(data.insertionPoint);
-            }
-            // don't adjust insert factor - block was already adjusted to unit
-            if (e2->rtti()==RS2::EntityInsert) {
-                RS_Insert *in = (RS_Insert*)e2;
-                QString bkName = in->getName();
-                if (blocksDict.contains(bkName))
-                    bkName = blocksDict.value(bkName);
-                RS_Block *bk = source->findBlock(bkName);
-                //if block not found create a new empty block
-				if (!bk) {
-                    QString noBlockName= "noname0";
-                    while ( graphic->findBlock(noBlockName)) {
-                        noBlockIndex++;
-                        noBlockName= QString("noname%1").arg(noBlockIndex);
-                    }
-                    bk = new RS_Block(graphic,
-                                      RS_BlockData(QString("noname%1").arg(noBlockIndex),
-                                      RS_Vector(0.0,0.0), false));
-                    graphic->addBlock(bk);
-                }
-                in->setName( bk->getName() );
-                RS_Vector ip = in->getInsertionPoint();
-                ip.scale(data.insertionPoint, RS_Vector(factor, factor));
-                in->setInsertionPoint(ip);
-                e2->update();
-            } else {
-                e2->scale(data.insertionPoint, RS_Vector(factor, factor));
-            }
-            //reparent after rename inserts
-            e2->reparent(host);
-            host->addEntity(e2);
-            e2->setLayer(layerName);
-
-            // make sure all sub entities point to layers of the container
-            if (e2->isContainer()) {
-                RS_EntityContainer* ec = (RS_EntityContainer*)e2;
-
-				for(auto e3: *ec){
-
-                    //RS_Entity* e3 = ec->entityAt(i);
-                    RS_Layer* l2 = e3->getLayer();
-                    if (l2) {
-                        e3->setLayer(l2->getName());
-                    }
-                }
-            }
-
-			if (document && !data.asInsert) {
-                document->addUndoable(e2);
-            }
-        }
-    }
-
-	if (data.asInsert) {
-        RS_Insert* ins =
-            new RS_Insert(container,
-                          RS_InsertData(
-                              blockName,
-                              data.insertionPoint,
-                              RS_Vector(data.factor, data.factor),
-                              data.angle,
-                              1,1,RS_Vector(0.0,0.0)));
-        container->addEntity(ins);
-        ins->setLayerToActive();
-        ins->setPenToActive();
-
-        if (document) {
-            document->addUndoable(ins);
-        }
+    // unblock all entities if not pasting as a new block by demand
+    if (!data.asInsert) {
+        // no inserts should be selected except from paste block and insert
+        i->setSelected(true);
+        explode();
+        graphic->removeEntity(i);
+        b->clear();
+        // if this call a destructor for the block?
+        graphic->removeBlock(b);
     }
 
     if (document) {
         document->endUndoCycle();
     }
+
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::paste: OK");
 }
+
+
+
+/**
+ * Create layers in destination graphic corresponding to entity to be copied
+ *
+ **/
+bool RS_Modification::pasteLayers(RS_Graphic* source) {
+
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::pasteLayers");
+
+    if (!source) {
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::pasteLayers: no valid graphic found");
+        return false;
+    }
+
+    RS_LayerList* lrs=source->getLayerList();
+    for(RS_Layer* l: *lrs) {
+
+        if(!l) {
+            RS_DEBUG->print(RS_Debug::D_WARNING, "RS_Modification::pasteLayers: nullptr layer in source");
+            continue;
+        }
+
+        // add layers if absent
+        QString ln = l->getName();
+        if (!graphic->findLayer(ln)) {
+            graphic->addLayer(l->clone());
+            RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::pasteLayers: layer added: %s", ln.toLatin1().data());
+        }
+    }
+
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::pasteLayers: OK");
+    return true;
+}
+
+
+
+/**
+ * Create inserts and blocks in destination graphic corresponding to entity to be copied
+ *
+ **/
+bool RS_Modification::pasteContainer(RS_Entity* entity, RS_EntityContainer* container, QHash<QString, QString>blocksDict, RS_Vector insertionPoint) {
+
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::pasteInsert");
+
+    if (!entity || entity->rtti() != RS2::EntityInsert) {
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::pasteInsert: no container to process");
+        return false;
+    }
+
+    RS_Insert* i = (RS_Insert*)entity;
+    // get block for this insert object
+    RS_Block* ib = i->getBlockForInsert();
+    if (!ib) {
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::pasteInsert: no block to process");
+        return false;
+    }
+    // get name for this insert object
+    QString name_old = ib->getName();
+    QString name_new = name_old;
+    if (name_old != i->getName()) {
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::pasteInsert: block and insert names don't coinside");
+        return false;
+    }
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::pasteInsert: processing container: %s", name_old.toLatin1().data());
+    // rename if needed
+    if (graphic->findBlock(name_old)) {
+        name_new = graphic->getBlockList()->newName(name_old);
+        RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::pasteInsert: new block name: %s", name_new.toLatin1().data());
+    }
+    blocksDict[name_old] = name_new;
+    // make new block in the destination
+    RS_BlockData db = RS_BlockData(name_new, RS_Vector(0.0, 0.0), false);
+    RS_Block* bc = new RS_Block(graphic, db);
+    bc->reparent(graphic);
+    graphic->addBlock(bc);
+    // create insert for the new block
+    RS_InsertData di = RS_InsertData(name_new, insertionPoint, RS_Vector(1.0, 1.0), i->getAngle(), 1, 1, RS_Vector(0.0,0.0));
+    RS_Insert* ic = new RS_Insert(container, di);
+    ic->reparent(container);
+    container->addEntity(ic);
+    ic->setLayerToActive();
+    ic->setPenToActive();
+
+    // get relative insertion point
+    RS_Vector ip = RS_Vector(0.0, 0.0);
+    if (container->getId() != graphic->getId()) {
+        ip = bc->getBasePoint();
+    }
+
+    // copy content of block/insert to destination
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::pasteInsert: copy content to the subcontainer");
+    for(auto* e: *i) {
+
+        if(!e) {
+            RS_DEBUG->print(RS_Debug::D_NOTICE, "RS_Modification::pasteInsert: nullptr entity in block");
+            continue;
+        }
+
+        if (e->rtti() == RS2::EntityInsert) {
+            RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::pasteInsert: process sub-insert for %s", ((RS_Insert*)e)->getName().toLatin1().data());
+            if (!pasteContainer(e, (RS_EntityContainer*)bc, blocksDict, ip)) {
+                RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::pasteInsert: unable to paste entity to sub-insert");
+                return false;
+            }
+        } else {
+            if (!pasteEntity(e, (RS_EntityContainer*)bc)) {
+                RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::pasteInsert: unable to paste entity");
+                return false;
+            }
+        }
+    }
+
+    ic->update();
+    ic->setSelected(false);
+
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::pasteInsert: OK");
+    return true;
+}
+
+
+
+bool RS_Modification::pasteEntity(RS_Entity* entity, RS_EntityContainer* container) {
+
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::pasteEntity");
+
+    if (!entity) {
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::pasteEntity: no entity to process");
+        return false;
+    }
+
+    // create entity copy to paste
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::pasteEntity ID/flag: %d/%d", entity->getId(), entity->rtti());
+    RS_Entity* e = entity->clone();
+
+    // scaling entity doesn't needed as it scaled with insert object
+    // paste entity
+    e->reparent(container);
+    container->addEntity(e);
+
+    e->setSelected(false);
+
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::pasteEntity: OK");
+    return true;
+}
+
 
 
 /**

--- a/librecad/src/lib/modification/rs_modification.h
+++ b/librecad/src/lib/modification/rs_modification.h
@@ -232,9 +232,12 @@ public:
         void copy(const RS_Vector& ref, const bool cut);
 private:
         void copyEntity(RS_Entity* e, const RS_Vector& ref, const bool cut);
-public:
         void copyLayers(RS_Entity* e);
         void copyBlocks(RS_Entity* e);
+        bool pasteLayers(RS_Graphic* source);
+        bool pasteContainer(RS_Entity* entity, RS_EntityContainer* container, QHash<QString, QString>blocksDict, RS_Vector insertionPoint);
+        bool pasteEntity(RS_Entity* entity, RS_EntityContainer* container);
+public:
         void paste(const RS_PasteData& data, RS_Graphic* source=NULL);
 
     bool move(RS_MoveData& data);


### PR DESCRIPTION
fix: blocks moving/pasting bug

Solve the problem with copy-paste or move blocks bug cause some blocks disappears.
Most changes are in ```librecad/src/lib/modification/rs_modification.cpp```.
```RS_Modification::paste``` function has been rewritten.

Closes #715