### PR TITLE
setup: don't require the user to agree to GPL to complete setup.

### DIFF
--- a/scripts/postprocess-windows/nsis-5.4.nsi
+++ b/scripts/postprocess-windows/nsis-5.4.nsi
@@ -24,6 +24,10 @@
 
   !define UNINSTKEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
 
+  ; GPL is not an EULA, no need to agree to it.
+  !define MUI_LICENSEPAGE_BUTTON $(^NextBtn)
+  !define MUI_LICENSEPAGE_TEXT_BOTTOM "You are now aware of your rights. Click Next to continue."
+
 ;--------------------------------
 ;General
 


### PR DESCRIPTION
As @foone complains on twitter often enough, this should not require
agreement for use since GPL is not an EULA.

The definitions are inspired from the similar NSIS setup file from VLC.