### PR TITLE
Fixes

### DIFF
--- a/librecad/src/lib/engine/rs_overlayline.h
+++ b/librecad/src/lib/engine/rs_overlayline.h
@@ -42,7 +42,7 @@ class RS_OverlayLine : public RS_Line {
 public:
 	RS_OverlayLine(RS_EntityContainer* parent, const RS_LineData& d);
 	
-    virtual void draw(RS_Painter* painter, RS_GraphicView* view, double& patternOffset);
+    virtual void draw(RS_Painter* painter, RS_GraphicView* view, double& patternOffset) override;
 
     RS2::EntityType rtti() const override{
         return RS2::EntityOverlayLine;

--- a/librecad/src/src.pro
+++ b/librecad/src/src.pro
@@ -50,7 +50,7 @@ unix {
         RC_FILE = ../res/main/librecad.icns
         contains(DISABLE_POSTSCRIPT, false) {
             QMAKE_POST_LINK = cd $$_PRO_FILE_PWD_/../.. && scripts/postprocess-osx.sh;
-            QMAKE_POST_LINK += /usr/libexec/PlistBuddy -c \"Set :CFBundleGetInfoString $${TARGET} $${LC_VERSION}\" $$_PRO_FILE_PWD_/$${DESTDIR}/$${TARGET}.app/Contents/Info.plist;
+            QMAKE_POST_LINK += /usr/libexec/PlistBuddy -c \"Add :CFBundleGetInfoString $${TARGET} $${LC_VERSION}\" $$_PRO_FILE_PWD_/$${DESTDIR}/$${TARGET}.app/Contents/Info.plist;
         }
     }
     else {

--- a/librecad/src/ui/qg_graphicview.cpp
+++ b/librecad/src/ui/qg_graphicview.cpp
@@ -518,12 +518,19 @@ void QG_GraphicView::wheelEvent(QWheelEvent *e) {
                 setCurrentAction(new RS_ActionZoomIn(*container, *this, direction,
                                                      RS2::Both, &mouse, factor));
             }
-            else if (scrollbars)
+            else
             {
-                // otherwise, scroll
-                //scroll by scrollbars: issue #479
-                hScrollBar->setValue(hScrollBar->value() - numPixels.x());
-                vScrollBar->setValue(vScrollBar->value() - numPixels.y());
+                // scroll by scrollbars: issue #479 (it has its own issues)
+                if (scrollbars)
+                {
+                    hScrollBar->setValue(hScrollBar->value() - numPixels.x());
+                    vScrollBar->setValue(vScrollBar->value() - numPixels.y());
+                }
+                else
+                {
+                    setCurrentAction(new RS_ActionZoomScroll(numPixels.x(), numPixels.y(),
+                                                             *container, *this));
+                }
             }
             redraw();
         }


### PR DESCRIPTION
Just a couple of fixes that i have found necessary for using and building LibreCAD on macos.

The issue with trackpad scroll not working with scrollbars disabled was from #479 where the scroll was controlled by the scrollbars so they were realigned correctly