### PR TITLE
SVG export changes/updates

### DIFF
--- a/librecad/src/actions/lc_actionfileexportmakercam.cpp
+++ b/librecad/src/actions/lc_actionfileexportmakercam.cpp
@@ -3,6 +3,7 @@
 ** This file is part of the LibreCAD project, a 2D CAD program
 **
 ** Copyright (C) 2014 Christian Luginbühl (dinkel@pimprecords.com)
+** Copyright (C) 2018 Andrey Yaromenok (ayaromenok@gmail.com)
 **
 **
 ** This program is free software; you can redistribute it and/or modify
@@ -36,7 +37,7 @@
 
 LC_ActionFileExportMakerCam::LC_ActionFileExportMakerCam(RS_EntityContainer& container,
                                                          RS_GraphicView& graphicView)
-    : RS_ActionInterface("Export as MakerCAM SVG...", container, graphicView) {}
+    : RS_ActionInterface("Export as CAM/plain SVG...", container, graphicView) {}
 
 
 void LC_ActionFileExportMakerCam::init(int status) {
@@ -67,7 +68,11 @@ void LC_ActionFileExportMakerCam::trigger() {
                                                                (bool)RS_SETTINGS->readNumEntry("/ExportInvisibleLayers"),
                                                                (bool)RS_SETTINGS->readNumEntry("/ExportConstructionLayers"),
                                                                (bool)RS_SETTINGS->readNumEntry("/WriteBlocksInline"),
-															   (bool)RS_SETTINGS->readNumEntry("/ConvertEllipsesToBeziers"))
+                                                               (bool)RS_SETTINGS->readNumEntry("/ConvertEllipsesToBeziers"),
+                                                               (bool)RS_SETTINGS->readNumEntry("/ExportImages"),
+                                                               (bool)RS_SETTINGS->readNumEntry("/BakeDashDotLines"),
+                                                               (double)RS_SETTINGS->readEntry("/DefaultElementWidth").toDouble(),
+                                                               (double)RS_SETTINGS->readEntry("/DefaultDashLinePatternLength").toDouble())
 														  );
 
                 RS_SETTINGS->endGroup();

--- a/librecad/src/lib/generators/lc_makercamsvg.cpp
+++ b/librecad/src/lib/generators/lc_makercamsvg.cpp
@@ -879,7 +879,7 @@ void LC_MakerCamSVG::writeImage(RS_Image* image)
         xmlWriter->addAttribute("height", lengthXml(image->getImageHeight()));
         xmlWriter->addAttribute("width", lengthXml(image->getImageWidth()));
         xmlWriter->addAttribute("preserveAspectRatio", "none");  //height and width above used
-        xmlWriter->addAttribute("xlink:href", image->getData().file.toStdString());
+        xmlWriter->addAttribute("href", image->getData().file.toStdString(), NAMESPACE_URI_XLINK);
         xmlWriter->closeElement();
     }
 }
@@ -1038,10 +1038,11 @@ std::string LC_MakerCamSVG::getPointSegment(RS_Vector *lastPos, RS_Vector step, 
     //! \todo need to add a option to control this value from export dialog and test on laser engraver
     const double dotSize = 0.2;
     double scaleTo;
-    if (abs(step.x) >= abs(step.y)){
-        scaleTo = dotSize/abs(step.x);
+
+    if (fabs(step.x) >= fabs(step.y)){
+        scaleTo = dotSize/fabs(step.x);
     } else {
-        scaleTo = dotSize/abs(step.y);
+        scaleTo = dotSize/fabs(step.y);
     }
     path += svgPathMoveTo(*lastPos);
     path += svgPathLineTo(*lastPos+step*scaleTo);

--- a/librecad/src/lib/generators/lc_makercamsvg.h
+++ b/librecad/src/lib/generators/lc_makercamsvg.h
@@ -3,6 +3,7 @@
 ** This file is part of the LibreCAD project, a 2D CAD program
 **
 ** Copyright (C) 2014 Christian Luginbühl (dinkel@pimprecords.com)
+** Copyright (C) 2018 Andrey Yaromenok (ayaromenok@gmail.com)
 **
 **
 ** This program is free software; you can redistribute it and/or modify
@@ -59,7 +60,11 @@ public:
                    bool writeInvisibleLayers = true,
                    bool writeConstructionLayers = true,
                    bool writeBlocksInline = false,
-                   bool convertEllipsesToBeziers = false);
+                   bool convertEllipsesToBeziers = false,
+                   bool exportImages = false,
+                   bool convertLineTypes = false,
+                   double defaultElementWidth = 1.0,
+                   double defaultDashLinePatternLength = 10.0);
 
 	~LC_MakerCamSVG() = default;
 
