### PR TITLE
Possible fix: import block to active layer

### DIFF
--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -509,6 +509,9 @@ void RS_Modification::paste(const RS_PasteData& data, RS_Graphic* source) {
     // default insertion point for container
     RS_Vector ip = data.insertionPoint;
 
+    // remember active layer before inserting absent layers
+    RS_Layer *l = graphic->getActiveLayer();
+
     // insert absent layers from source to graphic
     if (!pasteLayers(source)) {
         RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::paste: unable to copy due to absence of needed layers");
@@ -516,6 +519,7 @@ void RS_Modification::paste(const RS_PasteData& data, RS_Graphic* source) {
     }
 
     // select the same layer in graphic as in source
+    /*
     auto a_layer = source->getActiveLayer();
     if (!a_layer)
     {
@@ -524,6 +528,7 @@ void RS_Modification::paste(const RS_PasteData& data, RS_Graphic* source) {
     }
     QString ln = a_layer->getName();
     RS_Layer* l = graphic->getLayerList()->find(ln);
+    */
     if (!l) {
         RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::paste: unable to select layer to paste in");
         return;


### PR DESCRIPTION
There is an issue for me, when importing a block from file or library it is almost always inserted to layer 0 no matter what layer is selected. For example, in LibreCAD 2.1.3 that wasn't the case. In this pull request I try to fix that issue. But there is a block of code which tries to 'select the same layer in graphic as in source' (I just commented it out). I don't really understand why it is needed. Please feel free to reject this pull request if it breaks anything vital.