### PR TITLE
fix:  explode action changes container entities attributes to wrong values; #754

### DIFF
--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -3164,7 +3164,12 @@ bool RS_Modification::explode() {
                             clone->setLayer(e2->getLayer());
                         }
 
-                        clone->setPen(ec->getPen(resolvePen));
+//                        clone->setPen(ec->getPen(resolvePen));
+                        if (resolvePen) {
+                            clone->setPen(ec->getPen(true));
+                        } else {
+                            clone->setPen(e2->getPen(false));
+                        }
 
 						addList.push_back(clone);
 


### PR DESCRIPTION
Function ```RS_Modification::explode()``` modified. Pen for reparented entities is selected from the original sub-entities now.