### PR TITLE
fix:  Pasted blocks do not contain proper hatch data; #760

### DIFF
--- a/librecad/src/actions/rs_actionblocksedit.cpp
+++ b/librecad/src/actions/rs_actionblocksedit.cpp
@@ -38,17 +38,26 @@ RS_ActionBlocksEdit::RS_ActionBlocksEdit(RS_EntityContainer& container,
         :RS_ActionInterface("Edit Block", container, graphicView) {}
 
 void RS_ActionBlocksEdit::trigger() {
-    RS_DEBUG->print("edit block");
-	if (graphic) {
-		if(graphic->getBlockList()){
-			//                std::cout<<__func__<<" : "<<__LINE__<<" : graphic->getBlockList()->count()="<<graphic->getBlockList()->count()<<std::endl;
-			RS_DIALOGFACTORY->requestEditBlockWindow(graphic->getBlockList());
-		}
-	} else {
-        RS_DEBUG->print(RS_Debug::D_WARNING,
-        	"RS_ActionBlocksEdit::trigger(): graphic is NULL");
+
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_ActionBlocksEdit::trigger(): edit block");
+
+    if (!graphic) {
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_ActionBlocksEdit::trigger(): nullptr graphic");
+        return;
     }
+
+    RS_BlockList *bl = graphic->getBlockList();
+
+    if (!bl) {
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_ActionBlocksEdit::trigger(): nullptr block list in graphic");
+        return;
+    }
+
+//  std::cout<<__func__<<" : "<<__LINE__<<" : graphic->getBlockList()->count()="<<graphic->getBlockList()->count()<<std::endl;
+    RS_DIALOGFACTORY->requestEditBlockWindow(bl);
+
     finish(false);
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_ActionBlocksEdit::trigger(): OK");
 }
 
 

--- a/librecad/src/lib/engine/rs_hatch.cpp
+++ b/librecad/src/lib/engine/rs_hatch.cpp
@@ -102,11 +102,14 @@ bool RS_Hatch::validate() {
 
 
 RS_Entity* RS_Hatch::clone() const{
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Hatch::clone()");
     RS_Hatch* t = new RS_Hatch(*this);
     t->setOwner(isOwner());
     t->initId();
     t->detach();
-		t->hatch = nullptr;
+    t->update();
+//    t->hatch = nullptr;
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Hatch::clone(): OK");
     return t;
 }
 

--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -531,15 +531,7 @@ void RS_Modification::paste(const RS_PasteData& data, RS_Graphic* source) {
     RS_DEBUG->print(RS_Debug::D_INFORMATIONAL, "RS_Modification::paste");
 
 	if (!graphic) {
-        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::paste: source is nullptr");
-        return;
-    }
-
-    try {
-        data.asInsert;
-    }
-    catch (...) {
-        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::paste: data is nullptr");
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::paste: graphic is nullptr");
         return;
     }
 


### PR DESCRIPTION
Forcing hatch update in '''RS_Hatch::clone()''' to acquire valid '''RS_Hatch*->hatch''' property. Quick fix.

Minor changes in code of '''QC_DialogFactory::requestEditBlockWindow()''', '''RS_Modification::paste()''' and '''RS_ActionBlocksEdit::trigger()'''.