### PR TITLE
fix: copied objects are not hidden with other layer objects; #774

### DIFF
--- a/librecad/src/lib/engine/rs_layerlist.cpp
+++ b/librecad/src/lib/engine/rs_layerlist.cpp
@@ -315,16 +315,25 @@ void RS_LayerList::toggle(const QString& name) {
  * Listeners are notified.
  */
 void RS_LayerList::toggle(RS_Layer* layer) {
-    if (layer==NULL) {
+
+    if (!layer) {
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_LayerList::toggle: nullptr layer");
         return;
     }
 
+    // set flags
     layer->toggle();
     setModified(true);
 
     // Notify listeners:
-    for (int i=0; i<layerListListeners.size(); ++i) {
-        RS_LayerListListener* l = layerListListeners.at(i);
+    for (auto *i : layerListListeners) {
+
+        if (!i) {
+            RS_DEBUG->print(RS_Debug::D_WARNING, "RS_LayerList::toggle: nullptr layer listener");
+            continue;
+        }
+
+        RS_LayerListListener *l = (RS_LayerListListener *)i;
         l->layerToggled(layer);
     }
 }

--- a/librecad/src/lib/engine/rs_polyline.cpp
+++ b/librecad/src/lib/engine/rs_polyline.cpp
@@ -350,6 +350,22 @@ void RS_Polyline::setEndpoint(RS_Vector const& v) {
 	data.endpoint = v;
 }
 
+void RS_Polyline::setLayer(const QString& name) {
+    RS_Entity::setLayer(name);
+    // set layer for sub-entities
+    for (auto *e : entities) {
+        e->setLayer(layer);
+    }
+}
+
+void RS_Polyline::setLayer(RS_Layer* l) {
+    layer = l;
+    // set layer for sub-entities
+    for (auto *e : entities) {
+        e->setLayer(layer);
+    }
+}
+
 /** @return End point of the entity */
 RS_Vector RS_Polyline::getEndpoint() const {
 	return data.endpoint;

--- a/librecad/src/lib/engine/rs_polyline.h
+++ b/librecad/src/lib/engine/rs_polyline.h
@@ -81,6 +81,10 @@ public:
     /** sets a new end point of the polyline */
 	void setEndpoint(RS_Vector const& v);
 
+    // set layer for polyline and sub-entities
+    void setLayer(const QString& name);
+    void setLayer(RS_Layer* l);
+
     /** @return End point of the entity */
 	RS_Vector getEndpoint() const override;
 


### PR DESCRIPTION
Wrong logic for layers copying in ```RS_Modification::paste``` corected.

```RS_Polyline::setLayer``` function implemented to change sub-entities layers to the same value.

Some changes in code for better readability and stability