### PR TITLE
Fix for issue #884 -- Improve Current Drawing Preferences - Units tab

### DIFF
--- a/librecad/src/ui/forms/qg_dlgoptionsdrawing.cpp
+++ b/librecad/src/ui/forms/qg_dlgoptionsdrawing.cpp
@@ -608,7 +608,7 @@ void QG_DlgOptionsDrawing::updateCBLengthPrecision(QComboBox* f, QComboBox* p) {
  * Updates the angle precision combobox
  */
 void QG_DlgOptionsDrawing::updateAnglePrecision() {
-    updateCBAnglePrecision(cbLengthFormat, cbLengthPrecision);
+    updateCBAnglePrecision(cbAngleFormat, cbAnglePrecision);
 }
 
 /**


### PR DESCRIPTION
updateAnglePrecision referenced wrong comboBox