### PR TITLE
[WIP] Fix all but one compile warning.

### DIFF
--- a/libraries/jwwlib/src/jwwdoc.cpp
+++ b/libraries/jwwlib/src/jwwdoc.cpp
@@ -1759,7 +1759,7 @@ CDataList JWWBlockList::GetBlockList(unsigned int i)
     for(unsigned int k=0; k < FBlockList.size(); k++)
         if(i == FBlockList[k]->m_n_Number)
             return *(PCDataList)FBlockList[k];
-	return {};
+    return {};
 }
 
 int JWWBlockList::getBlockListCount()
@@ -1771,42 +1771,42 @@ CDataEnko JWWBlockList::GetCDataEnko(int i, int j)
 {
     if( GetCDataType(i,j) == Enko )
         return *(PCDataEnko)GetData(i,j);
-	return {};
+    return {};
 }
 
 CDataMoji JWWBlockList::GetCDataMoji(int i, int j)
 {
     if( GetCDataType(i,j) == Moji )
         return *(PCDataMoji)GetData(i,j);
-	return {};
+    return {};
 }
 
 CDataSen JWWBlockList::GetCDataSen(int i, int j)
 {
     if( GetCDataType(i,j) == Sen )
         return *(PCDataSen)GetData(i,j);
-	return {};
+    return {};
 }
 
 CDataSolid JWWBlockList::GetCDataSolid(int i, int j)
 {
     if( GetCDataType(i,j) == Solid )
         return *(PCDataSolid)GetData(i,j);
-	return {};
+    return {};
 }
 
 CDataSunpou JWWBlockList::GetCDataSunpou(int i, int j)
 {
     if( GetCDataType(i,j) == Sunpou )
         return *(PCDataSunpou)GetData(i,j);
-	return {};
+    return {};
 }
 
 CDataTen JWWBlockList::GetCDataTen(int i, int j)
 {
     if( GetCDataType(i,j) == Ten )
         return *(PCDataTen)GetData(i,j);
-	return {};
+    return {};
 }
 
 CDataType JWWBlockList::GetCDataType(int i, int j)
@@ -1933,5 +1933,5 @@ CDataBlock JWWBlockList::GetCDataBlock(int i, int j)
 {
     if( GetCDataType(i,j) == Block )
         return *PCDataBlock(GetData(i,j));
-	return {};
+    return {};
 }

