### PR TITLE
Fix a repeated typo in comments

### DIFF
--- a/librecad/src/lib/engine/rs_units.cpp
+++ b/librecad/src/lib/engine/rs_units.cpp
@@ -390,7 +390,7 @@ RS_Vector RS_Units::convert(const RS_Vector& val, RS2::Unit src, RS2::Unit dest)
  *
  * @param length The length in the current unit of the drawing.
  * @param format Format of the string.
- * @param prec Precisision of the value (e.g. 0.001 or 1/128 = 0.0078125)
+ * @param prec Precision of the value (e.g. 0.001 or 1/128 = 0.0078125)
  & @param showUnit Append unit to the value.
  */
 QString RS_Units::formatLinear(double length, RS2::Unit unit,
@@ -446,7 +446,7 @@ QString RS_Units::formatLinear(double length, RS2::Unit unit,
  * Formats the given length in scientific format (e.g. 2.5E7).
  *
  * @param length The length in the current unit of the drawing.
- * @param prec Precisision of the value (e.g. 0.001 or 1/128 = 0.0078125)
+ * @param prec Precision of the value (e.g. 0.001 or 1/128 = 0.0078125)
  & @param showUnit Append unit to the value.
  */
 QString RS_Units::formatScientific(double length, RS2::Unit unit,
@@ -464,7 +464,7 @@ QString RS_Units::formatScientific(double length, RS2::Unit unit,
  * Formats the given length in decimal (normal) format (e.g. 2.5).
  *
  * @param length The length in the current unit of the drawing.
- * @param prec Precisision of the value (e.g. 0.001)
+ * @param prec Precision of the value (e.g. 0.001)
  & @param showUnit Append unit to the value.
  */
 QString RS_Units::formatDecimal(double length, RS2::Unit unit,
@@ -482,7 +482,7 @@ QString RS_Units::formatDecimal(double length, RS2::Unit unit,
  * Formats the given length in engineering format (e.g. 5' 4.5").
  *
  * @param length The length in the current unit of the drawing.
- * @param prec Precisision of the value (e.g. 0.001 or 1/128 = 0.0078125)
+ * @param prec Precision of the value (e.g. 0.001 or 1/128 = 0.0078125)
  & @param showUnit Append unit to the value.
  */
 QString RS_Units::formatEngineering(double length, RS2::Unit /*unit*/,
@@ -519,7 +519,7 @@ QString RS_Units::formatEngineering(double length, RS2::Unit /*unit*/,
  * Formats the given length in architectural format (e.g. 5' 4 1/2").
  *
  * @param length The length in the current unit of the drawing.
- * @param prec Precisision of the value (e.g. 0.001 or 1/128 = 0.0078125)
+ * @param prec Precision of the value (e.g. 0.001 or 1/128 = 0.0078125)
  & @param showUnit Append unit to the value.
  */
 QString RS_Units::formatArchitectural(double length, RS2::Unit /*unit*/,
@@ -553,7 +553,7 @@ QString RS_Units::formatArchitectural(double length, RS2::Unit /*unit*/,
  * using DIN 406 (e.g. 1.12⁵).
  *
  * @param length The length in the current unit of the drawing.
- * @param prec Precisision of the value (e.g. 0.001)
+ * @param prec Precision of the value (e.g. 0.001)
  & @param showUnit Append unit to the value.
  */
 QString RS_Units::formatArchitecturalMetric(double length, RS2::Unit unit,
@@ -597,7 +597,7 @@ QString RS_Units::formatArchitecturalMetric(double length, RS2::Unit unit,
  *
  * @param length The length in the current unit of the drawing.
  * @param unit Should be inches.
- * @param prec Precisision of the value (e.g. 0.001 or 1/128 = 0.0078125)
+ * @param prec Precision of the value (e.g. 0.001 or 1/128 = 0.0078125)
  & @param showUnit Append unit to the value.
  */
 QString RS_Units::formatFractional(double length, RS2::Unit /*unit*/,
@@ -664,7 +664,7 @@ QString RS_Units::formatFractional(double length, RS2::Unit /*unit*/,
  *
  * @param angle The angle (always in rad).
  * @param format Format of the string.
- * @param prec Precisision of the value (e.g. 0.001 or 1/128 = 0.0078125)
+ * @param prec Precision of the value (e.g. 0.001 or 1/128 = 0.0078125)
  *
  * @ret String with the formatted angle.
  */


### PR DESCRIPTION
Fix a minor misspelling in the comments that was
(probably) picked up by copy-and-paste and repeated.