### PR TITLE
Basic Handling of ANGBASE and ANGDIR DXF variables. 

### DIFF
--- a/librecad/src/lib/engine/rs.h
+++ b/librecad/src/lib/engine/rs.h
@@ -512,6 +512,11 @@ public:
         Surveyors
     };
 
+    enum AngleDirection {
+        CounterClockwise,
+        Clockwise
+    };
+
     /**
      * Enum of levels of resolving when iterating through an entity tree.
      */

--- a/librecad/src/lib/engine/rs_graphic.cpp
+++ b/librecad/src/lib/engine/rs_graphic.cpp
@@ -730,6 +730,13 @@ int RS_Graphic::getAnglePrecision() {
     return getVariableInt("$AUPREC", 4);
 }
 
+double RS_Graphic::getAngleBase() {
+    return getVariableDouble("$ANGBASE", 0);
+}
+
+RS2::AngleDirection RS_Graphic::getAngleDirection() {
+    return (RS2::AngleDirection)getVariableInt("$ANGDIR", 0);
+}
 
 
 /**

--- a/librecad/src/lib/engine/rs_graphic.h
+++ b/librecad/src/lib/engine/rs_graphic.h
@@ -227,6 +227,8 @@ public:
     int getLinearPrecision();
     RS2::AngleFormat getAngleFormat();
     int getAnglePrecision();
+    double getAngleBase();
+    RS2::AngleDirection getAngleDirection();
 
     RS_Vector getPaperSize();
     void setPaperSize(const RS_Vector& s);

--- a/librecad/src/lib/engine/rs_units.cpp
+++ b/librecad/src/lib/engine/rs_units.cpp
@@ -32,6 +32,7 @@
 #include "rs_math.h"
 #include "rs_vector.h"
 #include "rs_debug.h"
+#include "math.h"
 
 /**
  * Converts a DXF integer () to a Unit enum.
@@ -673,17 +674,23 @@ QString RS_Units::formatAngle(double angle, RS2::AngleFormat format,
 
     QString ret;
     double value;
+    double temp;
+    if (angle < (M_PI*-1.)) {
+        temp = angle + M_PI*2.;
+    }else{
+        temp = angle;
+    }
 
     switch (format) {
     case RS2::DegreesDecimal:
     case RS2::DegreesMinutesSeconds:
-        value = RS_Math::rad2deg(angle);
+        value = RS_Math::rad2deg(temp);
         break;
     case RS2::Radians:
-        value = angle;
+        value = temp;
         break;
     case RS2::Gradians:
-        value = RS_Math::rad2gra(angle);
+        value = RS_Math::rad2gra(temp);
         break;
     default:
         RS_DEBUG->print(RS_Debug::D_WARNING,

--- a/librecad/src/ui/forms/qg_coordinatewidget.cpp
+++ b/librecad/src/ui/forms/qg_coordinatewidget.cpp
@@ -28,6 +28,7 @@
 #include "rs_settings.h"
 #include "rs_vector.h"
 #include "rs_graphic.h"
+#include "rs_math.h"
 
 /*
  *  Constructs a QG_CoordinateWidget as a child of 'parent', with the
@@ -49,6 +50,8 @@ QG_CoordinateWidget::QG_CoordinateWidget(QWidget* parent, const char* name, Qt::
     format = RS2::Decimal;
     aprec = 2;
     aformat = RS2::DegreesDecimal;
+    angBase = 0.00;
+    angDir = RS2::CounterClockwise;
 }
 
 /*
@@ -90,6 +93,8 @@ void QG_CoordinateWidget::setCoordinates(double x, double y,
             prec = graphic->getLinearPrecision();
             aformat = graphic->getAngleFormat();
             aprec = graphic->getAnglePrecision();
+            angBase = graphic->getAngleBase();
+            angDir = graphic->getAngleDirection();
         }
 
         // abs / rel coordinates:
@@ -110,13 +115,15 @@ void QG_CoordinateWidget::setCoordinates(double x, double y,
         lCoord2->setText(relX + " , " + relY);
 
         // polar coordinates:
+        double d = (angDir==RS2::CounterClockwise)?1.:-1.;
+        double abase = RS_Math::deg2rad(angBase);
         RS_Vector v;
         v = RS_Vector(x, y);
         QString str;
         QString rStr = RS_Units::formatLinear(v.magnitude(),
                                                graphic->getUnit(),
                                                format, prec);
-        QString aStr = RS_Units::formatAngle(v.angle(),
+        QString aStr = RS_Units::formatAngle((v.angle()-abase)*d,
                                                aformat, aprec);
 
         str = rStr + " < " + aStr;
@@ -126,7 +133,7 @@ void QG_CoordinateWidget::setCoordinates(double x, double y,
         rStr = RS_Units::formatLinear(v.magnitude(),
                                                graphic->getUnit(),
                                                format, prec);
-        aStr = RS_Units::formatAngle(v.angle(),
+        aStr = RS_Units::formatAngle((v.angle()-abase)*d,
                                                aformat, aprec);
         str = rStr + " < " + aStr;
         lCoord2b->setText(str);

--- a/librecad/src/ui/forms/qg_coordinatewidget.h
+++ b/librecad/src/ui/forms/qg_coordinatewidget.h
@@ -53,6 +53,8 @@ private:
     RS2::LinearFormat format;
     int aprec;
     RS2::AngleFormat aformat;
+    double angBase;
+    RS2::AngleDirection angDir;
 
 };
 

--- a/librecad/src/ui/forms/qg_dlgoptionsdrawing.cpp
+++ b/librecad/src/ui/forms/qg_dlgoptionsdrawing.cpp
@@ -123,6 +123,12 @@ void QG_DlgOptionsDrawing::init() {
     cbAngleFormat->insertItems(0, aunitList);
     cbDimAUnit->insertItems(0, aunitList);
 
+    // init angle direction combobox:
+    QStringList angDirList;
+    angDirList << tr("counter-clockwise")
+               << tr("clockwise");
+    cbAngleDirection->insertItems(0,angDirList);
+
     // Paper format:
     for (int i=RS2::Custom; i<=RS2::NPageSize; i++) {
 		cbPaperFormat->addItem(RS_Units::paperFormatToString(static_cast<RS2::PaperFormat>(i)));
@@ -164,6 +170,14 @@ void QG_DlgOptionsDrawing::setGraphic(RS_Graphic* g) {
     int auprec = graphic->getVariableInt("$AUPREC", 2);
     updateCBAnglePrecision(cbAngleFormat, cbAnglePrecision);
     cbAnglePrecision->setCurrentIndex(auprec);
+
+    // units / angle base:
+    double angbase = graphic->getVariableDouble("$ANGBASE", 0);
+    sbAngleBase->setValue(angbase);
+
+    // units / angle direction:
+    int angdir = graphic->getVariableInt("$ANGDIR", 0);
+    cbAngleDirection->setCurrentIndex(angdir);
 
     // paper format:
     bool landscape;
@@ -401,6 +415,8 @@ void QG_DlgOptionsDrawing::validate() {
         graphic->addVariable("$LUPREC", cbLengthPrecision->currentIndex(), 70);
         graphic->addVariable("$AUNITS", cbAngleFormat->currentIndex(), 70);
         graphic->addVariable("$AUPREC", cbAnglePrecision->currentIndex(), 70);
+        graphic->addVariable("$ANGBASE", sbAngleBase->value(), 50);
+        graphic->addVariable("$ANGDIR",cbAngleDirection->currentIndex(), 70);
 
         // paper:
         graphic->setPaperFormat(

--- a/librecad/src/ui/forms/qg_dlgoptionsdrawing.ui
+++ b/librecad/src/ui/forms/qg_dlgoptionsdrawing.ui
@@ -27,7 +27,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tab1">
       <attribute name="title">
@@ -322,6 +322,29 @@
               <string>Angle</string>
              </property>
              <layout class="QGridLayout" name="gridLayout_5">
+              <item row="1" column="0">
+               <widget class="QLabel" name="lAnglePrecision">
+                <property name="text">
+                 <string>Pre&amp;cision:</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>false</bool>
+                </property>
+                <property name="buddy">
+                 <cstring>cbAnglePrecision</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QComboBox" name="cbAnglePrecision"/>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="IAngleBase">
+                <property name="text">
+                 <string>Angle Base:</string>
+                </property>
+               </widget>
+              </item>
               <item row="0" column="0">
                <widget class="QLabel" name="lAngleFormat">
                 <property name="text">
@@ -335,7 +358,7 @@
                 </property>
                </widget>
               </item>
-              <item row="2" column="1">
+              <item row="4" column="1">
                <spacer name="spacer15_3">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>
@@ -351,7 +374,7 @@
                 </property>
                </spacer>
               </item>
-              <item row="2" column="0">
+              <item row="4" column="0">
                <spacer name="spacer15_2_2">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>
@@ -370,21 +393,25 @@
               <item row="0" column="1">
                <widget class="QComboBox" name="cbAngleFormat"/>
               </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="lAnglePrecision">
-                <property name="text">
-                 <string>Pre&amp;cision:</string>
+              <item row="2" column="1">
+               <widget class="QDoubleSpinBox" name="sbAngleBase">
+                <property name="maximum">
+                 <double>360.000000000000000</double>
                 </property>
-                <property name="wordWrap">
-                 <bool>false</bool>
-                </property>
-                <property name="buddy">
-                 <cstring>cbAnglePrecision</cstring>
+                <property name="singleStep">
+                 <double>5.000000000000000</double>
                 </property>
                </widget>
               </item>
-              <item row="1" column="1">
-               <widget class="QComboBox" name="cbAnglePrecision"/>
+              <item row="3" column="1">
+               <widget class="QComboBox" name="cbAngleDirection"/>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="label_8">
+                <property name="text">
+                 <string>Angle Direction:</string>
+                </property>
+               </widget>
               </item>
              </layout>
             </widget>


### PR DESCRIPTION
Required to provide fix for issue #883 and is a requirement for pull #889.
These variables were already being read and written at the filesystem level.
Coordinates widget on main page
adjusted to compensate for new base and angle direction. Access to
view and modify within drawing is provided by entries on the
'Units' Tab of the drawing preferences dialog, under the
'Angle' area of the page. 

It allows user to specify a new 'base' direction for 0 degrees and
to specify which direction the positive degrees will proceed in...
clockwise or counter-clockwise. 

Note: It is NOT complete. It has to have appropriate modifications applied
to all 'angle' related creation/preview/modification code.
probably should be done against a separate development branch until
it is consistent.

Comments and suggestions are welcome.