### PR TITLE
Fix compile with gcc 5.4

### DIFF
--- a/librecad/src/lib/engine/rs_spline.cpp
+++ b/librecad/src/lib/engine/rs_spline.cpp
@@ -26,6 +26,8 @@
 
 #include<iostream>
 #include<cmath>
+#include<numeric>
+
 #include "rs_spline.h"
 
 


### PR DESCRIPTION
lib/engine/rs_spline.cpp:592:2: error: 'iota' is not a member of 'std'
include numeric c++ header solves this.