### PR TITLE
Fixed segfault cause of #1048

### DIFF
--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -2500,7 +2500,12 @@ bool QC_ApplicationWindow::queryExit(bool force) {
         }
     }
 
-    if (succ) {storeSettings();}
+    if (succ) {
+        storeSettings();
+    } else {
+        QMdiSubWindow* subWindow=mdiAreaCAD->currentSubWindow();
+        appWindow->slotWindowActivated(subWindow);
+    }
 
     RS_DEBUG->print("QC_ApplicationWindow::queryExit(): OK");
 


### PR DESCRIPTION
The segfault appeared as side effect of #1032. During my search for causes I found out that after steps described in #1048, when the 'Closing Drawing' dialog was canceled, the MDI subwindow was not activated. Therefore, **actionHandler**'s **view** and **document** wasn't properly set (they were NULL) causing the segfault. I found a piece of code probably fixing some similar issue:

https://github.com/LibreCAD/LibreCAD/blob/8604f171ee380f294102da6154adf77ab754d403/librecad/src/main/qc_dialogfactory.cpp#L126-L128

and added it to QC_ApplicationWindow::queryExit(). Segfault has gone.