### PR TITLE
More misc. typos

### DIFF
--- a/libraries/libdxfrw/src/drw_header.cpp
+++ b/libraries/libdxfrw/src/drw_header.cpp
@@ -1526,7 +1526,7 @@ void DRW_Header::write(dxfWriter *writer, DRW::Version ver){
         else
             writer->writeDouble(40, 50.0);
         writer->writeString(9, "$CAMERAHEIGHT");
-        if (getDouble("$CAMERAHEIGTH", &varDouble))
+        if (getDouble("$CAMERAHEIGHT", &varDouble))
             writer->writeDouble(40, varDouble);
         else
             writer->writeDouble(40, 0.0);

--- a/librecad/src/lib/engine/lc_rect.cpp
+++ b/librecad/src/lib/engine/lc_rect.cpp
@@ -69,7 +69,7 @@ Area(coord, {coord.x + width, coord.y + height})
 	}
 
 	/**
-	  * Return the heighest corner
+	  * Return the highest corner
 	  */
 	const Coordinate& LC_Rect::maxP() const {
 		return _maxP;

--- a/librecad/src/lib/engine/lc_rect.h
+++ b/librecad/src/lib/engine/lc_rect.h
@@ -64,7 +64,7 @@ public:
 	const Coordinate& minP() const;
 
 	/**
-		  * Return the heighest corner
+		  * Return the highest corner
 		  */
 	const Coordinate& maxP() const;
 	/**

--- a/librecad/src/lib/engine/rs_arc.cpp
+++ b/librecad/src/lib/engine/rs_arc.cpp
@@ -1034,7 +1034,7 @@ void RS_Arc::drawVisible(RS_Painter* painter, RS_GraphicView* view,
 	double a1{RS_Math::correctAngle(getAngle1())};
 	double a2{RS_Math::correctAngle(getAngle2())};
 
-    if(isReversed()) {//always draw from a1 to a2, so, patternOffset is is automatic
+    if(isReversed()) {//always draw from a1 to a2, so, patternOffset is automatic
         if(a1<a2+RS_TOLERANCE_ANGLE) a2 -= 2.*M_PI;
         total = a1 - total*ira; //in angle
     }else{

--- a/librecad/src/lib/engine/rs_arc.cpp
+++ b/librecad/src/lib/engine/rs_arc.cpp
@@ -127,7 +127,7 @@ bool RS_Arc::createFrom3P(const RS_Vector& p1, const RS_Vector& p2,
  * and radius.
  *
  * @retval true Successfully created arc
- * @retval false Cannot creats arc (radius to small or endpoint to far away)
+ * @retval false Cannot create arc (radius to small or endpoint to far away)
  */
 bool RS_Arc::createFrom2PDirectionRadius(const RS_Vector& startPoint,
         const RS_Vector& endPoint,
@@ -162,7 +162,7 @@ bool RS_Arc::createFrom2PDirectionRadius(const RS_Vector& startPoint,
  * and angle length.
  *
  * @retval true Successfully created arc
- * @retval false Cannot creats arc (radius to small or endpoint to far away)
+ * @retval false Cannot create arc (radius to small or endpoint to far away)
  */
 bool RS_Arc::createFrom2PDirectionAngle(const RS_Vector& startPoint,
                                         const RS_Vector& endPoint,

--- a/librecad/src/lib/engine/rs_color.cpp
+++ b/librecad/src/lib/engine/rs_color.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include "rs_color.h"
 
-//This metod is used for plugins
+//This method is used for plugins
 int RS_Color::toIntColor(void) const {
     if (isByLayer())
         return -1;
@@ -15,7 +15,7 @@ int RS_Color::toIntColor(void) const {
 
 }
 
-//This metod is used for plugins
+//This method is used for plugins
 void RS_Color::fromIntColor(int co) {
     if (co == -1)
         setFlags(RS2::FlagByLayer);

--- a/librecad/src/lib/engine/rs_dimension.cpp
+++ b/librecad/src/lib/engine/rs_dimension.cpp
@@ -419,7 +419,7 @@ double RS_Dimension::getDimensionLineGap() {
 
 
 /**
- * @return Dimension lables text height.
+ * @return Dimension labels text height.
  */
 double RS_Dimension::getTextHeight() {
     return getGraphicVariable("$DIMTXT", 2.5, 40);

--- a/librecad/src/lib/engine/rs_entity.cpp
+++ b/librecad/src/lib/engine/rs_entity.cpp
@@ -368,7 +368,7 @@ bool RS_Entity::isVisible() const{
     //if (rtti()==RS2::EntityInsert) {
     //	return true;
     //}
-    // blocks are visible in editting window, issue#253
+    // blocks are visible in editing window, issue#253
     if( isDocument() && (rtti()==RS2::EntityBlock || rtti()==RS2::EntityInsert)) {
         return true;
     }

--- a/librecad/src/lib/engine/rs_entitycontainer.cpp
+++ b/librecad/src/lib/engine/rs_entitycontainer.cpp
@@ -788,7 +788,7 @@ RS_Entity* RS_EntityContainer::firstEntity(RS2::ResolveLevel level) {
 		if (e && e->isContainer() && e->rtti()!=RS2::EntityInsert) {
             subContainer = (RS_EntityContainer*)e;
             e = ((RS_EntityContainer*)e)->firstEntity(level);
-            // emtpy container:
+            // empty container:
 			if (!e) {
 				subContainer = nullptr;
                 e = nextEntity(level);
@@ -808,7 +808,7 @@ RS_Entity* RS_EntityContainer::firstEntity(RS2::ResolveLevel level) {
 		if (e && e->isContainer() && e->rtti()!=RS2::EntityText && e->rtti()!=RS2::EntityMText) {
             subContainer = (RS_EntityContainer*)e;
             e = ((RS_EntityContainer*)e)->firstEntity(level);
-            // emtpy container:
+            // empty container:
 			if (!e) {
 				subContainer = nullptr;
                 e = nextEntity(level);
@@ -827,7 +827,7 @@ RS_Entity* RS_EntityContainer::firstEntity(RS2::ResolveLevel level) {
 		if (e && e->isContainer()) {
             subContainer = (RS_EntityContainer*)e;
             e = ((RS_EntityContainer*)e)->firstEntity(level);
-            // emtpy container:
+            // empty container:
 			if (!e) {
 				subContainer = nullptr;
                 e = nextEntity(level);
@@ -933,7 +933,7 @@ RS_Entity* RS_EntityContainer::nextEntity(RS2::ResolveLevel level) {
 		if (e && e->isContainer() && e->rtti()!=RS2::EntityInsert) {
             subContainer = (RS_EntityContainer*)e;
             e = ((RS_EntityContainer*)e)->firstEntity(level);
-            // emtpy container:
+            // empty container:
 			if (!e) {
 				subContainer = nullptr;
                 e = nextEntity(level);
@@ -962,7 +962,7 @@ RS_Entity* RS_EntityContainer::nextEntity(RS2::ResolveLevel level) {
 		if (e && e->isContainer() && e->rtti()!=RS2::EntityText && e->rtti()!=RS2::EntityMText ) {
             subContainer = (RS_EntityContainer*)e;
             e = ((RS_EntityContainer*)e)->firstEntity(level);
-            // emtpy container:
+            // empty container:
 			if (!e) {
 				subContainer = nullptr;
                 e = nextEntity(level);
@@ -990,7 +990,7 @@ RS_Entity* RS_EntityContainer::nextEntity(RS2::ResolveLevel level) {
 		if (e && e->isContainer()) {
             subContainer = (RS_EntityContainer*)e;
             e = ((RS_EntityContainer*)e)->firstEntity(level);
-            // emtpy container:
+            // empty container:
 			if (!e) {
 				subContainer = nullptr;
                 e = nextEntity(level);
@@ -1036,7 +1036,7 @@ RS_Entity* RS_EntityContainer::prevEntity(RS2::ResolveLevel level) {
 		if (e && e->isContainer() && e->rtti()!=RS2::EntityInsert) {
             subContainer = (RS_EntityContainer*)e;
             e = ((RS_EntityContainer*)e)->lastEntity(level);
-            // emtpy container:
+            // empty container:
 			if (!e) {
 				subContainer = nullptr;
                 e = prevEntity(level);
@@ -1063,7 +1063,7 @@ RS_Entity* RS_EntityContainer::prevEntity(RS2::ResolveLevel level) {
 		if (e && e->isContainer() && e->rtti()!=RS2::EntityText && e->rtti()!=RS2::EntityMText) {
             subContainer = (RS_EntityContainer*)e;
             e = ((RS_EntityContainer*)e)->lastEntity(level);
-            // emtpy container:
+            // empty container:
 			if (!e) {
 				subContainer = nullptr;
                 e = prevEntity(level);
@@ -1090,7 +1090,7 @@ RS_Entity* RS_EntityContainer::prevEntity(RS2::ResolveLevel level) {
 		if (e && e->isContainer()) {
             subContainer = (RS_EntityContainer*)e;
             e = ((RS_EntityContainer*)e)->lastEntity(level);
-            // emtpy container:
+            // empty container:
 			if (!e) {
 				subContainer = nullptr;
                 e = prevEntity(level);
@@ -1140,7 +1140,7 @@ int RS_EntityContainer::findEntity(RS_Entity const* const entity) {
 
 /**
  * @return The point which is closest to 'coord'
- * (one of the vertexes)
+ * (one of the vertices)
  */
 RS_Vector RS_EntityContainer::getNearestEndpoint(const RS_Vector& coord,
                                                  double* dist  )const {
@@ -1173,7 +1173,7 @@ RS_Vector RS_EntityContainer::getNearestEndpoint(const RS_Vector& coord,
 
 /**
  * @return The point which is closest to 'coord'
- * (one of the vertexes)
+ * (one of the vertices)
  */
 RS_Vector RS_EntityContainer::getNearestEndpoint(const RS_Vector& coord,
                                                  double* dist,  RS_Entity** pEntity)const {

--- a/librecad/src/lib/engine/rs_leader.cpp
+++ b/librecad/src/lib/engine/rs_leader.cpp
@@ -106,7 +106,7 @@ void RS_Leader::update() {
  *
  * @param v vertex coordinate
  *
- * @return Pointer to the entity that was addded or nullptr if this
+ * @return Pointer to the entity that was added or nullptr if this
  *         was the first vertex added.
  */
 RS_Entity* RS_Leader::addVertex(const RS_Vector& v) {

--- a/librecad/src/lib/engine/rs_polyline.cpp
+++ b/librecad/src/lib/engine/rs_polyline.cpp
@@ -126,7 +126,7 @@ void RS_Polyline::removeLastVertex() {
  * @param bulge The bulge of the arc or 0 for a line segment (see DXF documentation)
  * @param prepend true: prepend at start instead of append at end
  *
- * @return Pointer to the entity that was addded or nullptr if this
+ * @return Pointer to the entity that was added or nullptr if this
  *         was the first vertex added.
  */
 RS_Entity* RS_Polyline::addVertex(const RS_Vector& v, double bulge, bool prepend) {

--- a/librecad/src/lib/engine/rs_solid.cpp
+++ b/librecad/src/lib/engine/rs_solid.cpp
@@ -171,7 +171,7 @@ bool RS_Solid::isInCrossWindow(const RS_Vector& v1,const RS_Vector& v2)const {
 //    bool sol = false;
     RS_Vector vBL, vTR;
     RS_VectorSolutions sol;
-//sort imput vectors to BottomLeft & TopRight
+//sort input vectors to BottomLeft & TopRight
     if (v1.x<v2.x) {
         vBL.x = v1.x;
         vTR.x = v2.x;

--- a/librecad/src/lib/engine/rs_spline.cpp
+++ b/librecad/src/lib/engine/rs_spline.cpp
@@ -121,7 +121,7 @@ bool RS_Spline::isClosed() const {
 }
 
 /**
- * Sets the closed falg of this spline.
+ * Sets the closed flag of this spline.
  */
 void RS_Spline::setClosed(bool c) {
 		data.closed = c;

--- a/librecad/src/lib/engine/rs_spline.h
+++ b/librecad/src/lib/engine/rs_spline.h
@@ -102,7 +102,7 @@ public:
 	bool isClosed() const;
 
 	/**
-		 * Sets the closed falg of this spline.
+		 * Sets the closed flag of this spline.
 		 */
 	void setClosed(bool c);
 

--- a/librecad/src/lib/engine/rs_undoable.h
+++ b/librecad/src/lib/engine/rs_undoable.h
@@ -59,7 +59,7 @@ public:
 	bool isUndone() const;
 
 	/**
-	 * Can be overwriten by the implementing class to be notified
+	 * Can be overwritten by the implementing class to be notified
 	 * when the undo state changes (the undoable becomes visible / invisible).
 	 */
 	virtual void undoStateChanged(bool /*undone*/) = 0;

--- a/librecad/src/lib/filters/rs_filterdxfrw.h
+++ b/librecad/src/lib/filters/rs_filterdxfrw.h
@@ -226,7 +226,7 @@ private:
     bool exactColor;
     /** hash of block containers and handleBlock numbers to read dwg files */
     QHash<int, RS_EntityContainer*> blockHash;
-    /** Pointer to entity container to store posible horphan entites like paper space */
+    /** Pointer to entity container to store possible orphan entities like paper space */
     RS_EntityContainer* dummyContainer;
 };
 

--- a/librecad/src/lib/gui/rs_dialogfactoryinterface.h
+++ b/librecad/src/lib/gui/rs_dialogfactoryinterface.h
@@ -371,9 +371,9 @@ public:
      * The implementation will be called every time the mouse position
      * changes.
      *
-     * @param abs Absolute coordiante of the mouse cursor or the
+     * @param abs Absolute coordinate of the mouse cursor or the
      *            point it snaps to.
-     * @param rel Relative coordiante.
+     * @param rel Relative coordinate.
      */
     virtual void updateCoordinateWidget(const RS_Vector& abs, const RS_Vector& rel, bool updateFormat=false) = 0;
 

--- a/librecad/src/lib/gui/rs_graphicview.cpp
+++ b/librecad/src/lib/gui/rs_graphicview.cpp
@@ -1095,7 +1095,7 @@ void RS_GraphicView::drawEntity(RS_Painter *painter, RS_Entity* e) {
 }
 void RS_GraphicView::drawEntity(RS_Painter *painter, RS_Entity* e, double& patternOffset) {
 
-	// update is diabled:
+	// update is disabled:
     // given entity is nullptr:
 	if (!e) {
 		return;
@@ -1323,9 +1323,9 @@ const RS_LineTypePattern* RS_GraphicView::getPattern(RS2::LineType t) {
 
 /**
  * This virtual method can be overwritten to draw the absolute
- * zero. It's called from within drawIt(). The default implemetation
+ * zero. It's called from within drawIt(). The default implementation
  * draws a simple red cross on the zero of the sheet
- * THis function can ONLY be called from within a paintEvent because it will
+ * This function can ONLY be called from within a paintEvent because it will
  * use the painter
  *
  * @see drawIt()
@@ -1352,9 +1352,9 @@ void RS_GraphicView::drawAbsoluteZero(RS_Painter *painter) {
 
 /**
  * This virtual method can be overwritten to draw the relative
- * zero point. It's called from within drawIt(). The default implemetation
+ * zero point. It's called from within drawIt(). The default implementation
  * draws a simple red round zero point. This is the point that was last created by the user, end of a line for example
- * THis function can ONLY be called from within a paintEvent because it will
+ * This function can ONLY be called from within a paintEvent because it will
  * use the painter
  *
  * @see drawIt()

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -480,7 +480,7 @@ void RS_Math::test() {
 //Equation solvers
 
 // quadratic, cubic, and quartic equation solver
-// @ ce[] contains coefficent of the cubic equation:
+// @ ce[] contains coefficient of the cubic equation:
 // @ returns a vector contains real roots
 //
 // solvers assume arguments are valid, and there's no attempt to verify validity of the argument pointers

--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -1650,7 +1650,7 @@ bool RS_Modification::move(RS_MoveData& data) {
 
 	std::vector<RS_Entity*> addList;
 
-    // Create new entites
+    // Create new entities
     for (int num=1;
             num<=data.number || (data.number==0 && num<=1);
             num++) {
@@ -1699,7 +1699,7 @@ bool RS_Modification::offset(const RS_OffsetData& data) {
 
 	std::vector<RS_Entity*> addList;
 
-    // Create new entites
+    // Create new entities
     for (int num=1;
             num<=data.number || (data.number==0 && num<=1);
             num++) {
@@ -1751,7 +1751,7 @@ bool RS_Modification::rotate(RS_RotateData& data) {
 
 	std::vector<RS_Entity*> addList;
 
-    // Create new entites
+    // Create new entities
     for (int num=1;
             num<=data.number || (data.number==0 && num<=1);
 			num++) {
@@ -1826,7 +1826,7 @@ bool RS_Modification::scale(RS_ScaleData& data) {
         }
     }
 
-    // Create new entites
+    // Create new entities
     for (int num=1;
             num<=data.number || (data.number==0 && num<=1);
             num++) {
@@ -1877,7 +1877,7 @@ bool RS_Modification::mirror(RS_MirrorData& data) {
 
 	std::vector<RS_Entity*> addList;
 
-    // Create new entites
+    // Create new entities
     for (int num=1;
             num<=(int)data.copy || (data.copy==false && num<=1);
 			++num) {
@@ -1924,7 +1924,7 @@ bool RS_Modification::rotate2(RS_Rotate2Data& data) {
 
 	std::vector<RS_Entity*> addList;
 
-    // Create new entites
+    // Create new entities
     for (int num=1;
             num<=data.number || (data.number==0 && num<=1);
             num++) {
@@ -1976,7 +1976,7 @@ bool RS_Modification::moveRotate(RS_MoveRotateData& data) {
 
 	std::vector<RS_Entity*> addList;
 
-    // Create new entites
+    // Create new entities
     for (int num=1;
             num<=data.number || (data.number==0 && num<=1);
 			++num) {
@@ -2016,7 +2016,7 @@ bool RS_Modification::moveRotate(RS_MoveRotateData& data) {
 /**
  * Deselects all selected entities and removes them if remove is true;
  *
- * @param remove true: Remove entites.
+ * @param remove true: Remove entities.
  */
 void RS_Modification::deselectOriginals(bool remove
 									   ) {
@@ -2532,7 +2532,7 @@ bool RS_Modification::stretch(const RS_Vector& firstCorner,
 
 	std::vector<RS_Entity*> addList;
 
-	// Create new entites
+	// Create new entities
 	for(auto e: *container){
 		if (e &&
                 e->isVisible() &&
@@ -3326,7 +3326,7 @@ bool RS_Modification::moveRef(RS_MoveRefData& data) {
 
 	std::vector<RS_Entity*> addList;
 
-    // Create new entites
+    // Create new entities
 	for(auto e: *container){
 		if (e && e->isSelected()) {
             RS_Entity* ec = e->clone();

--- a/librecad/src/main/doc_plugin_interface.h
+++ b/librecad/src/main/doc_plugin_interface.h
@@ -125,7 +125,7 @@ public:
     bool getString(QString *txt, const QString& mesage, const QString& title);
     QString realToStr(const qreal num, const int units = 0, const int prec = 0);
 
-    /*metod to handle undo in Plugin_Entity*/
+    //method to handle undo in Plugin_Entity 
     bool addToUndo(RS_Entity* current, RS_Entity* modified);
 private:
     RS_Document *doc;

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -356,10 +356,10 @@ QC_ApplicationWindow::QC_ApplicationWindow()
 }
 
 /**
-  * Find a menu entry in the current menu list. This function will try to recursivly find the menu
+  * Find a menu entry in the current menu list. This function will try to recursively find the menu
   * searchMenu for example foo/bar
   * thisMenuList list of Widgets
-  * currentEntry only used internally dueing recursion
+  * currentEntry only used internally during recursion
   * returns 0 when no menu was found
   */
 QMenu *QC_ApplicationWindow::findMenu(const QString &searchMenu, const QObjectList thisMenuList, const QString& currentEntry) {

--- a/librecad/src/plugins/document_interface.h
+++ b/librecad/src/plugins/document_interface.h
@@ -98,7 +98,7 @@ namespace DPI {
         ENDZ=30,        /*!< double: end z coordinate always 0 */
         LWIDTH=38,      /*!< QString: line width */  //verify number
         RADIUS=39,      /*!< double: radius */
-        HEIGHT=40,      /*!< double: text heigt or ellipse ratio*/
+        HEIGHT=40,      /*!< double: text height or ellipse ratio*/
         XSCALE=41,      /*!< double: x insert scale */
         YSCALE=42,      /*!< double: y insert scale */
         ZSCALE=43,      /*!< double: z insert scale always 1? */
@@ -459,7 +459,7 @@ public:
     //! Gets a entities selection.
     /*! Prompt message or an default message to the user asking for a selection.
     * You can delete all, the Plug_Entity and the returned QList wen no more needed.
-    * \param sel a QList of poiters to Plug_Entity handled the selected entities.
+    * \param sel a QList of pointers to Plug_Entity handled the selected entities.
     * \param mesage an optional QString with prompt message.
     * \return true if succes.
     * \return false if fail, i.e. user cancel.
@@ -468,7 +468,7 @@ public:
 
     //! Gets all entities in document.
     /*! You can delete all, the Plug_Entity and the returned QList wen no more needed.
-    * \param sel a QList of poiters to Plug_Entity handled the selected entities.
+    * \param sel a QList of pointers to Plug_Entity handled the selected entities.
     * \param visible default fo false, do not select entities in hidden layers.
     * \return true if succes.
     * \return false if fail, i.e. user cancel.

--- a/librecad/src/plugins/document_interface.h
+++ b/librecad/src/plugins/document_interface.h
@@ -443,7 +443,7 @@ public:
     * \param point a pointer to QPointF to store the obtained point.
     * \param mesage an optional QString with prompt message.
     * \param base visual helper point, if present.
-    * \return true if succes.
+    * \return true if success.
     * \return false if fail, i.e. user cancel.
     */
     virtual bool getPoint(QPointF *point, const QString& mesage = "", QPointF *base = 0) = 0;
@@ -461,7 +461,7 @@ public:
     * You can delete all, the Plug_Entity and the returned QList wen no more needed.
     * \param sel a QList of pointers to Plug_Entity handled the selected entities.
     * \param mesage an optional QString with prompt message.
-    * \return true if succes.
+    * \return true if success.
     * \return false if fail, i.e. user cancel.
     */
     virtual bool getSelect(QList<Plug_Entity *> *sel, const QString& mesage = "") = 0;
@@ -470,7 +470,7 @@ public:
     /*! You can delete all, the Plug_Entity and the returned QList wen no more needed.
     * \param sel a QList of pointers to Plug_Entity handled the selected entities.
     * \param visible default fo false, do not select entities in hidden layers.
-    * \return true if succes.
+    * \return true if success.
     * \return false if fail, i.e. user cancel.
     */
     virtual bool getAllEntities(QList<Plug_Entity *> *sel, bool visible = false) = 0;

--- a/librecad/src/ui/forms/qg_exitdialog.cpp
+++ b/librecad/src/ui/forms/qg_exitdialog.cpp
@@ -56,7 +56,7 @@ void QG_ExitDialog::languageChange()
 {
 	ui->retranslateUi(this);
 }
-//sets aditional accel, eg. Key_A for ALT+Key_A
+//sets additional accel, eg. Key_A for ALT+Key_A
 
 /*
 static void makeLetterAccell(QButton *btn)


### PR DESCRIPTION
Typos both in source and comments
Found via `codespell -q 3 -I ../librecad-whitelist.txt --skip="*.ts,./libraries"`