### PR TITLE
fixes #877

### DIFF
--- a/librecad/src/Info.plist.app
+++ b/librecad/src/Info.plist.app
@@ -20,5 +20,26 @@
 	<string>@EXECUTABLE@</string>
 	<key>CFBundleIdentifier</key>
 	<string>@BUNDLEIDENTIFIER@</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>dxf</string>
+				<string>llf</string>
+				<string>cxf</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>dwg</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/librecad/src/main/lc_application.cpp
+++ b/librecad/src/main/lc_application.cpp
@@ -1,0 +1,24 @@
+#include <QStringList>
+#include <QFileOpenEvent>
+
+#include "lc_application.h"
+
+LC_Application::LC_Application(int &argc, char **argv)
+    : QApplication(argc, argv)
+{
+    QStringList files = QStringList();
+}
+
+// This is only used until the event filter is in place in mainwindow
+bool LC_Application::event(QEvent *event)
+{
+    if (event->type() == QEvent::FileOpen) {
+        QFileOpenEvent *openEvent = static_cast<QFileOpenEvent *>(event);
+        files.append(openEvent->file());
+    }
+    return QApplication::event(event);
+}
+
+QStringList const& LC_Application::fileList() const {
+    return files;
+}

--- a/librecad/src/main/lc_application.h
+++ b/librecad/src/main/lc_application.h
@@ -1,0 +1,19 @@
+#ifndef LC_APPLICATION_H
+#define LC_APPLICATION_H
+
+#include <QApplication>
+
+class QStringList;
+
+class LC_Application : public QApplication
+{
+public:
+    LC_Application(int &argc, char **argv);
+    bool event(QEvent *event);
+
+    QStringList const& fileList() const;
+private:
+    QStringList files;
+};
+
+#endif // LC_APPLICATION_H

--- a/librecad/src/main/main.cpp
+++ b/librecad/src/main/main.cpp
@@ -31,14 +31,15 @@
 #include <QSplashScreen>
 #include <QSettings>
 #include <QMessageBox>
+#include <QFileInfo>
 
 #include "rs_fontlist.h"
 #include "rs_patternlist.h"
 #include "rs_settings.h"
 #include "rs_system.h"
-#include "rs_fileio.h"
 #include "qg_dlginitial.h"
 
+#include "lc_application.h"
 #include "qc_applicationwindow.h"
 #include "rs_debug.h"
 
@@ -51,7 +52,7 @@ int main(int argc, char** argv)
 
     RS_DEBUG->setLevel(RS_Debug::D_WARNING);
 
-    QApplication app(argc, argv);
+    LC_Application app(argc, argv);
     QCoreApplication::setOrganizationName("LibreCAD");
     QCoreApplication::setApplicationName("LibreCAD");
     QCoreApplication::setApplicationVersion(XSTR(LC_VERSION));
@@ -239,6 +240,7 @@ int main(int argc, char** argv)
 
     RS_DEBUG->print("main: creating main window..");
     QC_ApplicationWindow appWin;
+    app.installEventFilter(&appWin);
     RS_DEBUG->print("main: setting caption");
     appWin.setWindowTitle(app.applicationName());
 
@@ -294,6 +296,8 @@ int main(int argc, char** argv)
     setlocale(LC_NUMERIC, "C");
 
     RS_DEBUG->print("main: loading files..");
+    // get the file list from LC_Application
+    fileList << app.fileList();
     bool files_loaded = false;
     for (QStringList::Iterator it = fileList.begin(); it != fileList.end(); ++it )
     {
@@ -304,7 +308,7 @@ int main(int argc, char** argv)
             Qt::AlignRight|Qt::AlignBottom, Qt::black);
             qApp->processEvents();
         }
-        appWin.slotFileOpen(*it, RS2::FormatUnknown);
+        appWin.slotFileOpen(*it);
         files_loaded = true;
     }
     RS_DEBUG->print("main: loading files: OK");

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -506,7 +506,7 @@ void QC_ApplicationWindow::dropEvent(QDropEvent* event)
     for(QUrl const& url: event->mimeData()->urls()) {
         const QString &fileName = url.toLocalFile();
         if(QFileInfo(fileName).exists() && fileName.endsWith(R"(.dxf)", Qt::CaseInsensitive)){
-            slotFileOpen(fileName, RS2::FormatUnknown);
+            slotFileOpen(fileName);
             if(++counts>32) return;
         }
     }
@@ -1385,7 +1385,6 @@ QString QC_ApplicationWindow::
         return qstring_in;
 }
 
-
 /*	*
  *	Function name:
  *	Description:
@@ -1537,6 +1536,10 @@ void QC_ApplicationWindow::
 
     QApplication::restoreOverrideCursor();
     RS_DEBUG->print("QC_ApplicationWindow::slotFileOpen(..) OK");
+}
+
+void QC_ApplicationWindow::slotFileOpen(const QString& fileName) {
+    slotFileOpen(fileName, RS2::FormatUnknown);
 }
 
 
@@ -2835,6 +2838,17 @@ void QC_ApplicationWindow::reloadStyleSheet()
     // author: ravas
 
     loadStyleSheet(style_sheet_path);
+}
+
+bool QC_ApplicationWindow::eventFilter(QObject *obj, QEvent *event)
+{
+    if (event->type() == QEvent::FileOpen) {
+        QFileOpenEvent *openEvent = static_cast<QFileOpenEvent *>(event);
+        slotFileOpen(openEvent->file(), RS2::FormatUnknown);
+        return true;
+    } else {
+        return QObject::eventFilter(obj, event);
+    }
 }
 
 void QC_ApplicationWindow::updateGridStatus(const QString & status)

--- a/librecad/src/main/qc_applicationwindow.h
+++ b/librecad/src/main/qc_applicationwindow.h
@@ -94,6 +94,8 @@ public:
     void setUndoEnable(bool enable);
     bool loadStyleSheet(QString path);
 
+    bool eventFilter(QObject *obj, QEvent *event) override;
+
     QMap<QString, QAction*> a_map;
     LC_ActionGroupManager* ag_manager;
 
@@ -134,6 +136,7 @@ public slots:
      * opens the given file.
      */
     void slotFileOpen(const QString& fileName, RS2::FormatType type);
+    void slotFileOpen(const QString& fileName); // Assume Unknown type
     void slotFileOpenRecent(QAction* action);
     /** saves a document */
     void slotFileSave();

--- a/librecad/src/src.pro
+++ b/librecad/src/src.pro
@@ -216,7 +216,8 @@ HEADERS += \
     actions/lc_actionfileexportmakercam.h \
     lib/engine/lc_rect.h \
     lib/printing/lc_printing.h \
-    actions/lc_actiondrawlinepolygon3.h
+    actions/lc_actiondrawlinepolygon3.h \
+    main/lc_application.h
 
 SOURCES += \
     lib/actions/rs_actioninterface.cpp \
@@ -305,7 +306,8 @@ SOURCES += \
     lib/engine/lc_rect.cpp \
     lib/engine/rs.cpp \
     lib/printing/lc_printing.cpp \
-    actions/lc_actiondrawlinepolygon3.cpp
+    actions/lc_actiondrawlinepolygon3.cpp \
+    main/lc_application.cpp
 
 # ################################################################################
 # Command


### PR DESCRIPTION
- Adds required information for open with to Info.plist
- Uses a QApplication subclass to catch the file open events prior to the event filter being in place
- Creates an Event filter in the main window for QApplication for fileopen events that are received