### PR TITLE
fix build with Qt 5.11

### DIFF
--- a/librecad/src/ui/forms/qg_commandwidget.cpp
+++ b/librecad/src/ui/forms/qg_commandwidget.cpp
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 
+#include <QAction>
 #include <QKeyEvent>
 #include <QFileDialog>
 #include <QSettings>

--- a/librecad/src/ui/generic/colorwizard.cpp
+++ b/librecad/src/ui/generic/colorwizard.cpp
@@ -27,6 +27,7 @@
 #include "colorwizard.h"
 #include "ui_colorwizard.h"
 
+#include <QAction>
 #include <QColorDialog>
 #include <QLineEdit>
 #include <QListWidget>

--- a/librecad/src/ui/generic/widgetcreator.cpp
+++ b/librecad/src/ui/generic/widgetcreator.cpp
@@ -27,6 +27,8 @@
 #include "widgetcreator.h"
 #include "ui_widgetcreator.h"
 
+#include <QAction>
+#include <QActionGroup>
 #include <QSettings>
 #include <QLineEdit>
 #include <QPushButton>


### PR DESCRIPTION
The new Qt removed some implicit inclusions of headers. To avoid build
errors, add explicit includes of those we use in the sources.