### PR TITLE
Misc. typos (including doxy)

### DIFF
--- a/librecad/src/actions/rs_actiondimangular.cpp
+++ b/librecad/src/actions/rs_actiondimangular.cpp
@@ -283,7 +283,7 @@ void RS_ActionDimAngular::justify(RS_Line &line, const RS_Vector &click)
  * Create a sorted array with angles from the lines intersection point
  * to the starting points and their revers angles.
  * Ensure, that line1 and line2 are in CCW order.
- * Compute an offset for quadrant() methode.
+ * Compute an offset for quadrant() method.
  *
  * @param line A selected line for the dimension
  * @param click The click pos which selected the line
@@ -363,7 +363,7 @@ int RS_ActionDimAngular::quadrant(const double angle)
 
 /**
  * On \p mouseMoveEvent, \p mouseReleaseEvent and \p coordinateEvent
- * this methode sets the dimension data appropriate to the mouse
+ * this method sets the dimension data appropriate to the mouse
  * cursor/coordinate in \p dimPos.
  * When \p calcCenter is true, the intersection point and other static
  * values are computed. This is only necessary, when line selection changes,

--- a/librecad/src/lib/engine/rs_image.h
+++ b/librecad/src/lib/engine/rs_image.h
@@ -217,7 +217,7 @@ public:
 
 
 protected:
-	// whether the the point is within image
+	// whether the point is within image
 	bool containsPoint(const RS_Vector& coord) const;
 	RS_ImageData data;
 	std::unique_ptr<QImage> img;

--- a/librecad/src/lib/filters/rs_filterdxfrw.h
+++ b/librecad/src/lib/filters/rs_filterdxfrw.h
@@ -217,7 +217,7 @@ private:
     QString dimStyle;
     /** text style. */
     QString textStyle;
-    /** Temporary list to handle unnamed blocks fot write R12 dxf. */
+    /** Temporary list to handle unnamed blocks to write R12 dxf. */
     QHash <RS_Entity*, QString> noNameBlock;
     QHash <QString, QString> fontList;
     bool oldMText;

--- a/librecad/src/lib/gui/rs_graphicview.h
+++ b/librecad/src/lib/gui/rs_graphicview.h
@@ -350,7 +350,7 @@ public:
 	void setPrinting(bool p);
 
 	/**
-		 * @retval true This is a a graphic view for printing.
+		 * @retval true This is a graphic view for printing.
 		 * @retval false setSnapOtherwise.
 		 */
 	bool isPrinting() const;

--- a/librecad/src/plugins/document_interface.h
+++ b/librecad/src/plugins/document_interface.h
@@ -449,7 +449,7 @@ public:
     virtual bool getPoint(QPointF *point, const QString& mesage = "", QPointF *base = 0) = 0;
 
     //! Select a entity.
-    /*! Prompt message or a default message to the user asking for a sigle selection.
+    /*! Prompt message or a default message to the user asking for a single selection.
     * You can delete the Plug_Entity wen no more needed.
     * \param mesage an optional QString with prompt message.
     * \return a Plug_Entity handle the selected entity or NULL.

--- a/plugins/importshp/shapelib/ChangeLog
+++ b/plugins/importshp/shapelib/ChangeLog
@@ -68,7 +68,7 @@
 	* shpopen.c/shapefil.h: Handle the .shp file length limits more
 	gracefully. (http://trac.osgeo.org/gdal/ticket/3236)
 
-	* shpopen.c: Improve the numerical accurancy of algorithms in
+	* shpopen.c: Improve the numerical accuracy of algorithms in
 	SHPRewind() (http://trac.osgeo.org/gdal/ticket/3363).
 
 2010-01-16  Frank Warmerdam  <warmerdam@pobox.com>


### PR DESCRIPTION
Found via `codespell -q 3 -I ../librecad-whitelist.txt --skip="*.ts,./libraries"`
Whiteslist:
```
amin
ang
ans
behaviour
bload
cancellation
cancelled
ded
ede
emitted
initialisation
lightyear
mesage
ot
que
te
```