@@ -90,6 +95,7 @@ private:
 
     void writeCubicBeziers(const std::vector<RS_Vector> &control_points, bool is_closed);
     void writeQuadraticBeziers(const std::vector<RS_Vector> &control_points, bool is_closed);
+    void writeImage(RS_Image* image);
 
     std::vector<RS_Vector> calcCubicBezierPoints(const std::vector<RS_Vector> &control_points, bool is_closed);
     std::vector<RS_Vector> calcQuadraticBezierPoints(const std::vector<RS_Vector> &control_points, bool is_closed);
@@ -111,17 +117,26 @@ private:
     std::string svgPathMoveTo(RS_Vector point) const;
     std::string svgPathArc(RS_Arc* arc) const;
     std::string svgPathArc(RS_Vector point, double radius_x, double radius_y, double x_axis_rotation, bool large_arc_flag, bool sweep_flag) const;
+    std::string svgPathAnyLineType(RS_Vector startpoint, RS_Vector endpoint, RS2::LineType type) const;
+    std::string getLinePattern(RS_Vector *lastPos, RS_Vector step, RS2::LineType type, double lineScale) const;
+    std::string getPointSegment(RS_Vector *lastPos, RS_Vector step, double lineScale)const;
+    std::string getLineSegment(RS_Vector *lastPos, RS_Vector step, double lineScale, bool x2 = false)const;
+
 
     RS_Vector calcEllipsePointDerivative(double majorradius, double minorradius, double x_axis_rotation, double angle) const;
 
     static double calcAlpha(double angle);
 
+    std::unique_ptr<LC_XMLWriterInterface> xmlWriter;
+
     bool writeInvisibleLayers;
     bool writeConstructionLayers;
     bool writeBlocksInline;
     bool convertEllipsesToBeziers;
-
-    std::unique_ptr<LC_XMLWriterInterface> xmlWriter;
+    bool exportImages;
+    bool convertLineTypes;
+    double defaultElementWidth;
+    double defaultDashLinePatternLength;
 
     RS_Vector min;
     RS_Vector max;
@@ -133,6 +148,7 @@ private:
      * @brief lengthFactor factor from current unit to svg length units
      */
     double lengthFactor;
+
 };
 
 #endif

--- a/librecad/src/ui/forms/qg_dlgoptionsmakercam.cpp
+++ b/librecad/src/ui/forms/qg_dlgoptionsmakercam.cpp
@@ -3,6 +3,7 @@
 ** This file is part of the LibreCAD project, a 2D CAD program
 **
 ** Copyright (C) 2014 Christian Luginbühl (dinkel@pimprecords.com)
+** Copyright (C) 2018 Andrey Yaromenok (ayaromenok@gmail.com)
 **
 **
 ** This program is free software; you can redistribute it and/or modify
