### PR TITLE
Better inside-horizontal dimensions

### DIFF
--- a/librecad/src/lib/engine/rs_dimension.h
+++ b/librecad/src/lib/engine/rs_dimension.h
@@ -177,7 +177,7 @@ public:
     double getExtensionLineOffset();
     double getDimensionLineGap();
     double getTextHeight();
-    bool getAlignText();
+    bool getInsideHorizontalText();
     bool getFixedLengthOn();
     double getFixedLength();
     RS2::LineWidth getExtensionLineWidth();
@@ -200,6 +200,16 @@ public:
 		void rotate(const RS_Vector& center, const RS_Vector& angleVector) override;
 		void scale(const RS_Vector& center, const RS_Vector& factor) override;
 		void mirror(const RS_Vector& axisPoint1, const RS_Vector& axisPoint2) override;
+
+private:
+    static RS_VectorSolutions  getIntersectionsLineContainer(
+        const RS_Line* l, const RS_EntityContainer* c, bool infiniteLine=false);
+    void updateCreateHorizontalTextDimensionLine(
+        const RS_Vector& p1, const RS_Vector& p2,
+        bool arrow1=true, bool arrow2=true, bool autoText=false);
+    void updateCreateAlignedTextDimensionLine(
+        const RS_Vector& p1, const RS_Vector& p2,
+        bool arrow1=true, bool arrow2=true, bool autoText=false);
 
 protected:
     /** Data common to all dimension entities. */

--- a/librecad/src/lib/engine/rs_line.cpp
+++ b/librecad/src/lib/engine/rs_line.cpp
@@ -112,6 +112,30 @@ RS_Vector RS_Line::getNearestEndpoint(const RS_Vector& coord,
 
 }
 
