### PR TITLE
Update rs_math.cpp eval fn behavior

### DIFF
--- a/librecad/src/lib/math/rs_math.h
+++ b/librecad/src/lib/math/rs_math.h
@@ -28,6 +28,7 @@
 #define RS_MATH_H
 
 #include <vector>
+#include <string>
 
 class RS_Vector;
 class RS_VectorSolutions;
@@ -38,8 +39,10 @@ class QString;
  */
 class RS_Math {
 private:
+    static void replaceAll(QString& str, const std::string& from, const std::string& to);
 	RS_Math() = delete;
 public:
+    static void imperialTranslate(QString& str);
 	static int round(double v);
     static double pow(double x, double y);
     static RS_Vector pow(RS_Vector x, double y);


### PR DESCRIPTION
This allows for Imperial shorthand translation
prior to the main parser evaluation.
More user-friendly interface at the commandline
as users can use shorthand in relative
or absolute expressions.

examples below.
<pre>
Eval 20'2"+10'11"3/4
Eval (20*12+2)+(10*12+11+3/4)
----------------
Eval 20'2"-10'11"3/4
Eval (20*12+2)-(10*12+11+3/4)
----------------
Eval -10'11"3/4
Eval ()-(10*12+11+3/4)
----------------
Eval 20'2"+10
Eval (20*12+2)+(10)
----------------
</pre>
known issue:
The conditional check of units currently looks at global preferences
unit definition.  It should actually reference the units assigned
to the current drawing.