### PR TITLE
Update rs_math.cpp eval fn to allow Imperial shorthand

### DIFF
--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -243,9 +243,9 @@ double RS_Math::eval(const QString& expr, double def) {
 ** as many times as it exists within a given string.
 */
 void replaceAll(QString& str, const QStringRef& from, const QStringRef& to) {
-    if(from.empty())
+    if(from.isEmpty())
         return;
-    size_t start_pos = 0;
+    int start_pos = 0;
     while((start_pos = str.indexOf(from, start_pos)) != std::string::npos) {
         str.replace(start_pos, from.length(), to);
         start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
@@ -257,7 +257,7 @@ void replaceAll(QString& str, const QStringRef& from, const QStringRef& to) {
 ** which is probably a good thing.
 */
 void ImperialTxlate(Qstring& str) {
-    if (str.empty())
+    if (str.isEmpty())
        return;
     // put brackets around everything first
     str = "(" + str + ")";

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -285,12 +285,14 @@ double RS_Math::eval(const QString& expr, bool* ok) {
         return 0.0;
     }
     double ret(0.);
+    // create a local copy of expr
+    QString lexpr = expr;
     // translate imperial shorthand before you eval
-    ImperialTxlate(expr);
+    ImperialTxlate(lexpr);
     try{
         mu::Parser p;
         p.DefineConst("pi",M_PI);
-        p.SetExpr(expr.toStdString());
+        p.SetExpr(lexpr.toStdString());
         ret=p.Eval();
         *ok=true;
     }

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -256,7 +256,7 @@ void replaceAll(QString& str, const QStringRef& from, const QString& to) {
 ** this only holds true for simple +,- operators *,/ require manual braces..
 ** which is probably a good thing.
 */
-void ImperialTxlate(Qstring& str) {
+void ImperialTxlate(QString& str) {
     if (str.isEmpty())
        return;
     // put brackets around everything first

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -242,11 +242,11 @@ double RS_Math::eval(const QString& expr, double def) {
 ** generic replaceAll will allow substitution of one string for another
 ** as many times as it exists within a given string.
 */
-void replaceAll(QString& str, const std::string& from, const std::string& to) {
+void replaceAll(QString& str, const QStringRef& from, const QStringRef& to) {
     if(from.empty())
         return;
     size_t start_pos = 0;
-    while((start_pos = str.indexOf(from, start_pos,0)) != std::string::npos) {
+    while((start_pos = str.indexOf(from, start_pos)) != std::string::npos) {
         str.replace(start_pos, from.length(), to);
         start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
     }

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -242,7 +242,7 @@ double RS_Math::eval(const QString& expr, double def) {
 ** generic replaceAll will allow substitution of one string for another
 ** as many times as it exists within a given string.
 */
-void replaceAll(std::string& str, const std::string& from, const std::string& to) {
+void replaceAll(QString& str, const std::string& from, const std::string& to) {
     if(from.empty())
         return;
     size_t start_pos = 0;
@@ -256,7 +256,7 @@ void replaceAll(std::string& str, const std::string& from, const std::string& to
 ** this only holds true for simple +,- operators *,/ require manual braces..
 ** which is probably a good thing.
 */
-void ImperialTxlate(std::string & str) {
+void ImperialTxlate(Qstring& str) {
     if (str.empty())
        return;
     // put brackets around everything first

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -246,7 +246,7 @@ void replaceAll(QString& str, const std::string& from, const std::string& to) {
     if(from.empty())
         return;
     size_t start_pos = 0;
-    while((start_pos = str.indexOf(from, start_pos)) != std::string::npos) {
+    while((start_pos = str.indexOf(from, start_pos,0)) != std::string::npos) {
         str.replace(start_pos, from.length(), to);
         start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
     }

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -242,11 +242,11 @@ double RS_Math::eval(const QString& expr, double def) {
 ** generic replaceAll will allow substitution of one string for another
 ** as many times as it exists within a given string.
 */
-void replaceAll(QString& str, const QStringRef& from, const QStringRef& to) {
+void replaceAll(QString& str, const QStringRef& from, const QString& to) {
     if(from.isEmpty())
         return;
     int start_pos = 0;
-    while((start_pos = str.indexOf(from, start_pos)) != std::string::npos) {
+    while((start_pos = str.indexOf(from, start_pos)) != -1) {
         str.replace(start_pos, from.length(), to);
         start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
     }

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -242,13 +242,15 @@ double RS_Math::eval(const QString& expr, double def) {
 ** generic replaceAll will allow substitution of one string for another
 ** as many times as it exists within a given string.
 */
-void replaceAll(QString& str, const QStringRef& from, const QString& to) {
-    if(from.isEmpty())
+void replaceAll(QString& str, const std::string &from, const std::string &to) {
+    QString qfrom = QString::fromStdString(from);
+    QString qto = QString::fromStdString(to);
+    if(qfrom.isEmpty())
         return;
     int start_pos = 0;
-    while((start_pos = str.indexOf(from, start_pos)) != -1) {
-        str.replace(start_pos, from.length(), to);
-        start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
+    while((start_pos = str.indexOf(qfrom, start_pos)) != -1) {
+        str.replace(start_pos, qfrom.length(), qto);
+        start_pos += qto.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
     }
 }
 /*

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -242,7 +242,7 @@ double RS_Math::eval(const QString& expr, double def) {
 ** generic replaceAll will allow substitution of one string for another
 ** as many times as it exists within a given string.
 */
-void RS_Math::replaceAll(std::string& str, const std::string& from, const std::string& to) {
+void replaceAll(std::string& str, const std::string& from, const std::string& to) {
     if(from.empty())
         return;
     size_t start_pos = 0;
@@ -256,7 +256,7 @@ void RS_Math::replaceAll(std::string& str, const std::string& from, const std::s
 ** this only holds true for simple +,- operators *,/ require manual braces..
 ** which is probably a good thing.
 */
-void RS_Math::ImperialTxlate(std::string & str) {
+void ImperialTxlate(std::string & str) {
     if (str.empty())
        return;
     // put brackets around everything first

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -246,7 +246,7 @@ void replaceAll(QString& str, const std::string& from, const std::string& to) {
     if(from.empty())
         return;
     size_t start_pos = 0;
-    while((start_pos = str.find(from, start_pos)) != std::string::npos) {
+    while((start_pos = str.indexOf(from, start_pos)) != std::string::npos) {
         str.replace(start_pos, from.length(), to);
         start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
     }

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -238,7 +238,38 @@ double RS_Math::eval(const QString& expr, double def) {
 
     return res;
 }
-
+/*
+** generic replaceAll will allow substitution of one string for another
+** as many times as it exists within a given string.
+*/
+void RS_Math::replaceAll(std::string& str, const std::string& from, const std::string& to) {
+    if(from.empty())
+        return;
+    size_t start_pos = 0;
+    while((start_pos = str.find(from, start_pos)) != std::string::npos) {
+        str.replace(start_pos, from.length(), to);
+        start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
+    }
+}
+/*
+** Translate imperial shortform to inch equivalent math statements
+** this only holds true for simple +,- operators *,/ require manual braces..
+** which is probably a good thing.
+*/
+void RS_Math::ImperialTxlate(std::string & str) {
+    if (str.empty())
+       return;
+    // put brackets around everything first
+    str = "(" + str + ")";
+    replaceAll(str,"+",")+(");
+    replaceAll(str,"-",")-(");
+    // convert foot shortform
+    replaceAll(str,"\'","*12+");
+    // convert inch shortform
+    replaceAll(str,"\"","+");
+    // fix for inch with no fraction component
+    replaceAll(str,"+)",")");  // -- cleanup 
+}
 
 /**
  * Evaluates a mathematical expression and returns the result.
@@ -252,6 +283,8 @@ double RS_Math::eval(const QString& expr, bool* ok) {
         return 0.0;
     }
     double ret(0.);
+    // translate imperial shorthand before you eval
+    ImperialTxlate(expr);
     try{
         mu::Parser p;
         p.DefineConst("pi",M_PI);


### PR DESCRIPTION
This allows for Imperial shorthand translation prior to the main parser evaluation.
More user-friendly interface at the commandline as users can use shorthand in relative or absolute expressions.
examples below.
<pre>
Eval 20'2"+10'11"3/4                                                                                                                          
Eval (20*12+2)+(10*12+11+3/4)                                                                                                                 
----------------                                                                                                                              
Eval 20'2"-10'11"3/4                                                                                                                          
Eval (20*12+2)-(10*12+11+3/4)                                                                                                                 
----------------                                                                                                                              
Eval -10'11"3/4                                                                                                                               
Eval ()-(10*12+11+3/4)                                                                                                                        
----------------                                                                                                                              
Eval 20'2"+10                                                                                                                                 
Eval (20*12+2)+(10)                                                                                                                           
----------------
</pre>