### PR TITLE
fix for Issue #864, #883 -- custom page size - incorrect unit handling

### DIFF
--- a/librecad/src/lib/engine/rs_units.cpp
+++ b/librecad/src/lib/engine/rs_units.cpp
@@ -626,6 +626,7 @@ QString RS_Units::formatAngle(double angle, RS2::AngleFormat format,
     double value;
 
     switch (format) {
+    case RS2::Surveyors:
     case RS2::DegreesDecimal:
     case RS2::DegreesMinutesSeconds:
         value = RS_Math::rad2deg(angle);
@@ -699,7 +700,36 @@ QString RS_Units::formatAngle(double angle, RS2::AngleFormat format,
             }
         }
         break;
-
+    case RS2::Surveyors: {
+        QString prefix,suffix;
+        int quadrant;
+        quadrant = ((int)floor(value)/90);
+        switch(quadrant){
+            case 0:
+                prefix="N";
+                suffix="E";
+                break;
+            case 1:
+                prefix="S";
+                suffix="E";
+                value=180. - value;
+                break;
+            case 2:
+                prefix="S";
+                suffix="W";
+                value=value - 180.;
+                break;
+            case 3:
+                prefix="N";
+                suffix="W";
+                value=360. - value;
+                break;
+            }
+            ret = prefix+formatAngle(RS_Math::deg2rad(value),RS2::DegreesMinutesSeconds,prec)+suffix;
+            ret.replace(QChar(0xB0),"d");
+            ret.replace(" ","");
+        }
+        break;
     default:
         break;
     }

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -1925,15 +1925,18 @@ void QC_ApplicationWindow::slotFilePrint(bool printPDF) {
     QPrinter printer(QPrinter::HighResolution);
 
     bool landscape = false;
-    QPrinter::PageSize paperSize = LC_Printing::rsToQtPaperFormat(graphic->getPaperFormat(&landscape));
+    RS2::PaperFormat pf = graphic->getPaperFormat(&landscape);
+    QPrinter::PageSize paperSize = LC_Printing::rsToQtPaperFormat(pf);
     if(paperSize==QPrinter::Custom){
-        RS_Vector&& s=graphic->getPaperSize();
+        RS_Vector r=graphic->getPaperSize();
+        RS_Vector&& s=RS_Units::convert(r, graphic->getUnit(),RS2::Millimeter);
         if(landscape) s=s.flipXY();
         printer.setPaperSize(QSizeF(s.x,s.y),QPrinter::Millimeter);
-//        RS_DEBUG->print(RS_Debug::D_ERROR, "set paper size to (%g, %g)\n", s.x,s.y);
-    }else
+        // RS_DEBUG->print(RS_Debug::D_ERROR, "set Custom paper size to (%g, %g)\n", s.x,s.y);
+    }else{
         printer.setPaperSize(paperSize);
-//    qDebug()<<"paper size=("<<printer.paperSize(QPrinter::Millimeter).width()<<", "<<printer.paperSize(QPrinter::Millimeter).height()<<")";
+    }
+    // qDebug()<<"paper size=("<<printer.paperSize(QPrinter::Millimeter).width()<<", "<<printer.paperSize(QPrinter::Millimeter).height()<<")";
     if (landscape) {
         printer.setOrientation(QPrinter::Landscape);
     } else {

--- a/librecad/src/ui/forms/qg_dlgoptionsdrawing.cpp
+++ b/librecad/src/ui/forms/qg_dlgoptionsdrawing.cpp
@@ -177,9 +177,9 @@ void QG_DlgOptionsDrawing::setGraphic(RS_Graphic* g) {
         rbPortrait->setChecked(true);
     }
 	if(format==RS2::Custom){
-		RS_Vector s=graphic->getPaperSize();
-		lePaperWidth->setText(QString("%1").setNum(s.x,'g',5));
-		lePaperHeight->setText(QString("%1").setNum(s.y,'g',5));
+        RS_Vector s=graphic->getPaperSize();
+        lePaperWidth->setText(QString("%1").setNum(s.x,'g',5));
+        lePaperHeight->setText(QString("%1").setNum(s.y,'g',5));
 		lePaperWidth->setEnabled(true);
 		lePaperHeight->setEnabled(true);
 	}else{
@@ -397,13 +397,15 @@ void QG_DlgOptionsDrawing::validate() {
                     rbLandscape->isChecked());
         // custom paper size:
 		if (static_cast<RS2::PaperFormat>(cbPaperFormat->currentIndex()) == RS2::Custom) {
-            graphic->setPaperSize(
-                        RS_Units::convert(
-                            RS_Vector(RS_Math::eval(lePaperWidth->text()),
-                                      RS_Math::eval(lePaperHeight->text())),
-							static_cast<RS2::Unit>(cbUnit->currentIndex()),
-							RS2::Millimeter)
-						);
+            graphic->setPaperSize(RS_Vector(RS_Math::eval(lePaperWidth->text()),
+                                            RS_Math::eval(lePaperHeight->text())));
+            //graphic->setPaperSize(
+            //            RS_Units::convert(
+            //                RS_Vector(RS_Math::eval(lePaperWidth->text()),
+            //                          RS_Math::eval(lePaperHeight->text())),
+            //				static_cast<RS2::Unit>(cbUnit->currentIndex()),
+            //				RS2::Millimeter)
+            //			);
 			bool landscape;
 			graphic->getPaperFormat(&landscape);
 			rbLandscape->setChecked(landscape);
@@ -714,13 +716,8 @@ void  QG_DlgOptionsDrawing::updatePaperSize() {
 
 	RS_Vector s; //paper size: width, height
     if (format==RS2::Custom) {
-		s = RS_Units::convert(
-                    graphic->getPaperSize(),
-                    RS2::Millimeter,
-					static_cast<RS2::Unit>(cbUnit->currentIndex())
-					);
-        //RS_Vector plimmin = graphic->getVariableVector("$PLIMMIN", RS_Vector(0,0));
-		//RS_Vector plimmax = graphic->getVariableVector("$PLIMMAX", RS_Vector(100,100));
+        s.x = RS_Math::eval(lePaperWidth->text());
+        s.y = RS_Math::eval(lePaperHeight->text());
     }
     else {
         //display paper size according to current units


### PR DESCRIPTION
This gets the unit handling corrected for custom paper size.
It appears to generate correct dimensional pages for 'File | Export | pdf'
but it does not complete printing if using something like pdf creator if
just doing a 'File | Print'.