### PR TITLE
fix-new-layer-auto-numbering for issue #935

### DIFF
--- a/librecad/src/ui/qg_dialogfactory.cpp
+++ b/librecad/src/ui/qg_dialogfactory.cpp
@@ -187,9 +187,25 @@ RS_Layer* QG_DialogFactory::requestNewLayerDialog(RS_LayerList* layerList) {
             layer_name = "noname";
         }
         newLayerName = QString(layer_name);
-		int i = 2;
+        QString sBaseLayerName = layer_name;
+        int ndx = newLayerName.length();
+        while (newLayerName.at(--ndx).isDigit()) {
+            if (ndx == 0) {
+                ndx--;
+                break;
+            }
+        }
+        int i = 0;
+        if (ndx <= 0) {
+            sBaseLayerName = "";
+            i = newLayerName.toInt();
+        } else if ((ndx > 0) and (ndx < newLayerName.length()-1)) {
+            sBaseLayerName = newLayerName.left(ndx+1);
+            i = newLayerName.mid(ndx+1).toInt();
+            newLayerName = QString("%1%2").arg(sBaseLayerName).arg(++i);
+        }
 		while(layerList->find(newLayerName)) {
-            newLayerName = QString("%1%2").arg(layer_name).arg(i++);
+            newLayerName = QString("%1%2").arg(sBaseLayerName).arg(++i);
         }
     }
 


### PR DESCRIPTION
This allows for any base layer name with a suffix number to be auto
incremented. If no name is supplied it reverts to the default base layer
name of 'noname' and with any additional layers being provided a suffix
number automatically. It is also possible to just use numbered layers
with no base layer name and it will still auto increment correctly...the
only exception being layer '0'. So if you want simple numbered layers
click the + button then replace the default 'noname' layer name in the
dialog with '1' and click 'OK'. From then on highlighting the layer you
want to increment and clicking the '+' button will give you a new layer
with the next available number above the one you just selected.