### PR TITLE
Angular dimensions now respect user's custom label text

### DIFF
--- a/librecad/src/lib/engine/rs_dimangular.cpp
+++ b/librecad/src/lib/engine/rs_dimangular.cpp
@@ -361,7 +361,7 @@ void RS_DimAngular::updateDim(bool autoText /*= false*/)
                              RS_MTextData::LeftToRight,
                              RS_MTextData::Exact,
                              1.0,
-                             getMeasuredLabel(),
+                             getLabel(),
                              getTextStyle(),
                              textAngle);
 


### PR DESCRIPTION
dimangular objects should reference getLabel instead of getMeasuredLabel
in order to respect any optionally provided custom label text.

This bug was introduced in #896, and no explanation for the change was given in the commit message, so I assume it was just left over from testing the PR.