+/**
+ *  This is similar to getNearestPointOnEntity, but only returns the value of
+ *  the position of the projection.  The value may be negative, or greater than
+ *  the length of the line since there are no bounds checking.  The absolute
+ *  value of the return value represents a physical distance from the
+ *  startpoint.
+ *
+ *  @param coord The point which will be projected onto the line.
+ */
+double RS_Line::getProjectionValueAlongLine(const RS_Vector& coord) const
+{
+    RS_Vector direction {data.endpoint - data.startpoint};
+    RS_Vector vpc {coord - data.startpoint};
+    double direction_magnitude {direction.magnitude()};
+    double v = 0.0;
+
+    if(direction_magnitude > RS_TOLERANCE2) {
+        //find projection on line
+        v = RS_Vector::dotP(vpc, direction) / direction_magnitude;
+    }
+
+    return v;
+}
+
 RS_Vector RS_Line::getNearestPointOnEntity(const RS_Vector& coord,
                                            bool onEntity,
                                            double* dist,

--- a/librecad/src/lib/engine/rs_line.h
+++ b/librecad/src/lib/engine/rs_line.h
@@ -60,36 +60,36 @@ std::ostream& operator << (std::ostream& os, const RS_LineData& ld);
  */
 class RS_Line : public RS_AtomicEntity {
 public:
-	RS_Line() = default;
+    RS_Line() = default;
     RS_Line(RS_EntityContainer* parent,
             const RS_LineData& d);
     RS_Line(RS_EntityContainer* parent, const RS_Vector& pStart, const RS_Vector& pEnd);
     RS_Line(const RS_Vector& pStart, const RS_Vector& pEnd);
 
-	RS_Entity* clone() const override;
+    RS_Entity* clone() const override;
 
-    /**	@return RS2::EntityLine */
-	RS2::EntityType rtti() const override{
+    /** @return RS2::EntityLine */
+    RS2::EntityType rtti() const override{
         return RS2::EntityLine;
     }
     /** @return true */
-	bool isEdge() const override{
+    bool isEdge() const override{
         return true;
     }
 
     /** @return Copy of data that defines the line. */
-	RS_LineData getData() const{
+    RS_LineData getData() const{
         return data;
     }
 
-	RS_VectorSolutions getRefPoints() const override;
+    RS_VectorSolutions getRefPoints() const override;
 
     /** @return Start point of the entity */
-	RS_Vector getStartpoint() const override{
+    RS_Vector getStartpoint() const override{
         return data.startpoint;
     }
     /** @return End point of the entity */
-	RS_Vector getEndpoint() const override{
+    RS_Vector getEndpoint() const override{
         return data.endpoint;
     }
     /** Sets the startpoint */
@@ -106,25 +106,25 @@ public:
      * @return Direction 1. The angle at which the line starts at
      * the startpoint.
      */
-	double getDirection1() const override{
+    double getDirection1() const override{
         return getAngle1();
     }
     /**
      * @return Direction 2. The angle at which the line starts at
      * the endpoint.
      */
-	double getDirection2() const override{
+    double getDirection2() const override{
         return getAngle2();
     }
-	RS_Vector getTangentDirection(const RS_Vector& point)const override;
+    RS_Vector getTangentDirection(const RS_Vector& point)const override;
 
-	void moveStartpoint(const RS_Vector& pos) override;
-	void moveEndpoint(const RS_Vector& pos) override;
-	RS2::Ending getTrimPoint(const RS_Vector& trimCoord,
-									 const RS_Vector& trimPoint) override;
-	RS_Vector prepareTrim(const RS_Vector& trimCoord,
-								  const RS_VectorSolutions& trimSol) override;
-	void reverse() override;
+    void moveStartpoint(const RS_Vector& pos) override;
+    void moveEndpoint(const RS_Vector& pos) override;
+    RS2::Ending getTrimPoint(const RS_Vector& trimCoord,
+                             const RS_Vector& trimPoint) override;
+    RS_Vector prepareTrim(const RS_Vector& trimCoord,
+                          const RS_VectorSolutions& trimSol) override;
+    void reverse() override;
     /** Sets the y coordinate of the startpoint */
     void setStartpointY(double val) {
         data.startpoint.y = val;
@@ -135,98 +135,98 @@ public:
         data.endpoint.y = val;
         calculateBorders();
     }
-	bool hasEndpointsWithinWindow(const RS_Vector& v1, const RS_Vector& v2) override;
+    bool hasEndpointsWithinWindow(const RS_Vector& v1, const RS_Vector& v2) override;
 
     /**
      * @return The length of the line.
      */
-	double getLength() const override{
+    double getLength() const override{
         return data.startpoint.distanceTo(data.endpoint);
     }
 
     /**
      * @return The angle of the line (from start to endpoint).
      */
-	double getAngle1() const{
+    double getAngle1() const{
         return data.startpoint.angleTo(data.endpoint);
     }
 
     /**
      * @return The angle of the line (from end to startpoint).
      */
-	double getAngle2() const{
+    double getAngle2() const{
         return data.endpoint.angleTo(data.startpoint);
     }
-	bool isTangent(const RS_CircleData&  circleData) const override;
-
-/**
-  * @return a perpendicular vector
-  */
-	RS_Vector getNormalVector() const;
-	RS_Vector getMiddlePoint()const override;
-	RS_Vector getNearestEndpoint(const RS_Vector& coord,
-										 double* dist = nullptr)const override;
-	RS_Vector getNearestPointOnEntity(const RS_Vector& coord,
-			bool onEntity=true, double* dist = nullptr, RS_Entity** entity=nullptr)const override;
-//    RS_Vector getNearestCenter(const RS_Vector& coord,
-//                                       double* dist = nullptr);
-	RS_Vector getNearestMiddle(const RS_Vector& coord,
-									   double* dist = nullptr,
-                                       int middlePoints = 1
-									   )const override;
-	RS_Vector getNearestDist(double distance,
-                                     const RS_Vector& coord,
-									 double* dist = nullptr)const override;
-	RS_Vector getNearestDist(double distance,
-									 bool startp)const override;
+    bool isTangent(const RS_CircleData&  circleData) const override;
 
     /**
-          * implementations must revert the direction of an atomic entity
-          */
-	void revertDirection() override;
-	 std::vector<RS_Entity* > offsetTwoSides(const double& distance) const override;
+     * @return a perpendicular vector
+     */
+    RS_Vector getNormalVector() const;
+    RS_Vector getMiddlePoint() const override;
+    RS_Vector getNearestEndpoint(const RS_Vector& coord,
+                                 double* dist = nullptr) const override;
+    RS_Vector getNearestPointOnEntity(const RS_Vector& coord,
+                                      bool onEntity = true,
+                                      double* dist = nullptr,
+                                      RS_Entity** entity=nullptr) const override;
+    RS_Vector getNearestMiddle(const RS_Vector& coord,
+                               double* dist = nullptr,
+                               int middlePoints = 1) const override;
+    RS_Vector getNearestDist(double distance,
+                             const RS_Vector& coord,
+                             double* dist = nullptr) const override;
+    RS_Vector getNearestDist(double distance,
+                             bool startp) const override;
+
     /**
-      * the modify offset action
-      */
-	bool offset(const RS_Vector& coord, const double& distance) override;
-	void move(const RS_Vector& offset) override;
-	void rotate(const double& angle);
-	void rotate(const RS_Vector& center, const double& angle) override;
-	void rotate(const RS_Vector& center, const RS_Vector& angleVector) override;
-	void scale(const RS_Vector& factor) override;
-	void scale(const RS_Vector& center, const RS_Vector& factor) override;
-	void mirror(const RS_Vector& axisPoint1, const RS_Vector& axisPoint2) override;
-	void stretch(const RS_Vector& firstCorner,
-                         const RS_Vector& secondCorner,
-						 const RS_Vector& offset) override;
-	void moveRef(const RS_Vector& ref, const RS_Vector& offset) override;
+     * implementations must revert the direction of an atomic entity
+     */
+    void revertDirection() override;
+    std::vector<RS_Entity* > offsetTwoSides(const double& distance) const override;
+    /**
+     * the modify offset action
+     */
+    bool offset(const RS_Vector& coord, const double& distance) override;
+    void move(const RS_Vector& offset) override;
+    void rotate(const double& angle);
+    void rotate(const RS_Vector& center, const double& angle) override;
+    void rotate(const RS_Vector& center, const RS_Vector& angleVector) override;
+    void scale(const RS_Vector& factor) override;
+    void scale(const RS_Vector& center, const RS_Vector& factor) override;
+    void mirror(const RS_Vector& axisPoint1, const RS_Vector& axisPoint2) override;
+    void stretch(const RS_Vector& firstCorner,
+                 const RS_Vector& secondCorner,
+                 const RS_Vector& offset) override;
+    void moveRef(const RS_Vector& ref, const RS_Vector& offset) override;
 
     /** whether the entity's bounding box intersects with visible portion of graphic view */
-	void draw(RS_Painter* painter, RS_GraphicView* view, double& patternOffset) override;
+    void draw(RS_Painter* painter, RS_GraphicView* view, double& patternOffset) override;
 
     friend std::ostream& operator << (std::ostream& os, const RS_Line& l);
 
-	void calculateBorders() override;
-	/** \brief getQuadratic() returns the equation of the entity
-for quadratic,
-
-return a vector contains:
-m0 x^2 + m1 xy + m2 y^2 + m3 x + m4 y + m5 =0
-
-for linear:
-m0 x + m1 y + m2 =0
-**/
-	LC_Quadratic getQuadratic() const override;
+    void calculateBorders() override;
     /**
-	 * @brief areaLineIntegral line integral for contour area calculation by Green's Theorem
+     * @brief getQuadratic() returns the equation of the entity
+     * for quadratic,
+     *
+     * return a vector contains:
+     * m0 x^2 + m1 xy + m2 y^2 + m3 x + m4 y + m5 =0
+     *
+     * for linear:
+     * m0 x + m1 y + m2 =0
+     */
+    LC_Quadratic getQuadratic() const override;
+    /**
+     * @brief areaLineIntegral line integral for contour area calculation by Green's Theorem
      * Contour Area =\oint x dy
      * @return line integral \oint x dy along the entity
      * \oint x dy = 0.5*(x0+x1)*(y1-y0)
      */
-	double areaLineIntegral() const override;
+    double areaLineIntegral() const override;
 
 protected:
-	RS_LineData data;
+    RS_LineData data;
 };
 
 #endif

--- a/librecad/src/lib/engine/rs_line.h
+++ b/librecad/src/lib/engine/rs_line.h
@@ -163,6 +163,7 @@ public:
      * @return a perpendicular vector
      */
     RS_Vector getNormalVector() const;
+    double getProjectionValueAlongLine(const RS_Vector& coord) const;
     RS_Vector getMiddlePoint() const override;
     RS_Vector getNearestEndpoint(const RS_Vector& coord,
                                  double* dist = nullptr) const override;


### PR DESCRIPTION
I split this into two commits because I didn't want a bunch of style fixes to be mixed in with the actual code changes for the reviewer to parse.  Reviewer, it's best to review each commit individually.

The commit message should explain most of the changes:

    Improve appearance of inside-horizontal dimensions

    * The monolithic method to calculate both inside-horizontal and
      aligned dimensions were broken into two separate methods since they
      became too different.  As a result, some calculations are duplicated,
      so there is still room for improvement.

    * Now, dimension text is never offset from the insertion point for
      inside-horizontal mode.  This would otherwise be a breaking change,
      but inside-horizontal was broken to begin with, so I would rather take
      this oppportunity to fix what I believe to be a bug.

    * getAlignText() was renamed to getInsideHorizontalText() because the
      method returns true when inside-horizontal mode is enabled, not when
      aligned mode is enabled.

    * A new helper function was added for calculating intersections between
      dimensionLine and text boxes.  This de-dupes some code.

    * A new method was added to RS_Line (getProjectionValueAlongLine) to get
      the projected value of a point along the line.  This is only used
      currently for sorting vector solutions of intersections.

Here is a preview of inside-horizontal dimensions BEFORE this PR:

![test_librecad_dimensions_before-2](https://user-images.githubusercontent.com/85151/38120451-ed1b80fe-3396-11e8-97f1-760b36f501f3.png)

and AFTER:

![test_librecad_dimensions_after-2](https://user-images.githubusercontent.com/85151/38120457-f8e3252c-3396-11e8-9239-89c6dae02bb5.png)

I feel that most of the changes are fairly self explanatory, so I will not go into detail.  However, please feel free to ask questions.

Regarding the change to text insertion point, here is an example of the offset insertion point BEFORE this commit:

![test_librecad_dimensions_before-2_middle_of_text](https://user-images.githubusercontent.com/85151/38120640-495bae06-3398-11e8-9535-667836ac43bd.png)

and AFTER:

![test_librecad_dimensions_after-2_middle_of_text](https://user-images.githubusercontent.com/85151/38120643-4fb5b922-3398-11e8-82e5-bfb6320ead8f.png)

Note that the blue dot (reference point) for the dimension text is in the center of the text.  This will always be true after this commit, for inside-horizontal dimensions.

Finally, a comprehensive screencast demonstrating all the angles:

![out](https://user-images.githubusercontent.com/85151/38122628-20ba2980-33a4-11e8-80ca-8300835d8a8a.gif)
