### PR TITLE
adjusted correctAngle functions to be more consistent. Fix for #824 request.

### DIFF
--- a/librecad/src/lib/engine/rs_dimangular.cpp
+++ b/librecad/src/lib/engine/rs_dimangular.cpp
@@ -129,12 +129,15 @@ QString RS_DimAngular::getMeasuredLabel() {
 double RS_DimAngular::getAngle() {
     double ang1 = 0.0;
     double ang2 = 0.0;
+    double ang = 0.0;
     bool reversed = false;
         RS_Vector p1;
         RS_Vector p2;
 
     getAngles(ang1, ang2, reversed, p1, p2);
-    return reversed ? RS_Math::correctAngle(ang1 - ang2) :  RS_Math::correctAngle(ang2 - ang1);
+    ang = fabs(RS_Math::correctAngle(ang2 - ang1));
+    // -- if reversed return the explementary of the angle...otherwise just the angle...in radians.
+    return reversed ? M_PI*2.0 - ang :  ang;
 //
 //    if (!reversed) {
 //        if (ang2<ang1) {
@@ -198,14 +201,14 @@ double a1=d*(rp2*p0p1-p1p2*p0p2); // we only need the sign, so, use multiply ins
 if ( a1 >= 0. ) {
             p1 = edata.definitionPoint2;
 } else {
-            vp1 *= -1;
+            // vp1 *= -1;
             p1 = edata.definitionPoint1;
 }
 a1 = d*(rp1*p0p2-p1p2*p0p1);
 if ( a1 >= 0. ) {
 			p2 = data.definitionPoint;
 } else {
-            vp2 *= -1;
+            // vp2 *= -1;
             p2 = edata.definitionPoint3;
 }
 
@@ -457,7 +460,7 @@ void RS_DimAngular::updateDim(bool /*autoText*/) {
                            RS_MTextData::LeftToRight,
                            RS_MTextData::Exact,
                            1.0,
-                           getLabel(),
+                           getMeasuredLabel(),
                            getTextStyle(),
 //                           "standard",
                            textAngle);

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -142,12 +142,22 @@ bool RS_Math::isAngleBetween(double a,
 }
 
 /**
- * Corrects the given angle to the range of 0-2*Pi.
+ * Corrects the given angle to the range of 0 to +PI*2.0.
  */
 double RS_Math::correctAngle(double a) {
-    return M_PI + remainder(a - M_PI, m_piX2);
+    return fmod(M_PI + remainder(a - M_PI, m_piX2), m_piX2);
 }
 
+/**
+ * Corrects the given angle to the range of -PI to +PI.
+ */
+double RS_Math::correctAngle2(double a) {
+    return remainder(a, m_piX2);
+}
+
+/**
+ * Returns the given angle as an Unsigned Angle in the range of 0 to +PI.
+ */
 double RS_Math::correctAngleU(double a) {
     return fabs(remainder(a, m_piX2));
 }

--- a/librecad/src/lib/math/rs_math.h
+++ b/librecad/src/lib/math/rs_math.h
@@ -55,9 +55,11 @@ public:
     static bool isAngleBetween(double a,
                                double a1, double a2,
                                bool reversed = false);
-	//! \brief correct angle to be within [0, 2 Pi)
+    //! \brief correct angle to be within [0, +PI*2.0)
     static double correctAngle(double a);
-	//! \brief correct angle to be undirectional [0, Pi)
+    //! \brief correct angle to be within [-PI, +PI)
+    static double correctAngle2(double a);
+    //! \brief correct angle to be unsigned [0, +PI)
 	static double correctAngleU(double a);
 
 	//! \brief angular difference


### PR DESCRIPTION
Added fmod call in correctAngle to ensure 360 degree results wrap back to 0 degrees.
Added comments to document expected output range of functions.
Added correctAngle2 function with output range of -PI to +PI.
Adjusted Angular dimension code to provide inside/outside angles
rather than inside/supplementary angles. 
Solves issue #824 requested feature of being able to represent outside angles.
