### PR TITLE
Fixed 2 segfaults causes

### DIFF
--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -1906,6 +1906,8 @@ void QC_ApplicationWindow::slotFileClosing(QC_MDIWindow* win)
     openedFiles.removeAll(win->getDocument()->getFilename());
 
     activedMdiSubWindow = nullptr;
+    actionHandler->set_view(nullptr);
+    actionHandler->set_document(nullptr);
 }
 
 
@@ -2370,6 +2372,14 @@ void QC_ApplicationWindow::slotOptionsGeneral() {
  * Menu File -> import -> importBlock
  */
 void QC_ApplicationWindow::slotImportBlock() {
+
+    if (getMDIWindow() == nullptr) {
+        RS_DEBUG->print(RS_Debug::D_WARNING,
+                "QC_ApplicationWindow::slotImportBlock: "
+                "no window opened");
+        return;
+    }
+
     QG_FileDialog dlg(this);
     RS2::FormatType type = RS2::FormatDXFRW;
     QString dxfPath = dlg.getOpenFile(&type);

--- a/librecad/src/ui/qg_actionhandler.cpp
+++ b/librecad/src/ui/qg_actionhandler.cpp
@@ -218,6 +218,9 @@ RS_ActionInterface* QG_ActionHandler::setCurrentAction(RS2::ActionType id) {
     RS_ActionInterface* a = NULL;
 //    view->killAllActions();
 
+    RS_DEBUG->print("QC_ActionHandler::setCurrentAction: "
+            "view = %p, document = %p", view, document);
+
     // only global options are allowed without a document:
     if (view==NULL || document==NULL) {
         RS_DEBUG->print(RS_Debug::D_WARNING,


### PR DESCRIPTION
When all MDI windows are closed there are a bunch of document-dependent actions available through **File** menu (which obviously should be disabled, but they are not). Most of those actions don't cause any segfaults. But two of them do:

1. **File->Import->Block**
2. **File->Export->Export as CAM/plain SVG**

The first is pretty easy to fix by checking for MDI window in `QC_ApplicationWindow::slotImportBlock()` as most of the similar code does.

The second is trickier and is rooted down to `QC_ActionHandler::setCurrentAction()`. Although inside that method there is a check for if _view_ is NULL or if _document_ is NULL, neither _view_ nor _document_ is set to NULL after closing document window.

Fix for the second segfault cause probably should be thoroughly tested for any side effects, though I didn't encountered any during my tests.