### PR TITLE
fix: Save after Undo does nothing; #803

### DIFF
--- a/librecad/src/actions/rs_actioneditundo.cpp
+++ b/librecad/src/actions/rs_actioneditundo.cpp
@@ -63,6 +63,7 @@ void RS_ActionEditUndo::trigger() {
 
 	if (graphic)
         graphic->addBlockNotification();
+        graphic->setModified(true);
     document->updateInserts();
 
     graphicView->redraw(RS2::RedrawDrawing);


### PR DESCRIPTION
Added trigger ```graphic->setModified(true)``` in ```RS_ActionEditUndo::trigger()``` on "redo" action.

This trigger must be added to any procedure that change draft, because "save/save as" action checks if document is modified.

Changes to be committed:
    modified:   librecad/src/actions/rs_actioneditundo.cpp