### PR TITLE
Fix VS error C2600 by removing ambiguity in the default constructor.

### DIFF
--- a/librecad/src/lib/engine/rs_blocklist.h
+++ b/librecad/src/lib/engine/rs_blocklist.h
@@ -44,7 +44,6 @@ class RS_BlockListListener;
  */
 class RS_BlockList {
 public:
-	RS_BlockList()=default;
     RS_BlockList(bool owner=false);
 	virtual ~RS_BlockList() = default;
 

--- a/librecad/src/lib/engine/rs_entity.h
+++ b/librecad/src/lib/engine/rs_entity.h
@@ -60,8 +60,6 @@ class QString;
  */
 class RS_Entity : public RS_Undoable {
 public:
-
-	RS_Entity()=default;
 	RS_Entity(RS_EntityContainer* parent=nullptr);
 	virtual ~RS_Entity() = default;
 


### PR DESCRIPTION
When compiling the code using VS2017, I get C2600 errors:

error C2600: 'RS_BlockList::RS_BlockList': cannot define a compiler-generated special member function (must be declared in the class first)
error C2600: 'RS_Entity::RS_Entity': cannot define a compiler-generated special member function (must be declared in the class first)

which eventually occur due to ambiguity of the default constructors (what should RS_BlockList() do?)

This change deletes unnecessary definitions and eliminates the error.