### PR TITLE
Check viewport intersection only through points along the line

### DIFF
--- a/librecad/src/lib/engine/rs_line.cpp
+++ b/librecad/src/lib/engine/rs_line.cpp
@@ -575,7 +575,9 @@ void RS_Line::draw(RS_Painter* painter, RS_GraphicView* view, double& patternOff
 
     if ((endPoints[0] - getStartpoint()).squared() >
             (endPoints[1] - getStartpoint()).squared() )
+    {
         std::swap(endPoints[0],endPoints[1]);
+    }
 
 	RS_Vector pStart{view->toGui(endPoints.at(0))};
 	RS_Vector pEnd{view->toGui(endPoints.at(1))};
@@ -586,7 +588,7 @@ void RS_Line::draw(RS_Painter* painter, RS_GraphicView* view, double& patternOff
         //extend line on a construction layer to fill the whole view
 		RS_VectorSolutions vpIts;
 		for(auto p: ec) {
-			auto const sol=RS_Information::getIntersection(this, p, false);
+            auto const sol=RS_Information::getIntersection(this, p, true);
 			for (auto const& vp: sol) {
 				if (vpIts.getClosestDistance(vp) <= RS_TOLERANCE * 10.)
 					continue;


### PR DESCRIPTION
I've noticed the code to draw the line was creating an intersection on a point outside the line and the viewport boundaries and that was resulting in an almost infinite loop when trying to draw the pattern. I just changed the parameter on getIntersection to consider only points on the entities.