### PR TITLE
Fix: Factor value was ignored on block import

### DIFF
--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -489,7 +489,7 @@ void RS_Modification::paste(const RS_PasteData& data, RS_Graphic* source) {
     }
 
     // adjust scaling factor for units conversion in case of clipboard paste
-    double factor = (RS_TOLERANCE < data.factor) ? data.factor : 1.0;
+    double factor = (RS_TOLERANCE < fabs(data.factor)) ? data.factor : 1.0;
     // scale factor as vector
     RS_Vector vfactor = RS_Vector(factor, factor);
     // select source for paste

--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -489,7 +489,7 @@ void RS_Modification::paste(const RS_PasteData& data, RS_Graphic* source) {
     }
 
     // adjust scaling factor for units conversion in case of clipboard paste
-    double factor = 1.0;
+    double factor = data.factor;
     // scale factor as vector
     RS_Vector vfactor = RS_Vector(factor, factor);
     // select source for paste

--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -489,7 +489,7 @@ void RS_Modification::paste(const RS_PasteData& data, RS_Graphic* source) {
     }
 
     // adjust scaling factor for units conversion in case of clipboard paste
-    double factor = data.factor;
+    double factor = (data.factor) ? data.factor : 1.0;
     // scale factor as vector
     RS_Vector vfactor = RS_Vector(factor, factor);
     // select source for paste

--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -489,7 +489,7 @@ void RS_Modification::paste(const RS_PasteData& data, RS_Graphic* source) {
     }
 
     // adjust scaling factor for units conversion in case of clipboard paste
-    double factor = (data.factor) ? data.factor : 1.0;
+    double factor = (RS_TOLERANCE < data.factor) ? data.factor : 1.0;
     // scale factor as vector
     RS_Vector vfactor = RS_Vector(factor, factor);
     // select source for paste


### PR DESCRIPTION
This is reopening of #1029 pull request with check for user inputs 0 as factor value. Substituting 0 with 1.0 for preventing empty blocks inserts. 