### PR TITLE
fix: Right mouse button click does not select block in Block List; #759

### DIFF
--- a/librecad/src/ui/qg_blockwidget.cpp
+++ b/librecad/src/ui/qg_blockwidget.cpp
@@ -315,6 +315,9 @@ void QG_BlockWidget::slotActivated(QModelIndex blockIdx) {
  */
 void QG_BlockWidget::contextMenuEvent(QContextMenuEvent *e) {
 
+    // select item (block) in Block List widget first because left-mouse-click event are not to be triggered
+    slotActivated(blockView->currentIndex());
+
     QMenu* contextMenu = new QMenu(this);
     QLabel* caption = new QLabel(tr("Block Menu"), this);
     QPalette palette;


### PR DESCRIPTION
Force triggering ```slotActivated``` action on right-mouse-button-clicked (context menu) event