### PR TITLE
fix a couple more issues on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Apple generated directories
 LibreCAD.app/
 LibreCAD.pbproj/
+LibreCAD.dmg
 Info.plist
 
 # globs, anywhere

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -196,6 +196,7 @@ QC_ApplicationWindow::QC_ApplicationWindow()
     setCentralWidget(central);
 
     mdiAreaCAD = central->getMdiArea();
+    mdiAreaCAD->setDocumentMode(true);
 
     settings.beginGroup("Startup");
     if (settings.value("TabMode", 0).toBool())

--- a/librecad/src/src.pro
+++ b/librecad/src/src.pro
@@ -47,10 +47,10 @@ unix {
         VERSION=$$system(echo "$${LC_VERSION}" | sed -e 's/\-.*//g')
         QMAKE_INFO_PLIST = Info.plist.app
         DEFINES += QC_APPDIR="\"LibreCAD\""
-        RC_FILE = ../res/main/librecad.icns
+        ICON = ../res/main/librecad.icns
         contains(DISABLE_POSTSCRIPT, false) {
-            QMAKE_POST_LINK = cd $$_PRO_FILE_PWD_/../.. && scripts/postprocess-osx.sh $$[QT_INSTALL_BINS];
-            QMAKE_POST_LINK += /usr/libexec/PlistBuddy -c \"Set :CFBundleGetInfoString string $${TARGET} $${LC_VERSION}\" $$_PRO_FILE_PWD_/$${DESTDIR}/$${TARGET}.app/Contents/Info.plist;
+            QMAKE_POST_LINK = /bin/sh $$_PRO_FILE_PWD_/../../scripts/postprocess-osx.sh $$OUT_PWD/$${DESTDIR}/$${TARGET}.app/ $$[QT_INSTALL_BINS];
+            QMAKE_POST_LINK += /usr/libexec/PlistBuddy -c \"Set :CFBundleGetInfoString string $${TARGET} $${LC_VERSION}\" $$OUT_PWD/$${DESTDIR}/$${TARGET}.app/Contents/Info.plist;
         }
     }
     else {

--- a/librecad/src/src.pro
+++ b/librecad/src/src.pro
@@ -50,7 +50,7 @@ unix {
         RC_FILE = ../res/main/librecad.icns
         contains(DISABLE_POSTSCRIPT, false) {
             QMAKE_POST_LINK = cd $$_PRO_FILE_PWD_/../.. && scripts/postprocess-osx.sh;
-            QMAKE_POST_LINK += /usr/libexec/PlistBuddy -c \"Add :CFBundleGetInfoString $${TARGET} $${LC_VERSION}\" $$_PRO_FILE_PWD_/$${DESTDIR}/$${TARGET}.app/Contents/Info.plist;
+            QMAKE_POST_LINK += /usr/libexec/PlistBuddy -c \"Set :CFBundleGetInfoString string $${TARGET} $${LC_VERSION}\" $$_PRO_FILE_PWD_/$${DESTDIR}/$${TARGET}.app/Contents/Info.plist;
         }
     }
     else {

--- a/librecad/src/src.pro
+++ b/librecad/src/src.pro
@@ -49,7 +49,7 @@ unix {
         DEFINES += QC_APPDIR="\"LibreCAD\""
         RC_FILE = ../res/main/librecad.icns
         contains(DISABLE_POSTSCRIPT, false) {
-            QMAKE_POST_LINK = cd $$_PRO_FILE_PWD_/../.. && scripts/postprocess-osx.sh;
+            QMAKE_POST_LINK = cd $$_PRO_FILE_PWD_/../.. && scripts/postprocess-osx.sh $$[QT_INSTALL_BINS];
             QMAKE_POST_LINK += /usr/libexec/PlistBuddy -c \"Set :CFBundleGetInfoString string $${TARGET} $${LC_VERSION}\" $$_PRO_FILE_PWD_/$${DESTDIR}/$${TARGET}.app/Contents/Info.plist;
         }
     }

--- a/librecad/src/ui/qg_layerwidget.cpp
+++ b/librecad/src/ui/qg_layerwidget.cpp
@@ -246,7 +246,8 @@ QG_LayerWidget::QG_LayerWidget(QG_ActionHandler* ah, QWidget* parent,
     // lineEdit to filter layer list with RegEx
     matchLayerName = new QLineEdit(this);
     matchLayerName->setReadOnly(false);
-    //matchLayerName->setText("*");
+    matchLayerName->setPlaceholderText("Filter");
+    matchLayerName->setClearButtonEnabled(true);
     matchLayerName->setToolTip(tr("Looking for matching layer names"));
     connect(matchLayerName, SIGNAL( textChanged(QString) ), this, SLOT( slotUpdateLayerList() ) );
 

--- a/scripts/postprocess-osx.sh
+++ b/scripts/postprocess-osx.sh
@@ -1,38 +1,37 @@
 #!/bin/bash
 
-THISDIR="`pwd`"
-RESOURCEDIR="`pwd`/LibreCAD.app/Contents"
-TSDIRLC="`pwd`/librecad/ts"
-TSDIRPI="`pwd`/plugins/ts"
-LRELEASE="$1/lrelease"
+# sh path/to/script <.app directory for output bundle> <path to qt bin>
 
-cd "$THISDIR"
+CONTENTSDIR="$1/Contents"
+LRELEASE="$2/lrelease"
+SCRIPTDIR="$(dirname $0)"
+
+RESOURCEDIR="$CONTENTSDIR/Resources"
+TSDIRLC="$SCRIPTDIR/../librecad/ts"
+TSDIRPI="$SCRIPTDIR/../plugins/ts"
 
 # Postprocess for osx
-mkdir -p $RESOURCEDIR/Resources/fonts
-mkdir -p $RESOURCEDIR/Resources/patterns
-mkdir -p $RESOURCEDIR/PlugIns
-cp librecad/support/patterns/*.dxf $RESOURCEDIR/Resources/patterns
-cp librecad/support/fonts/*.lff $RESOURCEDIR/Resources/fonts
+mkdir -p "$RESOURCEDIR/fonts"
+mkdir -p "$RESOURCEDIR/patterns"
+mkdir -p "$CONTENTSDIR/PlugIns"
+cp "$SCRIPTDIR/../librecad/support/patterns/"*.dxf "$RESOURCEDIR/patterns/"
+cp "$SCRIPTDIR/../librecad/support/fonts/"*.lff "$RESOURCEDIR/fonts/"
 
 if [ -x $LRELEASE ]
 then
 	# Generate translations
-	$LRELEASE librecad/src/src.pro
-	$LRELEASE plugins/plugins.pro
-	mkdir -p $RESOURCEDIR/Resources/qm
+	$LRELEASE "$SCRIPTDIR/../librecad/src/src.pro"
+	$LRELEASE "$SCRIPTDIR/../plugins/plugins.pro"
+	mkdir -p "$RESOURCEDIR/qm"
 
-	# Go into translations directory
-	cd "$TSDIRLC"
-	for tf in *.qm
+	for tf in "$TSDIRLC/"*.qm
 	do
-		cp $tf $RESOURCEDIR/Resources/qm/$tf
+		mv "$tf" "$RESOURCEDIR/qm/$(basename $tf)"
 	done
 
-	cd "$TSDIRPI"
-	for tf in *.qm
+	for tf in "$TSDIRPI/"*.qm
 	do
-		cp $tf $RESOURCEDIR/Resources/qm/$tf
+		mv "$tf" "$RESOURCEDIR/qm/$(basename $tf)"
 	done
 else
 	echo "WARNING: lrelease not found - Translations will not be generated"

--- a/scripts/postprocess-osx.sh
+++ b/scripts/postprocess-osx.sh
@@ -4,11 +4,7 @@ THISDIR="`pwd`"
 RESOURCEDIR="`pwd`/LibreCAD.app/Contents"
 TSDIRLC="`pwd`/librecad/ts"
 TSDIRPI="`pwd`/plugins/ts"
-LRELEASE="lrelease"
-if [ -z "$(which lrelease)" ] && [ -x "/opt/local/libexec/qt5/bin/lrelease" ]
-then
-	LRELEASE="/opt/local/libexec/qt5/bin/lrelease"
-fi
+LRELEASE="$1/lrelease"
 
 cd "$THISDIR"
 
@@ -19,20 +15,25 @@ mkdir -p $RESOURCEDIR/PlugIns
 cp librecad/support/patterns/*.dxf $RESOURCEDIR/Resources/patterns
 cp librecad/support/fonts/*.lff $RESOURCEDIR/Resources/fonts
 
-# Generate translations
-$LRELEASE librecad/src/src.pro
-$LRELEASE plugins/plugins.pro
-mkdir -p $RESOURCEDIR/Resources/qm
+if [ -x $LRELEASE ]
+then
+	# Generate translations
+	$LRELEASE librecad/src/src.pro
+	$LRELEASE plugins/plugins.pro
+	mkdir -p $RESOURCEDIR/Resources/qm
 
-# Go into translations directory
-cd "$TSDIRLC"
-for tf in *.qm
-do
-	cp $tf $RESOURCEDIR/Resources/qm/$tf
-done
+	# Go into translations directory
+	cd "$TSDIRLC"
+	for tf in *.qm
+	do
+		cp $tf $RESOURCEDIR/Resources/qm/$tf
+	done
 
-cd "$TSDIRPI"
-for tf in *.qm
-do
-	cp $tf $RESOURCEDIR/Resources/qm/$tf
-done
+	cd "$TSDIRPI"
+	for tf in *.qm
+	do
+		cp $tf $RESOURCEDIR/Resources/qm/$tf
+	done
+else
+	echo "WARNING: lrelease not found - Translations will not be generated"
+fi

--- a/scripts/postprocess-osx.sh
+++ b/scripts/postprocess-osx.sh
@@ -13,9 +13,11 @@ TSDIRPI="$SCRIPTDIR/../plugins/ts"
 # Postprocess for osx
 mkdir -p "$RESOURCEDIR/fonts"
 mkdir -p "$RESOURCEDIR/patterns"
+mkdir -p "$RESOURCEDIR/library"
 mkdir -p "$CONTENTSDIR/PlugIns"
 cp "$SCRIPTDIR/../librecad/support/patterns/"*.dxf "$RESOURCEDIR/patterns/"
 cp "$SCRIPTDIR/../librecad/support/fonts/"*.lff "$RESOURCEDIR/fonts/"
+cp -r "$SCRIPTDIR/../librecad/support/library/" "$RESOURCEDIR/library/"
 
 if [ -x $LRELEASE ]
 then


### PR DESCRIPTION
the PlistBuddy line requires the type, misunderstood the issue as it was working sometimes, however the one here works on the command line all the time

The postprocess-osx script was very specific and so now it will use the information gained from qmake to find the lrelease executable, the choice of qmakes to use is able to be done as well so will work for non-path qmake/lrelease.

Added the generated dmg file to .gitignore just in case

sorry about the noise, closed the last pull request and redid it as this as it got ugly