### PR TITLE
Respect paper scale with 'fixed' checked. Issues #592, #605, #705.

### DIFF
--- a/librecad/src/actions/rs_actionprintpreview.cpp
+++ b/librecad/src/actions/rs_actionprintpreview.cpp
@@ -35,6 +35,7 @@
 #include "rs_coordinateevent.h"
 #include "rs_math.h"
 #include "rs_preview.h"
+#include "rs_settings.h"
 
 struct RS_ActionPrintPreview::Points {
 	RS_Vector v1;
@@ -55,6 +56,10 @@ RS_ActionPrintPreview::RS_ActionPrintPreview(RS_EntityContainer& container,
 {
     showOptions();
 	actionType=RS2::ActionFilePrintPreview;
+    RS_SETTINGS->beginGroup("/PrintPreview");
+    bool fixed = (RS_SETTINGS->readNumEntry("/PrintScaleFixed", 0) != 0);
+    RS_SETTINGS->endGroup();
+    setPaperScaleFixed(fixed);
 }
 
 RS_ActionPrintPreview::~RS_ActionPrintPreview()=default;

--- a/librecad/src/lib/engine/rs_graphic.cpp
+++ b/librecad/src/lib/engine/rs_graphic.cpp
@@ -920,6 +920,14 @@ bool RS_Graphic::fitToPage() {
     return ret;
 }
 
+
+bool RS_Graphic::isBiggerThanPaper() {
+    RS_Vector ps = getPaperSize();
+    RS_Vector s = getSize() * getPaperScale();
+    return !s.isInWindow(RS_Vector(0.0, 0.0), ps);
+}
+
+
 void RS_Graphic::addEntity(RS_Entity* entity)
 {
     RS_EntityContainer::addEntity(entity);

--- a/librecad/src/lib/engine/rs_graphic.h
+++ b/librecad/src/lib/engine/rs_graphic.h
@@ -270,6 +270,8 @@ public:
     void centerToPage();
     bool fitToPage();
 
+    bool isBiggerThanPaper();
+
     /**
      * @retval true The document has been modified since it was last saved.
      * @retval false The document has not been modified since it was last saved.

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -2187,7 +2187,24 @@ void QC_ApplicationWindow::slotFilePrintPreview(bool on)
                 }
 
                 if(graphic){
+                    bool bigger = graphic->isBiggerThanPaper();
+                    bool fixed = graphic->getPaperScaleFixed();
+
                     graphic->fitToPage();
+
+                    // Calling zoomPage() after fitToPage() always fits
+                    // preview paper in preview window. The only reason not
+                    // to call zoomPage() is when drawing is bigger than paper,
+                    // plus it is fixed. In that case, not calling zoomPage()
+                    // prevents displaying empty paper (when drawing is actually
+                    // outside the paper and the preview window) and displays
+                    // full drawing and smaller paper inside it.
+                    if (bigger && fixed) {
+                        RS_DEBUG->print("%s: don't call zoomPage()", __func__);
+                    } else {
+                        RS_DEBUG->print("%s: call zoomPage()", __func__);
+                        gv->zoomPage();
+                    }
                 }
                 w->getGraphicView()->getDefaultAction()->showOptions();
 


### PR DESCRIPTION
This pull request attempts to fix #592, #605, #705.
Also it tries to make paper always fully visible when switching to preview view thus making it more consistent with any drawings.

### Test cases I checked

#### Test drawings

All drawings have paper size A3, landscape.

1. Paper scale is not set, drawn a rectangle which is less than paper.
2. Paper scale is not set, drawn a rectangle which is bigger than paper.
3. Paper scale is 1:10 saved to drawing, drawn a rectangle which is less than paper.
4. Paper scale is 1:10 saved to drawing, drawn a rectangle which is bigger than paper.
5. Paper scale is 10:1 saved to drawing, drawn a rectangle which is less than paper.
6. Paper scale is 10:1 saved to drawing, drawn a rectangle which is bigger than paper.

#### 'fixed' flag is not set

All drawings display as expected, paper always fits preview window. With drawings which are bigger than paper (2, 4, 6), full drawing fits in preview window with smaller paper inside it.

#### 'fixed' flag is set

All drawings display as expected, scale always correspond to what is saved in drawings (for 3, 4, 5, 6) or 1:1 if not saved in drawings (for 1, 2). Paper and drawings are always fit to preview window.