### PR TITLE
updated-AddLayer-routine-to-use-QRegularExpression

### DIFF
--- a/librecad/src/ui/qg_dialogfactory.cpp
+++ b/librecad/src/ui/qg_dialogfactory.cpp
@@ -32,6 +32,7 @@
 #include <QString>
 #include <QFileDialog>
 #include <QToolBar>
+#include <QRegularExpression>
 
 #include "rs_patternlist.h"
 #include "rs_settings.h"
@@ -188,24 +189,21 @@ RS_Layer* QG_DialogFactory::requestNewLayerDialog(RS_LayerList* layerList) {
         }
         newLayerName = QString(layer_name);
         QString sBaseLayerName = layer_name;
-        int ndx = newLayerName.length();
-        while (newLayerName.at(--ndx).isDigit()) {
-            if (ndx == 0) {
-                ndx--;
-                break;
-            }
-        }
+        QString sNumLayerName = "";
+        int nlen = 1;
         int i = 0;
-        if (ndx <= 0) {
-            sBaseLayerName = "";
-            i = newLayerName.toInt();
-        } else if ((ndx > 0) and (ndx < newLayerName.length()-1)) {
-            sBaseLayerName = newLayerName.left(ndx+1);
-            i = newLayerName.mid(ndx+1).toInt();
-            newLayerName = QString("%1%2").arg(sBaseLayerName).arg(++i);
+        QRegularExpression re("^(\\D+?|)(\\d+)$");
+        re.setPatternOptions(QRegularExpression::DotMatchesEverythingOption);
+        QRegularExpressionMatch match = re.match(layer_name);
+        if (match.hasMatch()) {
+            sBaseLayerName = match.captured(1);
+            sNumLayerName = match.captured(2);
+            nlen = sNumLayerName.length();
+            i = sNumLayerName.toInt();
         }
-		while(layerList->find(newLayerName)) {
-            newLayerName = QString("%1%2").arg(sBaseLayerName).arg(++i);
+        while (layerList->find(newLayerName)) {
+            sNumLayerName = QString("%1").arg(++i,nlen,10,QChar('0'));
+            newLayerName = QString("%1%2").arg(sBaseLayerName).arg(sNumLayerName);
         }
     }
 

--- a/librecad/src/ui/qg_dialogfactory.cpp
+++ b/librecad/src/ui/qg_dialogfactory.cpp
@@ -2,6 +2,8 @@
 **
 ** This file is part of the LibreCAD project, a 2D CAD program
 **
+** Copyright (C) 2018 webmite <ianm.main@gmail.com>
+** Copyright (C) 2018 A. Stebich (librecad@mail.lordofbikes.de)
 ** Copyright (C) 2010 R. van Twisk (librecad@rvt.dds.nl)
 ** Copyright (C) 2001-2003 RibbonSoft. All rights reserved.
 **
@@ -176,34 +178,36 @@ void QG_DialogFactory::requestWarningDialog(const QString& warning) {
  * @return a pointer to the newly created layer that
  * should be added.
  */
-RS_Layer* QG_DialogFactory::requestNewLayerDialog(RS_LayerList* layerList) {
+RS_Layer* QG_DialogFactory::requestNewLayerDialog(RS_LayerList* layerList)
+{
+    RS_Layer* layer {nullptr};
 
-	RS_Layer* layer = nullptr;
-
-    QString layer_name = "", newLayerName = "";
-
-	if (layerList) {
-        layer_name = QString(layerList->getActive()->getName());
-        if (layer_name.isEmpty() || !layer_name.compare("0", Qt::CaseInsensitive) ) {
-            layer_name = "noname";
+    QString layer_name;
+    QString newLayerName;
+    if (nullptr != layerList) {
+        layer_name = layerList->getActive()->getName();
+        if (layer_name.isEmpty() || !layer_name.compare("0") ) {
+            layer_name = QObject::tr( "noname", "default layer name");
         }
-        newLayerName = QString(layer_name);
-        QString sBaseLayerName = layer_name;
-        QString sNumLayerName = "";
-        int nlen = 1;
-        int i = 0;
-        QRegularExpression re("^(\\D+?|)(\\d+)$");
-        re.setPatternOptions(QRegularExpression::DotMatchesEverythingOption);
-        QRegularExpressionMatch match = re.match(layer_name);
+        newLayerName = layer_name;
+
+        QString sBaseLayerName( layer_name);
+        QString sNumLayerName;
+        int nlen {1};
+        int i {0};
+        QRegularExpression re("^(.*\\D+|)(\\d*)$");
+        QRegularExpressionMatch match( re.match(layer_name));
         if (match.hasMatch()) {
             sBaseLayerName = match.captured(1);
-            sNumLayerName = match.captured(2);
-            nlen = sNumLayerName.length();
-            i = sNumLayerName.toInt();
+            if( 1 < match.lastCapturedIndex()) {
+                sNumLayerName = match.captured(2);
+                nlen = sNumLayerName.length();
+                i = sNumLayerName.toInt();
+            }
         }
-        while (layerList->find(newLayerName)) {
-            sNumLayerName = QString("%1").arg(++i,nlen,10,QChar('0'));
-            newLayerName = QString("%1%2").arg(sBaseLayerName).arg(sNumLayerName);
+
+        while (layerList->find( newLayerName)) {
+            newLayerName = QString("%1%2").arg( sBaseLayerName).arg( ++i, nlen, 10, QChar('0'));
         }
     }
 
@@ -218,8 +222,9 @@ RS_Layer* QG_DialogFactory::requestNewLayerDialog(RS_LayerList* layerList) {
         dlg.updateLayer();
     } else {
         delete layer;
-		layer = nullptr;
+        layer = nullptr;
     }
+
     return layer;
 }
 


### PR DESCRIPTION
This routine uses QRegularExpression in the AddLayer routine to identify the base layer name and numeric component and also extends the existing routine by allowing zero padded numbers to be correctly incremented