### PR TITLE
Fix for Trackpads without smooth/hi-res scrolling

### DIFF
--- a/librecad/src/ui/qg_graphicview.cpp
+++ b/librecad/src/ui/qg_graphicview.cpp
@@ -493,37 +493,42 @@ void QG_GraphicView::wheelEvent(QWheelEvent *e) {
         if (isSmoothScrolling)
         {
             if (e->phase() == Qt::ScrollEnd) isSmoothScrolling = false;
-
-            if (!numPixels.isNull())
-            {
-                if (e->modifiers()==Qt::ControlModifier)
-                {
-                    // Hold ctrl to zoom. 1 % per pixel
-                    double v = -numPixels.y() / 100.;
-                    RS2::ZoomDirection direction;
-                    double factor;
-
-                    if (v < 0) {
-                        direction = RS2::Out; factor = 1-v;
-                    } else {
-                        direction = RS2::In;  factor = 1+v;
-                    }
-
-                    setCurrentAction(new RS_ActionZoomIn(*container, *this, direction,
-                                                         RS2::Both, &mouse, factor));
-                }
-                else if (scrollbars)
-                {
-                    // otherwise, scroll
-                    //scroll by scrollbars: issue #479
-                    hScrollBar->setValue(hScrollBar->value() - numPixels.x());
-                    vScrollBar->setValue(vScrollBar->value() - numPixels.y());
-                }
-                redraw();
-            }
-            e->accept();
-            return;
         }
+        else // Trackpads that without high-resolution scrolling
+             // e.g. libinput-XWayland trackpads
+        {
+            numPixels = e->angleDelta() / 4;
+        }
+
+        if (!numPixels.isNull())
+        {
+            if (e->modifiers()==Qt::ControlModifier)
+            {
+                // Hold ctrl to zoom. 1 % per pixel
+                double v = -numPixels.y() / 100.;
+                RS2::ZoomDirection direction;
+                double factor;
+
+                if (v < 0) {
+                    direction = RS2::Out; factor = 1-v;
+                } else {
+                    direction = RS2::In;  factor = 1+v;
+                }
+
+                setCurrentAction(new RS_ActionZoomIn(*container, *this, direction,
+                                                     RS2::Both, &mouse, factor));
+            }
+            else if (scrollbars)
+            {
+                // otherwise, scroll
+                //scroll by scrollbars: issue #479
+                hScrollBar->setValue(hScrollBar->value() - numPixels.x());
+                vScrollBar->setValue(vScrollBar->value() - numPixels.y());
+            }
+            redraw();
+        }
+        e->accept();
+        return;
     }
 
     if (e->delta() == 0) {


### PR DESCRIPTION
Trackpads that did not have hi-res scrolling fell back on the
default (mouse) behaviour. This makes behaviour inconsistent between
machines (or even DE's: Gnome X.org has hi-res, Gnome Wayland+XWayland
does not).

This patch assumes that if
  `options->device == "Trackpad"`
  and
  no smooth scrolling
the "scroll wheel" (`QWheelEvent::angleDelta()`) is used instead of
the "trackpad" (`QWheelEvent::pixelDelta()`).

Division by four is an arbitrary constant to make a compromise
between smooth scrolling and scrolling too fast.

This patch makes working with LibreCAD under XWayland the same
experience as under X.org afaik. More work is needed for native
Wayland (`librecad -platform wayland`) support.

Note on the first commit in this PR: it fixes wrong indentation of the altered code. Was too ugly to work with :)