@@ -29,6 +30,13 @@ QG_DlgOptionsMakerCam::QG_DlgOptionsMakerCam(QWidget* parent, bool modal, Qt::Wi
 {
     setModal(modal);
     setupUi(this);
+    this->gbLayers->setToolTip(tr("MakerCAM as of November 2014 does not hide SVG content \nthat has been set invisibe (\"display: none\" or \"visibility: hidden\")."));
+    this->gbBlocks->setToolTip(tr("MakerCAM as of November 2014 cannot correctly deal with blocks,\nbecause it does not take into account the reference point in the <use>."));
+    this->gbEllipses->setToolTip(tr("MakerCAM as of March 2015 cannot display ellipses and ellipse arcs correctly, \nwhen they are created using the <ellipse> tag  with a rotation in \nthe <transform> attribute or as <path> using elliptic arc segments."));
+    this->gbImages->setToolTip(tr("Exported images can be useful in SVG editors (Inkscape, etc), \nbut avoided in some CAM's."));
+    this->gbDashLines->setToolTip(tr("Many CAM's(MakerCAM, EleskCAM, LaserWeb) ignore dashed/doted line style, \nwhich can be useful in lasercut of plywood or for papercraft. "));
+    this->dSpinBoxDefaultElementWidth->setToolTip(tr("Default width of elements can affect some CAM's/SVG Editors, \nbut ignored by other"));
+    this->dSpinBoxDashLinePatternLength->setToolTip(tr("Length of line pattern related to zoom, \nso default step value required for baking"));
 
     loadSettings();
 }
@@ -57,13 +65,21 @@ void QG_DlgOptionsMakerCam::loadSettings() {
     updateCheckbox(checkConstructionLayers, "ExportConstructionLayers", 0);
     updateCheckbox(checkBlocksInline, "WriteBlocksInline", 1);
     updateCheckbox(checkEllipsesToBeziers, "ConvertEllipsesToBeziers", 1);
-
+    updateCheckbox(checkImages, "ExportImages", 0);
+    updateCheckbox(checkDashDotLines, "BakeDashDotLines", 0);
+    updateDoubleSpinBox(dSpinBoxDefaultElementWidth, "DefaultElementWidth", 1.0);
+    updateDoubleSpinBox(dSpinBoxDashLinePatternLength, "DefaultDashLinePatternLength", 2.5);
     RS_SETTINGS->endGroup();
 }
 
 void QG_DlgOptionsMakerCam::updateCheckbox(QCheckBox* checkbox, QString name, int defaultValue) {
 
     checkbox->setChecked(RS_SETTINGS->readNumEntry("/" + name, defaultValue) ? true : false);
+}
+
+void QG_DlgOptionsMakerCam::updateDoubleSpinBox(QDoubleSpinBox* dSpinBox, QString name, double defaultValue) {
+
+    dSpinBox->setValue(RS_SETTINGS->readEntry("/" + name, QString::number(defaultValue)).toDouble());
 }
 
 void QG_DlgOptionsMakerCam::saveSettings() {
@@ -74,6 +90,10 @@ void QG_DlgOptionsMakerCam::saveSettings() {
     saveBoolean("ExportConstructionLayers", checkConstructionLayers);
     saveBoolean("WriteBlocksInline", checkBlocksInline);
     saveBoolean("ConvertEllipsesToBeziers", checkEllipsesToBeziers);
+    saveBoolean("ExportImages", checkImages);
+    saveBoolean("BakeDashDotLines", checkDashDotLines);
+    saveDouble("DefaultElementWidth", dSpinBoxDefaultElementWidth);
+    saveDouble("DefaultDashLinePatternLength", dSpinBoxDashLinePatternLength);
 
     RS_SETTINGS->endGroup();
 }
@@ -81,4 +101,8 @@ void QG_DlgOptionsMakerCam::saveSettings() {
 void QG_DlgOptionsMakerCam::saveBoolean(QString name, QCheckBox* checkbox) {
 
     RS_SETTINGS->writeEntry("/" + name, checkbox->isChecked() ? 1 : 0);
+}
+
+void QG_DlgOptionsMakerCam::saveDouble(QString name, QDoubleSpinBox* dSpinBox) {
+    RS_SETTINGS->writeEntry("/" + name, dSpinBox->value());
 }

--- a/librecad/src/ui/forms/qg_dlgoptionsmakercam.h
+++ b/librecad/src/ui/forms/qg_dlgoptionsmakercam.h
@@ -44,9 +44,11 @@ protected slots:
 private:
     void loadSettings();
     void updateCheckbox(QCheckBox* checkbox, QString name, int defaultValue);
+    void updateDoubleSpinBox(QDoubleSpinBox* dSpinBox, QString name, double defaultValue);
 
     void saveSettings();
     void saveBoolean(QString name, QCheckBox* checkbox);
+    void saveDouble(QString name, QDoubleSpinBox* dSpinBox);
 };
 
 #endif

--- a/librecad/src/ui/forms/qg_dlgoptionsmakercam.ui
+++ b/librecad/src/ui/forms/qg_dlgoptionsmakercam.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>490</height>
+    <height>522</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>500</width>
-    <height>490</height>
+    <height>522</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -51,6 +51,12 @@
           </item>
           <item>
            <widget class="QDoubleSpinBox" name="dSpinBoxDefaultElementWidth">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
             <property name="singleStep">
              <double>0.010000000000000</double>
             </property>
@@ -156,7 +162,7 @@
           <item>
            <widget class="QLabel" name="lbDashLinePatternLength">
             <property name="text">
-             <string>length of the pattern in mm</string>
+             <string>Length of the pattern, mm</string>
             </property>
            </widget>
           </item>

--- a/librecad/src/ui/forms/qg_dlgoptionsmakercam.ui
+++ b/librecad/src/ui/forms/qg_dlgoptionsmakercam.ui
@@ -1,24 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-This file is part of the LibreCAD project, a 2D CAD program
-
-Copyright (C) 2014 Christian Luginbühl (dinkel@pimprecords.com)
-
-
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
--->
 <ui version="4.0">
  <class>QG_DlgOptionsMakerCam</class>
  <widget class="QDialog" name="QG_DlgOptionsMakerCam">
@@ -27,24 +7,33 @@ with this program; if not, write to the Free Software Foundation, Inc.,
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>400</height>
+    <height>490</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>500</width>
-    <height>400</height>
+    <height>490</height>
    </size>
   </property>
   <property name="windowTitle">
-   <string>Export as MakerCAM SVG</string>
+   <string>Export as CAM/plain SVG</string>
   </property>
   <layout class="QVBoxLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>11</number>
+   </property>
+   <property name="topMargin">
+    <number>11</number>
+   </property>
+   <property name="rightMargin">
+    <number>11</number>
+   </property>
+   <property name="bottomMargin">
     <number>11</number>
    </property>
    <item alignment="Qt::AlignTop">
-    <widget class="QGroupBox">
+    <widget class="QGroupBox" name="gbLayers">
      <property name="title">
       <string>Layers</string>
      </property>
@@ -52,20 +41,25 @@ with this program; if not, write to the Free Software Foundation, Inc.,
       <item>
        <layout class="QVBoxLayout">
         <item>
-         <widget class="QLabel" name="labelLayers">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>MakerCAM as of November 2014 does not hide SVG content that has been set invisibe (&quot;display: none;&quot; or &quot;visibility: hidden;&quot;).</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
+         <layout class="QHBoxLayout" name="hLayoutDefaultElementWidth">
+          <item>
+           <widget class="QLabel" name="lbDefaultElementWidth">
+            <property name="text">
+             <string>Default width of elements, mm</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QDoubleSpinBox" name="dSpinBoxDefaultElementWidth">
+            <property name="singleStep">
+             <double>0.010000000000000</double>
+            </property>
+            <property name="value">
+             <double>1.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item>
          <widget class="QCheckBox" name="checkInvisibleLayers">
@@ -87,29 +81,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
     </widget>
    </item>
    <item alignment="Qt::AlignTop">
-    <widget class="QGroupBox">
+    <widget class="QGroupBox" name="gbBlocks">
      <property name="title">
       <string>Blocks</string>
      </property>
      <layout class="QHBoxLayout">
       <item>
        <layout class="QVBoxLayout">
-        <item>
-         <widget class="QLabel" name="labelBlocks">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>MakerCAM as of November 2014 cannot correctly deal with blocks, because it does not take into account the reference point in the &lt;use&gt;.</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
         <item>
          <widget class="QCheckBox" name="checkBlocksInline">
           <property name="text">
@@ -126,7 +104,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
     </widget>
    </item>
    <item alignment="Qt::AlignTop">
-    <widget class="QGroupBox">
+    <widget class="QGroupBox" name="gbEllipses">
      <property name="title">
       <string>Ellipses / Ellipse arcs</string>
      </property>
@@ -134,25 +112,73 @@ with this program; if not, write to the Free Software Foundation, Inc.,
       <item>
        <layout class="QVBoxLayout">
         <item>
-         <widget class="QLabel" name="labelElipses">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>MakerCAM as of March 2015 cannot display ellipses and ellipse arcs correctly, when they are created using the &lt;ellipse&gt; tag  with a rotation in the &quot;transform&quot; attribute or as &lt;path&gt; using elliptic arc segments.</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
          <widget class="QCheckBox" name="checkEllipsesToBeziers">
           <property name="text">
            <string>Approximate ellipses and ellipse arcs with cubic béziers</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignTop">
+    <widget class="QGroupBox" name="gbImages">
+     <property name="title">
+      <string>Images</string>
+     </property>
+     <layout class="QHBoxLayout">
+      <item>
+       <layout class="QVBoxLayout">
+        <item>
+         <widget class="QCheckBox" name="checkImages">
+          <property name="text">
+           <string>Raster Image export</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignTop">
+    <widget class="QGroupBox" name="gbDashLines">
+     <property name="title">
+      <string>Dash/Dot Lines</string>
+     </property>
+     <layout class="QHBoxLayout">
+      <item>
+       <layout class="QVBoxLayout">
+        <item>
+         <layout class="QHBoxLayout" name="hLayoutDashLinePatternLength">
+          <item>
+           <widget class="QLabel" name="lbDashLinePatternLength">
+            <property name="text">
+             <string>length of the pattern in mm</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QDoubleSpinBox" name="dSpinBoxDashLinePatternLength">
+            <property name="maximum">
+             <double>999.990000000000009</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>10.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="checkDashDotLines">
+          <property name="text">
+           <string>Bake dash/dot lines to SVG path</string>
           </property>
          </widget>
         </item>

--- a/librecad/src/ui/lc_actionfactory.cpp
+++ b/librecad/src/ui/lc_actionfactory.cpp
@@ -1020,7 +1020,7 @@ void LC_ActionFactory::fillActionContainer(QMap<QString, QAction*>& a_map, LC_Ac
 
     // <[~ Misc ~]>
 
-    action = new QAction(tr("Export as &MakerCAM SVG..."), agm->file);
+    action = new QAction(tr("Export as CA&M/plain SVG..."), agm->file);
     connect(action, SIGNAL(triggered()), action_handler, SLOT(slotFileExportMakerCam()));
     action->setObjectName("FileExportMakerCam");
     a_map["FileExportMakerCam"] = action;


### PR DESCRIPTION
 - renamed to Export as CAM/plain SVG;
 - MakerCAM option description, which originally was implemented as QLabel, replaced with ToolTips - to make it more similar to other UI/save space in dialog;
 - all options by default is the same, as was before;
 - added option to set line width (it was hardcoded to 1mm, so default value is the same)
 - added export of image and corresponding option to dialog (absolute path used)
 - added baking of lines of all supported types (dot, dash, dashdot, etc) to used it in CAM's

related forum thread - http://forum.librecad.org/SVG-Import-Export-td5715881.html