--- a/libraries/libdxfrw/src/drw_header.cpp
+++ b/libraries/libdxfrw/src/drw_header.cpp
@@ -473,11 +473,11 @@ void DRW_Header::write(dxfWriter *writer, DRW::Version ver){
         writer->writeInt16(70, varInt);
     else
         writer->writeInt16(70, 0);
-        writer->writeString(9, "$DIMSAH");
-        if (getInt("$DIMSAH", &varInt))
-            writer->writeInt16(70, varInt);
-        else
-            writer->writeInt16(70, 0);
+    writer->writeString(9, "$DIMSAH");
+    if (getInt("$DIMSAH", &varInt))
+        writer->writeInt16(70, varInt);
+    else
+        writer->writeInt16(70, 0);
     writer->writeString(9, "$DIMBLK1");
     if (getStr("$DIMBLK1", &varStr))
         if (ver == DRW::AC1009)

--- a/libraries/libdxfrw/src/intern/dwgreader15.cpp
+++ b/libraries/libdxfrw/src/intern/dwgreader15.cpp
@@ -174,7 +174,7 @@ bool dwgReader15::readDwgHandles() {
     if (si.Id<0)//not found, ends
         return false;
 
-	bool ret = dwgReader::readDwgHandles(fileBuf.get(), si.address, si.size);
+    bool ret = dwgReader::readDwgHandles(fileBuf.get(), si.address, si.size);
     return ret;
 }
 

--- a/libraries/libdxfrw/src/intern/dwgreader21.cpp
+++ b/libraries/libdxfrw/src/intern/dwgreader21.cpp
@@ -355,7 +355,7 @@ bool dwgReader21::readDwgClasses(){
     if (!ret)
         return ret;
 
-	dwgBuffer buff(tmpClassesData.data(), si.size, &decoder);
+    dwgBuffer buff(tmpClassesData.data(), si.size, &decoder);
     DRW_DBG("classes section sentinel= ");
     checkSentinel(&buff, secEnum::CLASSES, true);
 
@@ -438,7 +438,7 @@ bool dwgReader21::readDwgHandles(){
     if (!ret)
         return ret;
 
-	dwgBuffer dataBuf(tmpHandlesData.data(), si.size, &decoder);
+    dwgBuffer dataBuf(tmpHandlesData.data(), si.size, &decoder);
 
     ret = dwgReader::readDwgHandles(&dataBuf, 0, si.size);
     return ret;

--- a/librecad/src/lib/engine/lc_splinepoints.cpp
+++ b/librecad/src/lib/engine/lc_splinepoints.cpp
@@ -3407,7 +3407,7 @@ RS_VectorSolutions getQuadraticLineIntersect(std::vector<double> dQuadCoefs,
 		{
             if(d < 0.0) d = 0.0;
             if(d > 1.0) d = 1.0;
-			ret.push_back(vx1*(1.0 - d) + vx2*d);
+            ret.push_back(vx1*(1.0 - d) + vx2*d);
 		}
 	}
 

--- a/librecad/src/lib/filters/rs_filterdxfrw.cpp
+++ b/librecad/src/lib/filters/rs_filterdxfrw.cpp
@@ -527,17 +527,17 @@ void RS_FilterDXFRW::addLWPolyline(const DRW_LWPolyline& data) {
     RS_DEBUG->print("RS_FilterDXFRW::addLWPolyline");
     if (data.vertlist.empty())
         return;
-	RS_PolylineData d(RS_Vector{},
-					  RS_Vector{},
+    RS_PolylineData d(RS_Vector{},
+                      RS_Vector{},
                       data.flags&0x1);
     RS_Polyline *polyline = new RS_Polyline(currentContainer, d);
     setEntityAttributes(polyline, &data);
 
-	std::vector< std::pair<RS_Vector, double> > verList;
-	for (auto const& v: data.vertlist)
-		verList.emplace_back(std::make_pair(RS_Vector{v->x, v->y}, v->bulge));
+    std::vector< std::pair<RS_Vector, double> > verList;
+    for (auto const& v: data.vertlist)
+        verList.emplace_back(std::make_pair(RS_Vector{v->x, v->y}, v->bulge));
 
-	polyline->appendVertexs(verList);
+    polyline->appendVertexs(verList);
 
     currentContainer->addEntity(polyline);
 }
@@ -554,20 +554,20 @@ void RS_FilterDXFRW::addPolyline(const DRW_Polyline& data) {
     if ( data.flags&0x40)
         return; //the polyline is a poliface mesh, TODO convert
 
-	RS_PolylineData d(RS_Vector{},
-					  RS_Vector{},
+    RS_PolylineData d(RS_Vector{},
+                      RS_Vector{},
                       data.flags&0x1);
     RS_Polyline *polyline = new RS_Polyline(currentContainer, d);
     setEntityAttributes(polyline, &data);
 
-	std::vector< std::pair<RS_Vector, double> > verList;
+    std::vector< std::pair<RS_Vector, double> > verList;
 
-	for (auto const& v: data.vertlist)
-		verList.emplace_back(
-					std::make_pair(RS_Vector{v->basePoint.x, v->basePoint.y},
-								   v->bulge));
+    for (auto const& v: data.vertlist)
+        verList.emplace_back(
+                    std::make_pair(RS_Vector{v->basePoint.x, v->basePoint.y},
+                                   v->bulge));
 
-	polyline->appendVertexs(verList);
+    polyline->appendVertexs(verList);
 
     currentContainer->addEntity(polyline);
 }

--- a/librecad/src/ui/forms/qg_arctangentialoptions.cpp
+++ b/librecad/src/ui/forms/qg_arctangentialoptions.cpp
@@ -158,13 +158,13 @@ void QG_ArcTangentialOptions::on_leAngle_editingFinished()
 {
 	if(ui->rbAngle->isChecked()) {
         bool ok;
-		double d=RS_Math::correctAngle(RS_Math::eval(ui->leAngle->text(), &ok)*M_PI/180.);
+        double d=RS_Math::correctAngle(RS_Math::eval(ui->leAngle->text(), &ok)*M_PI/180.);
         if(!ok) return;
-		if(d<RS_TOLERANCE_ANGLE || d + RS_TOLERANCE_ANGLE > 2. * M_PI) d=M_PI; // can not do full circle
+        if(d<RS_TOLERANCE_ANGLE || d + RS_TOLERANCE_ANGLE > 2. * M_PI) d=M_PI; // can not do full circle
         action->setAngle(d);
         //updateAngle(QString::number(d*180./M_PI,'g',5));
         action->setByRadius(false);
-		ui->leAngle->setText(QString::number(RS_Math::rad2deg( d),'g',5));
+        ui->leAngle->setText(QString::number(RS_Math::rad2deg( d),'g',5));
     }
 }
 


### PR DESCRIPTION
Most of them were misleading indentations, caused by mixed use of tabs
and spaces (or even caused by misleading amount of spaces).

Please have a look over here:
https://github.com/LibreCAD/LibreCAD/blob/master/librecad/src/lib/modification/rs_modification.cpp#L538

This thing causes

```
lib/modification/rs_modification.cpp: In member function ‘void RS_Modification::paste(const RS_PasteData&, RS_Graphic*)’:
lib/modification/rs_modification.cpp:539:14: warning: statement has no effect [-Wunused-value]
         data.asInsert;
         ~~~~~^~~~~~~~
```

Afaik, there is no such thing as a `nullptr` exception in C++, but perhaps I am wrong and there exists some compiler that throws them? Either case, having a reference that could be `nullptr`, is _very_ bad design.

I propose on entirely getting rid of that `try` block.

After fixing that warning, LibreCAD compiles without warnings on `-Wall`, GCC 6.1!