### PR TITLE
fix: changing attributes of a block sub-entities; #755

### DIFF
--- a/librecad/src/lib/modification/rs_modification.h
+++ b/librecad/src/lib/modification/rs_modification.h
@@ -230,6 +230,7 @@ public:
 	void remove();
 	void revertDirection();
 	bool changeAttributes(RS_AttributesData& data);
+    bool changeAttributes(RS_AttributesData& data, RS_EntityContainer* container, std::vector<RS_Entity*> addList);
 
         void copy(const RS_Vector& ref, const bool cut);
 private:


### PR DESCRIPTION
Function ```RS_Modification::changeAttributes(...)``` changed.
Overloaded recursive function ```RS_Modification::changeAttributes(...)``` added.
Sub-entities of ```RS_Insert/RS_Block``` now change their attributes together with their containers.