### PR TITLE
fixed length extension lines should scale according to the General Scale

### DIFF
--- a/librecad/src/lib/engine/rs_dimaligned.cpp
+++ b/librecad/src/lib/engine/rs_dimaligned.cpp
@@ -177,7 +177,7 @@ void RS_DimAligned::updateDim(bool autoText) {
 	double extLength = edata.extensionPoint2.distanceTo(data.definitionPoint);
 
     if (getFixedLengthOn()){
-        double dimfxl = getFixedLength();
+        double dimfxl = getFixedLength()*dimscale;
         if (extLength-dimexo > dimfxl)
             dimexo =  extLength - dimfxl;
     }

--- a/librecad/src/lib/engine/rs_dimlinear.cpp
+++ b/librecad/src/lib/engine/rs_dimlinear.cpp
@@ -211,12 +211,12 @@ void RS_DimLinear::updateDim(bool autoText) {
             extAngle2 = edata.extensionPoint2.angleTo(dimP2);
     }
 
-	RS_Vector vDimexe1 = RS_Vector::polar(dimexe, extAngle1);
-	RS_Vector vDimexe2 = RS_Vector::polar(dimexe, extAngle2);
+    RS_Vector vDimexe1 = RS_Vector::polar(dimexe, extAngle1);
+    RS_Vector vDimexe2 = RS_Vector::polar(dimexe, extAngle2);
 
-	RS_Vector vDimexo1, vDimexo2;
-	if (getFixedLengthOn()){
-        double dimfxl = getFixedLength();
+    RS_Vector vDimexo1, vDimexo2;
+    if (getFixedLengthOn()){
+        double dimfxl = getFixedLength()*dimscale;
         double extLength = (edata.extensionPoint1-dimP1).magnitude();
         if (extLength-dimexo > dimfxl)
             vDimexo1.setPolar(extLength - dimfxl, extAngle1);


### PR DESCRIPTION
This was reported by dellus on the forum:

http://forum.librecad.org/Inside-horizontal-dimensions-tp5715827p5715872.html

I'm not *certain* what the correct behavior should be, but this seems
right to me (scaling with General Scale).

Standard general scale of 1:
![2018-04-19-184110_526x457_scrot](https://user-images.githubusercontent.com/85151/39022261-adaa4424-4402-11e8-82d6-cb6c81191947.png)

After setting general scale to 2:
![2018-04-19-184204_531x452_scrot](https://user-images.githubusercontent.com/85151/39022258-ab8d5618-4402-11e8-8905-efc04bd27420.png)