### PR TITLE
Multi-selection in Layer List and Block List

### DIFF
--- a/librecad/src/actions/lc_actionlayerstoggleconstruction.cpp
+++ b/librecad/src/actions/lc_actionlayerstoggleconstruction.cpp
@@ -52,20 +52,21 @@ LC_ActionLayersToggleConstruction::LC_ActionLayersToggleConstruction(
 void LC_ActionLayersToggleConstruction::trigger() {
     RS_DEBUG->print("toggle layer construction");
     if (graphic) {
-        if (a_layer) {
+        RS_LayerList* ll = graphic->getLayerList();
+        unsigned cnt = 0;
+        // toggle selected layers
+        for (auto layer: *ll) {
+            if (!layer) continue;
+            if (!layer->isVisibleInLayerList()) continue;
+            if (!layer->isSelectedInLayerList()) continue;
+            graphic->toggleLayerConstruction(layer);
+            deselectEntities(layer);
+            cnt++;
+        }
+        // if there wasn't selected layers, toggle active layer
+        if (!cnt) {
             graphic->toggleLayerConstruction(a_layer);
-
-            // deselect entities on locked layer:
-			for(auto e: *container){
-                if (e && e->isVisible() && e->getLayer()==a_layer) {
-                    if (graphicView) {
-                        graphicView->deleteEntity(e);
-                    }
-                    if (graphicView) {
-                        graphicView->drawEntity(e);
-                    }
-                }
-            }
+            deselectEntities(a_layer);
         }
     }
     finish(false);
@@ -76,5 +77,25 @@ void LC_ActionLayersToggleConstruction::init(int status) {
     RS_ActionInterface::init(status);
     trigger();
 }
+
+
+void LC_ActionLayersToggleConstruction::deselectEntities(RS_Layer* layer)
+{
+    if (!layer) return;
+
+    for(auto e: *container){
+        if (e && e->isVisible() && e->getLayer() == layer) {
+
+            if (graphicView) {
+                graphicView->deleteEntity(e);
+            }
+
+            if (graphicView) {
+                graphicView->drawEntity(e);
+            }
+        }
+    }
+}
+
 
 // EOF

--- a/librecad/src/actions/lc_actionlayerstoggleconstruction.h
+++ b/librecad/src/actions/lc_actionlayerstoggleconstruction.h
@@ -51,6 +51,8 @@ public:
 protected:
     RS_Layer* a_layer;
 
+private:
+    void deselectEntities(RS_Layer* layer);
 };
 
 #endif

--- a/librecad/src/actions/rs_actionblockstoggleview.cpp
+++ b/librecad/src/actions/rs_actionblockstoggleview.cpp
@@ -43,7 +43,7 @@ RS_ActionBlocksToggleView::RS_ActionBlocksToggleView(
 
 void RS_ActionBlocksToggleView::trigger() {
     RS_DEBUG->print("toggle block");
-	if (graphic) {
+    if (graphic) {
         RS_BlockList* bl = graphic->getBlockList();
         unsigned cnt = 0;
         // toggle selected blocks
@@ -59,7 +59,7 @@ void RS_ActionBlocksToggleView::trigger() {
             graphic->toggleBlock(graphic->getActiveBlock());
         }
     }
-        graphicView->redraw(RS2::RedrawDrawing);
+    graphicView->redraw(RS2::RedrawDrawing);
 
     finish(false);
 }

--- a/librecad/src/actions/rs_actionblockstoggleview.cpp
+++ b/librecad/src/actions/rs_actionblockstoggleview.cpp
@@ -29,6 +29,7 @@
 #include <QAction>
 #include "rs_graphicview.h"
 #include "rs_graphic.h"
+#include "rs_block.h"
 #include "rs_debug.h"
 
 
@@ -43,8 +44,20 @@ RS_ActionBlocksToggleView::RS_ActionBlocksToggleView(
 void RS_ActionBlocksToggleView::trigger() {
     RS_DEBUG->print("toggle block");
 	if (graphic) {
-        RS_Block* block = graphic->getActiveBlock();
-        graphic->toggleBlock(block);
+        RS_BlockList* bl = graphic->getBlockList();
+        unsigned cnt = 0;
+        // toggle selected blocks
+        for (auto block: *bl) {
+            if (!block) continue;
+            if (!block->isVisibleInBlockList()) continue;
+            if (!block->isSelectedInBlockList()) continue;
+            graphic->toggleBlock(block);
+            cnt++;
+        }
+        // if there wasn't selected blocks, toggle active block
+        if (!cnt) {
+            graphic->toggleBlock(graphic->getActiveBlock());
+        }
     }
         graphicView->redraw(RS2::RedrawDrawing);
 

--- a/librecad/src/actions/rs_actionlayersremove.cpp
+++ b/librecad/src/actions/rs_actionlayersremove.cpp
@@ -41,13 +41,18 @@ void RS_ActionLayersRemove::trigger() {
     RS_DEBUG->print("RS_ActionLayersRemove::trigger");
 
     if (graphic) {
-        RS_Layer* layer =
-            RS_DIALOGFACTORY->requestLayerRemovalDialog(graphic->getLayerList());
+        RS_LayerList *ll = graphic->getLayerList();
+        QStringList names =
+            RS_DIALOGFACTORY->requestSelectedLayersRemovalDialog(ll);
 
-        // Now remove the layer from the layer list:
-		graphic->removeLayer(layer);
-
-		graphic->getLayerList()->getLayerWitget()->slotUpdateLayerList();
+        if (!names.isEmpty()) {
+            for (auto name: names) {
+                graphic->removeLayer(ll->find(name));
+            }
+            graphic->updateInserts();
+            container->calculateBorders();
+            graphic->getLayerList()->getLayerWitget()->slotUpdateLayerList();
+        }
     }
     finish(false);
     RS_DIALOGFACTORY->updateSelectionWidget(container->countSelected(),container->totalSelectedLength());

--- a/librecad/src/actions/rs_actionlayerstogglelock.cpp
+++ b/librecad/src/actions/rs_actionlayerstogglelock.cpp
@@ -45,28 +45,22 @@ RS_ActionLayersToggleLock::RS_ActionLayersToggleLock(
 void RS_ActionLayersToggleLock::trigger() {
     RS_DEBUG->print("toggle layer");
     if (graphic) {
-        if (a_layer) {
-            graphic->toggleLayerLock(a_layer);
-
-            // deselect entities on locked layer:
-            if (a_layer->isLocked()) {
-				for(auto e: *container){
-                    if (e && e->isVisible() && e->getLayer()==a_layer) {
-
-                        if (graphicView) {
-                            graphicView->deleteEntity(e);
-                        }
-
-                        e->setSelected(false);
-
-                        if (graphicView) {
-                            graphicView->drawEntity(e);
-                        }
-                    }
-                }
-            }
+        RS_LayerList* ll = graphic->getLayerList();
+        unsigned cnt = 0;
+        // toggle selected layers
+        for (auto layer: *ll) {
+            if (!layer) continue;
+            if (!layer->isVisibleInLayerList()) continue;
+            if (!layer->isSelectedInLayerList()) continue;
+            graphic->toggleLayerLock(layer);
+            deselectEntitiesOnLockedLayer(layer);
+            cnt++;
         }
-
+        // if there wasn't selected layers, toggle active layer
+        if (!cnt) {
+            graphic->toggleLayerLock(a_layer);
+            deselectEntitiesOnLockedLayer(a_layer);
+        }
     }
     finish(false);
 }
@@ -75,5 +69,27 @@ void RS_ActionLayersToggleLock::init(int status) {
     RS_ActionInterface::init(status);
     trigger();
 }
+
+void RS_ActionLayersToggleLock::deselectEntitiesOnLockedLayer(RS_Layer* layer)
+{
+    if (!layer) return;
+    if (!layer->isLocked()) return;
+
+    for(auto e: *container){
+        if (e && e->isVisible() && e->getLayer() == layer) {
+
+            if (graphicView) {
+                graphicView->deleteEntity(e);
+            }
+
+            e->setSelected(false);
+
+            if (graphicView) {
+                graphicView->drawEntity(e);
+            }
+        }
+    }
+}
+
 
 // EOF

--- a/librecad/src/actions/rs_actionlayerstogglelock.h
+++ b/librecad/src/actions/rs_actionlayerstogglelock.h
@@ -50,6 +50,8 @@ public:
 protected:
     RS_Layer* a_layer;
 
+private:
+    void deselectEntitiesOnLockedLayer(RS_Layer* layer);
 };
 
 #endif

--- a/librecad/src/actions/rs_actionlayerstoggleprint.cpp
+++ b/librecad/src/actions/rs_actionlayerstoggleprint.cpp
@@ -48,33 +48,50 @@ RS_ActionLayersTogglePrint::RS_ActionLayersTogglePrint(
 void RS_ActionLayersTogglePrint::trigger() {
     RS_DEBUG->print("toggle layer printing");
     if (graphic) {
-        if (a_layer) {
-            graphic->toggleLayerPrint(a_layer);
-
-			// deselect entities on locked layer:
-			for(auto e: *container){
-                if (e && e->isVisible() && e->getLayer()==a_layer) {
-
-                    if (graphicView) {
-                        graphicView->deleteEntity(e);
-                    }
-
-                    if (graphicView) {
-                        graphicView->drawEntity(e);
-                    }
-                }
-            }
+        RS_LayerList* ll = graphic->getLayerList();
+        unsigned cnt = 0;
+        // toggle selected layers
+        for (auto layer: *ll) {
+            if (!layer) continue;
+            if (!layer->isVisibleInLayerList()) continue;
+            if (!layer->isSelectedInLayerList()) continue;
+            graphic->toggleLayerPrint(layer);
+            deselectEntities(layer);
+            cnt++;
         }
-
+        // if there wasn't selected layers, toggle active layer
+        if (!cnt) {
+            graphic->toggleLayerPrint(a_layer);
+            deselectEntities(a_layer);
+        }
     }
     finish(false);
 }
-
 
 
 void RS_ActionLayersTogglePrint::init(int status) {
     RS_ActionInterface::init(status);
     trigger();
 }
+
+
+void RS_ActionLayersTogglePrint::deselectEntities(RS_Layer* layer)
+{
+    if (!layer) return;
+
+    for(auto e: *container){
+        if (e && e->isVisible() && e->getLayer() == layer) {
+
+            if (graphicView) {
+                graphicView->deleteEntity(e);
+            }
+
+            if (graphicView) {
+                graphicView->drawEntity(e);
+            }
+        }
+    }
+}
+
 
 // EOF

--- a/librecad/src/actions/rs_actionlayerstoggleprint.h
+++ b/librecad/src/actions/rs_actionlayerstoggleprint.h
@@ -48,6 +48,8 @@ public:
 protected:
     RS_Layer* a_layer;
 
+private:
+    void deselectEntities(RS_Layer* layer);
 };
 
 #endif

--- a/librecad/src/actions/rs_actionlayerstoggleview.cpp
+++ b/librecad/src/actions/rs_actionlayerstoggleview.cpp
@@ -46,7 +46,20 @@ RS_ActionLayersToggleView::RS_ActionLayersToggleView(
 void RS_ActionLayersToggleView::trigger() {
     RS_DEBUG->print("toggle layer");
     if (graphic) {
-        graphic->toggleLayer(a_layer);
+        RS_LayerList* ll = graphic->getLayerList();
+        unsigned cnt = 0;
+        // toggle selected layers
+        for (auto layer: *ll) {
+            if (!layer) continue;
+            if (!layer->isVisibleInLayerList()) continue;
+            if (!layer->isSelectedInLayerList()) continue;
+            graphic->toggleLayer(layer);
+            cnt++;
+        }
+        // if there wasn't selected layers, toggle active layer
+        if (!cnt) {
+            graphic->toggleLayer(a_layer);
+        }
         graphic->updateInserts();
         container->calculateBorders();
     }

--- a/librecad/src/lib/engine/rs_block.cpp
+++ b/librecad/src/lib/engine/rs_block.cpp
@@ -137,6 +137,23 @@ bool RS_Block::isVisibleInBlockList() const {
 }
 
 
+/**
+ * Sets selection state of the block in block list
+ *
+ * @param v true: selected, false: deselected
+ */
+void RS_Block::selectedInBlockList(bool v) {
+    data.selectedInBlockList = v;
+}
+
+/**
+ * Returns selection state of the block in block list
+ */
+bool RS_Block::isSelectedInBlockList() const {
+    return data.selectedInBlockList;
+}
+
+
 std::ostream& operator << (std::ostream& os, const RS_Block& b) {
     os << " name: " << b.getName().toLatin1().data() << "\n";
     os << " entities: " << (RS_EntityContainer&)b << "\n";

--- a/librecad/src/lib/engine/rs_block.h
+++ b/librecad/src/lib/engine/rs_block.h
@@ -54,6 +54,7 @@ struct RS_BlockData {
 
 	bool frozen {false};              //!< Frozen flag
 	bool visibleInBlockList {true};   //!< Visible in block list
+	bool selectedInBlockList {false}; //!< selected in block list
 };
 
 
@@ -194,6 +195,18 @@ public:
      * Returns the visibility of the Block in block list
      */
     bool isVisibleInBlockList() const;
+
+    /**
+     * Sets selection state of the block in block list
+     *
+     * @param v true: selected, false: deselected
+     */
+    void selectedInBlockList(bool v);
+
+    /**
+     * Returns selection state of the block in block list
+     */
+    bool isSelectedInBlockList() const;
 
 protected:
 	//! Block data

--- a/librecad/src/lib/engine/rs_layer.cpp
+++ b/librecad/src/lib/engine/rs_layer.cpp
@@ -169,6 +169,22 @@ bool RS_Layer::isVisibleInLayerList() const{
 }
 
 /**
+ * set selection state of the layer in layer list
+ *
+ * @param val true: selected, false: deselected
+ */
+void RS_Layer::selectedInLayerList(bool val) {
+	data.selectedInLayerList = val;
+}
+
+/**
+ * return selection state of the layer in layer list
+ */
+bool RS_Layer::isSelectedInLayerList() const {
+	return data.selectedInLayerList;
+}
+
+/**
  * set the PRINT state of the Layer
  *
  * @param print true: print layer, false: don't print layer

--- a/librecad/src/lib/engine/rs_layer.h
+++ b/librecad/src/lib/engine/rs_layer.h
@@ -59,6 +59,7 @@ struct RS_LayerData {
     bool construction {false};      //!< a construction layer has entities of infinite length
                                     //!< and will never be printed out
     bool visibleInLayerList {true}; //!< visible in layer list
+    bool selectedInLayerList {false}; //!< selected in layer list
 };
 
 
@@ -155,6 +156,18 @@ public:
      * return the visibility of the Layer in layer list
      */
 	bool isVisibleInLayerList() const;
+
+    /**
+     * set selection state of the layer in layer list
+     *
+     * @param val true: selected, false: deselected
+     */
+    void selectedInLayerList(bool val);
+
+    /**
+     * return selection state of the layer in layer list
+     */
+    bool isSelectedInLayerList() const;
 
     /**
      * set the PRINT state of the Layer

--- a/librecad/src/lib/gui/rs_dialogfactoryadapter.h
+++ b/librecad/src/lib/gui/rs_dialogfactoryadapter.h
@@ -47,6 +47,7 @@ public:
 	RS_Layer* requestEditLayerDialog(RS_LayerList*) override{return nullptr;}
 	RS_BlockData requestNewBlockDialog(RS_BlockList*) override {return {};}
 	RS_Block* requestBlockRemovalDialog(RS_BlockList*) override {return nullptr;}
+	QList<RS_Block*> requestSelectedBlocksRemovalDialog(RS_BlockList*) override{return {};}
 	RS_BlockData requestBlockAttributesDialog(RS_BlockList*) override{return {};}
 	void requestEditBlockWindow(RS_BlockList*) override{}
 	void closeEditBlockWindow(RS_Block*) override {}

--- a/librecad/src/lib/gui/rs_dialogfactoryadapter.h
+++ b/librecad/src/lib/gui/rs_dialogfactoryadapter.h
@@ -43,6 +43,7 @@ public:
 	RS_GraphicView* requestNewDocument(const QString&, RS_Document*) {return nullptr;}
 	RS_Layer* requestNewLayerDialog(RS_LayerList*) override{return nullptr;}
 	RS_Layer* requestLayerRemovalDialog(RS_LayerList*) override{return nullptr;}
+	QStringList requestSelectedLayersRemovalDialog(RS_LayerList*) override{return {};}
 	RS_Layer* requestEditLayerDialog(RS_LayerList*) override{return nullptr;}
 	RS_BlockData requestNewBlockDialog(RS_BlockList*) override {return {};}
 	RS_Block* requestBlockRemovalDialog(RS_BlockList*) override {return nullptr;}

--- a/librecad/src/lib/gui/rs_dialogfactoryinterface.h
+++ b/librecad/src/lib/gui/rs_dialogfactoryinterface.h
@@ -117,6 +117,19 @@ public:
 
     /**
      * This virtual method must be overwritten and must provide
+     * a dialog that asks for permission for removing the selected
+     * layers from the layer list. The method must not actually
+     * remove those layers. This is up to the caller.
+     *
+     * @return The implementation is expected to return a list
+     *         of selected layers names to be removed, or empty
+     *         list if the user cancels the dialog.
+     */
+    virtual QStringList requestSelectedLayersRemovalDialog(
+        RS_LayerList* layerList = NULL) = 0;
+
+    /**
+     * This virtual method must be overwritten and must provide
      * a dialog to edit the layers attributes. The method must
      * not actually edit the layer. This is up to the caller.
      *

--- a/librecad/src/lib/gui/rs_dialogfactoryinterface.h
+++ b/librecad/src/lib/gui/rs_dialogfactoryinterface.h
@@ -170,6 +170,19 @@ public:
 
     /**
      * This virtual method must be overwritten and must provide
+     * a dialog that asks for permission for removing the selected
+     * blocks from the block list. The method must not actually
+     * remove those blocks. This is up to the caller.
+     *
+     * @return The implementation is expected to return a list
+     *         of selected blocks to be removed, or empty
+     *         list if the user cancels the dialog.
+     */
+    virtual QList<RS_Block*> requestSelectedBlocksRemovalDialog(
+        RS_BlockList* blockList = NULL) = 0;
+
+    /**
+     * This virtual method must be overwritten and must provide
      * a dialog that allows to change blocks attributes of the
      * currently active block.
      *

--- a/librecad/src/ui/lc_actionfactory.cpp
+++ b/librecad/src/ui/lc_actionfactory.cpp
@@ -917,7 +917,7 @@ void LC_ActionFactory::fillActionContainer(QMap<QString, QAction*>& a_map, LC_Ac
     action->setObjectName("BlocksAdd");
     a_map["BlocksAdd"] = action;
 
-    action = new QAction(tr("&Remove Block"), agm->block);
+    action = new QAction(tr("&Remove Selected Blocks"), agm->block);
     action->setIcon(QIcon(":/icons/remove.svg"));
     connect(action, SIGNAL(triggered()),
     action_handler, SLOT(slotBlocksRemove()));

--- a/librecad/src/ui/lc_actionfactory.cpp
+++ b/librecad/src/ui/lc_actionfactory.cpp
@@ -852,7 +852,7 @@ void LC_ActionFactory::fillActionContainer(QMap<QString, QAction*>& a_map, LC_Ac
     action->setObjectName("LayersAdd");
     a_map["LayersAdd"] = action;
 
-    action = new QAction(tr("&Remove Selected Layers"), agm->layer);
+    action = new QAction(tr("&Remove Layer"), agm->layer);
     action->setIcon(QIcon(":/icons/remove.svg"));
     connect(action, SIGNAL(triggered()),
     action_handler, SLOT(slotLayersRemove()));
@@ -917,7 +917,7 @@ void LC_ActionFactory::fillActionContainer(QMap<QString, QAction*>& a_map, LC_Ac
     action->setObjectName("BlocksAdd");
     a_map["BlocksAdd"] = action;
 
-    action = new QAction(tr("&Remove Selected Blocks"), agm->block);
+    action = new QAction(tr("&Remove Block"), agm->block);
     action->setIcon(QIcon(":/icons/remove.svg"));
     connect(action, SIGNAL(triggered()),
     action_handler, SLOT(slotBlocksRemove()));

--- a/librecad/src/ui/lc_actionfactory.cpp
+++ b/librecad/src/ui/lc_actionfactory.cpp
@@ -852,7 +852,7 @@ void LC_ActionFactory::fillActionContainer(QMap<QString, QAction*>& a_map, LC_Ac
     action->setObjectName("LayersAdd");
     a_map["LayersAdd"] = action;
 
-    action = new QAction(tr("&Remove Layer"), agm->layer);
+    action = new QAction(tr("&Remove Selected Layers"), agm->layer);
     action->setIcon(QIcon(":/icons/remove.svg"));
     connect(action, SIGNAL(triggered()),
     action_handler, SLOT(slotLayersRemove()));

--- a/librecad/src/ui/qg_blockwidget.cpp
+++ b/librecad/src/ui/qg_blockwidget.cpp
@@ -187,11 +187,11 @@ QG_BlockWidget::QG_BlockWidget(QG_ActionHandler* ah, QWidget* parent,
     connect(but, SIGNAL(clicked()),
             actionHandler, SLOT(slotBlocksAdd()));
     layButtons->addWidget(but);
-    // remove selected blocks:
+    // remove block:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/remove.svg"));
     but->setMinimumSize(button_size);
-    but->setToolTip(tr("Remove selected blocks"));
+    but->setToolTip(tr("Remove block"));
     connect(but, SIGNAL(clicked()),
             actionHandler, SLOT(slotBlocksRemove()));
     layButtons->addWidget(but);
@@ -389,14 +389,6 @@ void QG_BlockWidget::slotSelectionChanged(
             block->selectedInBlockList(false);
         }
     }
-
-    // for (auto block: *blockList) {
-    //     if (!block) continue;
-    //     RS_DEBUG->print(RS_Debug::D_WARNING, "=== %s %s: %s",
-    //         block == blockModel->getActiveBlock() ? "*" : " ",
-    //         block->isSelectedInBlockList() ? "+" : "-",
-    //         block->getName().toLatin1().data());
-    // }
 }
 
 
@@ -421,11 +413,12 @@ void QG_BlockWidget::contextMenuEvent(QContextMenuEvent *e) {
     contextMenu->addAction( tr("&Freeze all Blocks"), actionHandler,
                              SLOT(slotBlocksFreezeAll()), 0);
     contextMenu->addSeparator();
-    // Actions for selected blocks:
-    contextMenu->addAction( tr("&Remove Selected Blocks"), actionHandler,
-                             SLOT(slotBlocksRemove()), 0);
-    contextMenu->addAction( tr("&Toggle Visibility of Selected"), actionHandler,
+    // Actions for selected blocks or,
+    // if nothing is selected, for active block:
+    contextMenu->addAction( tr("&Toggle Visibility"), actionHandler,
                              SLOT(slotBlocksToggleView()), 0);
+    contextMenu->addAction( tr("&Remove Block"), actionHandler,
+                             SLOT(slotBlocksRemove()), 0);
     contextMenu->addSeparator();
     // Single block actions:
     contextMenu->addAction( tr("&Add Block"), actionHandler,

--- a/librecad/src/ui/qg_blockwidget.h
+++ b/librecad/src/ui/qg_blockwidget.h
@@ -30,6 +30,7 @@
 #include <QWidget>
 #include <QIcon>
 #include <QAbstractTableModel>
+#include <QItemSelection>
 
 #include "rs_blocklistlistener.h"
 
@@ -61,10 +62,14 @@ public:
     RS_Block *getBlock( int row );
     QModelIndex getIndex (RS_Block * blk);
 
+    RS_Block* getActiveBlock() { return activeBlock; };
+    void setActiveBlock(RS_Block* b) { activeBlock = b; };
+
 private:
     QList<RS_Block*> listBlock;
     QIcon blockVisible;
     QIcon blockHidden;
+    RS_Block* activeBlock {nullptr};
 };
 
 
@@ -109,6 +114,9 @@ signals:
 
 public slots:
     void slotActivated(QModelIndex blockIdx);
+    void slotSelectionChanged(
+        const QItemSelection &selected,
+        const QItemSelection &deselected);
     void slotUpdateBlockList();
 
 protected:
@@ -123,6 +131,8 @@ private:
     RS_Block* lastBlock;
 
     QG_ActionHandler* actionHandler;
+
+    void restoreSelections();
 };
 
 #endif

--- a/librecad/src/ui/qg_dialogfactory.cpp
+++ b/librecad/src/ui/qg_dialogfactory.cpp
@@ -531,6 +531,69 @@ RS_Block* QG_DialogFactory::requestBlockRemovalDialog(RS_BlockList* blockList) {
 
 
 /**
+ * Shows a dialog that asks the user if the selected blocks
+ * can be removed. Doesn't remove the blocks. This is up to the caller.
+ *
+ * @return a list of blocks to be removed.
+ */
+QList<RS_Block*> QG_DialogFactory::requestSelectedBlocksRemovalDialog(
+    RS_BlockList* blockList)
+{
+
+    if (!blockList) {
+        RS_DEBUG->print(RS_Debug::D_WARNING,
+                "QG_DialogFactory::requestSelectedBlocksRemovalDialog(): "
+                "blockList is nullptr");
+        return QList<RS_Block*>();
+    }
+
+    QList<RS_Block*> blocks;
+
+    for (auto block: *blockList) {
+        if (!block) continue;
+        if (!block->isVisibleInBlockList()) continue;
+        if (!block->isSelectedInBlockList()) continue;
+        blocks << block;
+    }
+
+    if (blocks.isEmpty()) {
+        return blocks; // empty, nothing to remove
+    }
+
+    QString title(
+        QMessageBox::tr("Remove %n selected block(s)", "", blocks.size())
+    );
+
+    QString text(
+        QMessageBox::tr("Selected blocks and all their entities will be removed.")
+    );
+
+    QStringList detail_lines = {
+        QMessageBox::tr("Selected blocks:"),
+        "",
+    };
+    for (auto block: blocks) {
+        detail_lines << block->getName();
+    }
+
+    QMessageBox msgBox(
+        QMessageBox::Warning,
+        title,
+        text,
+        QMessageBox::Ok | QMessageBox::Cancel
+    );
+
+    msgBox.setDetailedText(detail_lines.join("\n"));
+
+    if (msgBox.exec() == QMessageBox::Ok) {
+        return blocks;
+    }
+
+    return QList<RS_Block*>();
+}
+
+
+/**
  * Shows a dialog for choosing a file name. Opening the file is up to
  * the caller.
  *

--- a/librecad/src/ui/qg_dialogfactory.cpp
+++ b/librecad/src/ui/qg_dialogfactory.cpp
@@ -305,6 +305,7 @@ QStringList QG_DialogFactory::requestSelectedLayersRemovalDialog(
     QStringList names;
     bool layer_0_selected {false};
 
+    // first, try to add selected layers
     for (auto layer: *layerList) {
         if (!layer) continue;
         if (!layer->isVisibleInLayerList()) continue;
@@ -316,6 +317,20 @@ QStringList QG_DialogFactory::requestSelectedLayersRemovalDialog(
         names << layer->getName();
     }
 
+    // then, if there're no selected layers,
+    // try to add active layer instead
+    if (names.isEmpty()) {
+        RS_Layer* layer = layerList->getActive();
+        if (layer && layer->isVisibleInLayerList()) {
+            if (layer->getName() == "0") {
+                layer_0_selected = true;
+            } else {
+                names << layer->getName();
+            }
+        }
+    }
+
+    // still there're no layers, so return
     if (names.isEmpty()) {
         if (layer_0_selected) {
             QMessageBox::information(
@@ -328,12 +343,14 @@ QStringList QG_DialogFactory::requestSelectedLayersRemovalDialog(
         return names; // empty, nothing to remove
     }
 
+    // layers added, show confirmation dialog
+
     QString title(
-        QMessageBox::tr("Remove %n selected layer(s)", "", names.size())
+        QMessageBox::tr("Remove %n layer(s)", "", names.size())
     );
 
     QStringList text_lines = {
-        QMessageBox::tr("Selected layers and all entities on them will be removed."),
+        QMessageBox::tr("Listed layers and all entities on them will be removed."),
         "",
         QMessageBox::tr("Warning: this action can NOT be undone!"),
     };
@@ -344,7 +361,7 @@ QStringList QG_DialogFactory::requestSelectedLayersRemovalDialog(
     }
 
     QStringList detail_lines = {
-        QMessageBox::tr("Selected layers:"),
+        QMessageBox::tr("Layers for removal:"),
         "",
     };
     detail_lines << names;
@@ -549,6 +566,7 @@ QList<RS_Block*> QG_DialogFactory::requestSelectedBlocksRemovalDialog(
 
     QList<RS_Block*> blocks;
 
+    // first, try to add selected blocks
     for (auto block: *blockList) {
         if (!block) continue;
         if (!block->isVisibleInBlockList()) continue;
@@ -556,20 +574,32 @@ QList<RS_Block*> QG_DialogFactory::requestSelectedBlocksRemovalDialog(
         blocks << block;
     }
 
+    // then, if there're no selected blocks,
+    // try to add active block instead
+    if (blocks.isEmpty()) {
+        RS_Block* block = blockList->getActive();
+        if (block && block->isVisibleInBlockList()) {
+            blocks << block;
+        }
+    }
+
+    // still nothing was added, so return
     if (blocks.isEmpty()) {
         return blocks; // empty, nothing to remove
     }
 
+    // blocks added, show confirmation dialog
+
     QString title(
-        QMessageBox::tr("Remove %n selected block(s)", "", blocks.size())
+        QMessageBox::tr("Remove %n block(s)", "", blocks.size())
     );
 
     QString text(
-        QMessageBox::tr("Selected blocks and all their entities will be removed.")
+        QMessageBox::tr("Listed blocks and all their entities will be removed.")
     );
 
     QStringList detail_lines = {
-        QMessageBox::tr("Selected blocks:"),
+        QMessageBox::tr("Blocks for removal:"),
         "",
     };
     for (auto block: blocks) {

--- a/librecad/src/ui/qg_dialogfactory.cpp
+++ b/librecad/src/ui/qg_dialogfactory.cpp
@@ -307,6 +307,7 @@ QStringList QG_DialogFactory::requestSelectedLayersRemovalDialog(
 
     for (auto layer: *layerList) {
         if (!layer) continue;
+        if (!layer->isVisibleInLayerList()) continue;
         if (!layer->isSelectedInLayerList()) continue;
         if (layer->getName() == "0") {
             layer_0_selected = true;

--- a/librecad/src/ui/qg_dialogfactory.h
+++ b/librecad/src/ui/qg_dialogfactory.h
@@ -109,6 +109,8 @@ public:
 			RS_LayerList* layerList = nullptr) override;
 	RS_Layer* requestLayerRemovalDialog(
 			RS_LayerList* layerList = nullptr) override;
+	QStringList requestSelectedLayersRemovalDialog(
+			RS_LayerList* layerList = nullptr) override;
 	RS_Layer* requestEditLayerDialog(
 			RS_LayerList* layerList = nullptr) override;
 

--- a/librecad/src/ui/qg_dialogfactory.h
+++ b/librecad/src/ui/qg_dialogfactory.h
@@ -117,6 +117,8 @@ public:
 	RS_BlockData requestNewBlockDialog(RS_BlockList* blockList) override;
 	RS_Block* requestBlockRemovalDialog(
 			RS_BlockList* blockList) override;
+	QList<RS_Block*> requestSelectedBlocksRemovalDialog(
+			RS_BlockList* blockList = nullptr) override;
 	RS_BlockData requestBlockAttributesDialog(
 			RS_BlockList* blockList) override;
 	void requestEditBlockWindow(RS_BlockList* /*blockList*/) override{}

--- a/librecad/src/ui/qg_layerwidget.cpp
+++ b/librecad/src/ui/qg_layerwidget.cpp
@@ -88,6 +88,7 @@ void QG_LayerModel::setLayerList(RS_LayerList* ll) {
     for (unsigned i=0; i < ll->count(); ++i) {
         listLayer.append(ll->at(i));
     }
+    setActiveLayer(ll->getActive());
     std::sort( listLayer.begin(), listLayer.end(), [](const RS_Layer *s1, const RS_Layer *s2)-> bool{
         return s1->getName() < s2->getName();
     } );
@@ -165,6 +166,15 @@ QVariant QG_LayerModel::data ( const QModelIndex & index, int role ) const {
         }
         break;
 
+    case Qt::FontRole:
+        if (NAME == col) {
+            if (activeLayer && activeLayer == layer) {
+                QFont font;
+                font.setBold(true);
+                return font;
+            }
+        }
+        break;
     }
 
     return QVariant();
@@ -189,7 +199,7 @@ QG_LayerWidget::QG_LayerWidget(QG_ActionHandler* ah, QWidget* parent,
     layerView = new QTableView(this);
     layerView->setModel(layerModel);
     layerView->setShowGrid(true);
-    layerView->setSelectionMode(QAbstractItemView::SingleSelection);
+    layerView->setSelectionMode(QAbstractItemView::ExtendedSelection);
     layerView->setEditTriggers(QAbstractItemView::NoEditTriggers);
     layerView->setFocusPolicy(Qt::NoFocus);
     layerView->setMinimumHeight(140);
@@ -251,11 +261,11 @@ QG_LayerWidget::QG_LayerWidget(QG_ActionHandler* ah, QWidget* parent,
     connect(but, SIGNAL(clicked()),
             actionHandler, SLOT(slotLayersAdd()));
     layButtons->addWidget(but);
-    // remove layer:
+    // remove selected layers:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/remove.svg"));
     but->setMinimumSize(minButSize);
-    but->setToolTip(tr("Remove the current layer"));
+    but->setToolTip(tr("Remove selected layers"));
     connect(but, SIGNAL(clicked()),
             actionHandler, SLOT(slotLayersRemove()));
     layButtons->addWidget(but);
@@ -271,7 +281,7 @@ QG_LayerWidget::QG_LayerWidget(QG_ActionHandler* ah, QWidget* parent,
     // lineEdit to filter layer list with RegEx
     matchLayerName = new QLineEdit(this);
     matchLayerName->setReadOnly(false);
-    matchLayerName->setPlaceholderText("Filter");
+    matchLayerName->setPlaceholderText(tr("Filter"));
     matchLayerName->setClearButtonEnabled(true);
     matchLayerName->setToolTip(tr("Looking for matching layer names"));
     connect(matchLayerName, SIGNAL( textChanged(QString) ), this, SLOT( slotUpdateLayerList() ) );
@@ -282,7 +292,11 @@ QG_LayerWidget::QG_LayerWidget(QG_ActionHandler* ah, QWidget* parent,
     lay->addWidget(layerView);
 	this->setLayout(lay);
 
-    connect(layerView, SIGNAL(pressed(QModelIndex)), this, SLOT(slotActivated(QModelIndex)));
+    // connect(layerView, SIGNAL(pressed(QModelIndex)), this, SLOT(slotActivated(QModelIndex)));
+    connect(layerView, SIGNAL(clicked(QModelIndex)), this, SLOT(slotActivated(QModelIndex)));
+    connect(layerView->selectionModel(),
+        SIGNAL(selectionChanged(QItemSelection, QItemSelection)),
+        this, SLOT(slotSelectionChanged(QItemSelection, QItemSelection)));
 }
 
 
@@ -358,6 +372,7 @@ void QG_LayerWidget::update() {
     RS_Layer* activeLayer = layerList->getActive();
     if (!activeLayer) {
         RS_DEBUG->print(RS_Debug::D_ERROR, "QG_LayerWidget::update: nullptr activeLayer");
+        layerModel->setActiveLayer(nullptr);
         return;
     }
     activateLayer(activeLayer);
@@ -365,6 +380,16 @@ void QG_LayerWidget::update() {
     if (!lastLayer) {
         RS_DEBUG->print(RS_Debug::D_WARNING, "QG_LayerWidget::update: nullptr lastLayer");
         lastLayer = activeLayer;
+    }
+
+    // restore selections
+    QItemSelectionModel* selectionModel = layerView->selectionModel();
+    for (auto layer: *layerList) {
+        if (layer && layer->isSelectedInLayerList()) {
+            QModelIndex idx = layerModel->getIndex(layer);
+            QItemSelection selection(idx, idx);
+            selectionModel->select(selection, QItemSelectionModel::Select);
+        }
     }
 
     RS_DEBUG->print("QG_LayerWidget::update(): OK");
@@ -399,7 +424,22 @@ void QG_LayerWidget::activateLayer(RS_Layer* layer, bool updateScroll) {
         RS_DEBUG->print(RS_Debug::D_ERROR, "QG_LayerWidget::activateLayer: invalid layer or nullptr layerView");
         return;
     }
+
+    // remember selected status of the layer
+    bool selected = layer->isSelectedInLayerList();
+
     layerView->setCurrentIndex(idx);
+    layerModel->setActiveLayer(layer);
+    layerView->viewport()->update();
+
+    // restore selected status of the layer
+    QItemSelectionModel::SelectionFlag selFlag;
+    if (selected) {
+        selFlag = QItemSelectionModel::Select;
+    } else {
+        selFlag = QItemSelectionModel::Deselect;
+    }
+    layerView->selectionModel()->select(QItemSelection(idx, idx), selFlag);
 
     if (!updateScroll) {
         int yPos = layerView->verticalScrollBar()->value();
@@ -449,6 +489,38 @@ void QG_LayerWidget::slotActivated(QModelIndex layerIdx /*const QString& layerNa
     }
 }
 
+
+/**
+ * Called on layers selection/deselection
+ */
+void QG_LayerWidget::slotSelectionChanged(
+    const QItemSelection &selected,
+    const QItemSelection &deselected)
+{
+    QModelIndex index;
+
+    foreach (index, selected.indexes()) {
+        auto layer = layerModel->getLayer(index.row());
+        if (layer) {
+            layer->selectedInLayerList(true);
+        }
+    }
+
+    foreach (index, deselected.indexes()) {
+        auto layer = layerModel->getLayer(index.row());
+        if (layer) {
+            layer->selectedInLayerList(false);
+        }
+    }
+
+    // for (auto layer: *layerList) {
+    //     if (!layer) continue;
+    //     RS_DEBUG->print(RS_Debug::D_WARNING, "=== %s %s: %s",
+    //         layer == layerModel->getActiveLayer() ? "*" : " ",
+    //         layer->isSelectedInLayerList() ? "+" : "-",
+    //         layer->getName().toLatin1().data());
+    // }
+}
 
 
 /**
@@ -500,12 +572,14 @@ void QG_LayerWidget::contextMenuEvent(QContextMenuEvent *e) {
         contextMenu->addSeparator();
         contextMenu->addAction( tr("&Add Layer"), actionHandler,
                                  SLOT(slotLayersAdd()), 0);
-        contextMenu->addAction( tr("&Remove Layer"), actionHandler,
+        contextMenu->addAction( tr("&Remove Selected Layers"), actionHandler,
                                  SLOT(slotLayersRemove()), 0);
         contextMenu->addAction( tr("Edit Layer &Attributes"), actionHandler,
                                  SLOT(slotLayersEdit()), 0);
         contextMenu->addAction( tr("Toggle Layer &Visibility"), actionHandler,
                                  SLOT(slotLayersToggleView()), 0);
+        contextMenu->addAction( tr("Toggle Layer Loc&k"), actionHandler,
+                                 SLOT(slotLayersToggleLock()), 0);
         contextMenu->addAction( tr("Toggle Layer &Printing"), actionHandler,
                                  SLOT(slotLayersTogglePrint()), 0);
         contextMenu->addAction( tr("Toggle &Construction Layer"), actionHandler,

--- a/librecad/src/ui/qg_layerwidget.cpp
+++ b/librecad/src/ui/qg_layerwidget.cpp
@@ -261,11 +261,11 @@ QG_LayerWidget::QG_LayerWidget(QG_ActionHandler* ah, QWidget* parent,
     connect(but, SIGNAL(clicked()),
             actionHandler, SLOT(slotLayersAdd()));
     layButtons->addWidget(but);
-    // remove selected layers:
+    // remove layer:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/remove.svg"));
     but->setMinimumSize(minButSize);
-    but->setToolTip(tr("Remove selected layers"));
+    but->setToolTip(tr("Remove layer"));
     connect(but, SIGNAL(clicked()),
             actionHandler, SLOT(slotLayersRemove()));
     layButtons->addWidget(but);
@@ -520,14 +520,6 @@ void QG_LayerWidget::slotSelectionChanged(
             layer->selectedInLayerList(false);
         }
     }
-
-    // for (auto layer: *layerList) {
-    //     if (!layer) continue;
-    //     RS_DEBUG->print(RS_Debug::D_WARNING, "=== %s %s: %s",
-    //         layer == layerModel->getActiveLayer() ? "*" : " ",
-    //         layer->isSelectedInLayerList() ? "+" : "-",
-    //         layer->getName().toLatin1().data());
-    // }
 }
 
 
@@ -571,6 +563,7 @@ void QG_LayerWidget::contextMenuEvent(QContextMenuEvent *e) {
         palette.setColor(caption->foregroundRole(), RS_Color(255,255,255));
         caption->setPalette(palette);
         caption->setAlignment( Qt::AlignCenter );
+        // Actions for all layers:
         contextMenu->addAction( tr("&Defreeze all Layers"), actionHandler,
                                  SLOT(slotLayersDefreezeAll()), 0);
         contextMenu->addAction( tr("&Freeze all Layers"), actionHandler,
@@ -580,12 +573,8 @@ void QG_LayerWidget::contextMenuEvent(QContextMenuEvent *e) {
         contextMenu->addAction( tr("&Lock all Layers"), actionHandler,
                                  SLOT(slotLayersLockAll()), 0);
         contextMenu->addSeparator();
-        contextMenu->addAction( tr("&Add Layer"), actionHandler,
-                                 SLOT(slotLayersAdd()), 0);
-        contextMenu->addAction( tr("&Remove Selected Layers"), actionHandler,
-                                 SLOT(slotLayersRemove()), 0);
-        contextMenu->addAction( tr("Edit Layer &Attributes"), actionHandler,
-                                 SLOT(slotLayersEdit()), 0);
+        // Actions for selected layers or,
+        // if nothing is selected, for active layer:
         contextMenu->addAction( tr("Toggle Layer &Visibility"), actionHandler,
                                  SLOT(slotLayersToggleView()), 0);
         contextMenu->addAction( tr("Toggle Layer Loc&k"), actionHandler,
@@ -594,6 +583,14 @@ void QG_LayerWidget::contextMenuEvent(QContextMenuEvent *e) {
                                  SLOT(slotLayersTogglePrint()), 0);
         contextMenu->addAction( tr("Toggle &Construction Layer"), actionHandler,
                                  SLOT(slotLayersToggleConstruction()), 0);
+        contextMenu->addAction( tr("&Remove Layer"), actionHandler,
+                                 SLOT(slotLayersRemove()), 0);
+        contextMenu->addSeparator();
+        // Single layer actions:
+        contextMenu->addAction( tr("&Add Layer"), actionHandler,
+                                 SLOT(slotLayersAdd()), 0);
+        contextMenu->addAction( tr("Edit Layer &Attributes"), actionHandler,
+                                 SLOT(slotLayersEdit()), 0);
         contextMenu->exec(QCursor::pos());
         delete contextMenu;
     }

--- a/librecad/src/ui/qg_layerwidget.h
+++ b/librecad/src/ui/qg_layerwidget.h
@@ -31,6 +31,7 @@
 #include <QWidget>
 #include <QIcon>
 #include <QAbstractTableModel>
+#include <QItemSelection>
 
 #include "rs_layerlistlistener.h"
 #include "rs_layerlist.h"
@@ -75,6 +76,9 @@ public:
     RS_Layer *getLayer( int row );
     QModelIndex getIndex (RS_Layer * lay);
 
+    RS_Layer* getActiveLayer() { return activeLayer; };
+    void setActiveLayer(RS_Layer* l) { activeLayer = l; };
+
 private:
     QList<RS_Layer*> listLayer;
     QIcon layerVisible;
@@ -85,6 +89,7 @@ private:
     QIcon layerNoPrint;
     QIcon layerConstruction;
     QIcon layerNoConstruction;
+    RS_Layer* activeLayer {nullptr};
 };
 
 
@@ -143,6 +148,9 @@ signals:
 
 public slots:
     void slotActivated(QModelIndex layerIdx);
+    void slotSelectionChanged(
+        const QItemSelection &selected,
+        const QItemSelection &deselected);
     void slotUpdateLayerList();
     void activateLayer(int row);
 

--- a/librecad/src/ui/qg_layerwidget.h
+++ b/librecad/src/ui/qg_layerwidget.h
@@ -166,6 +166,8 @@ private:
     QG_LayerModel *layerModel;
     RS_Layer* lastLayer;   
     QG_ActionHandler* actionHandler;
+
+    void restoreSelections();
 };
 
 #endif


### PR DESCRIPTION
My drawings may contain hundreds of layers or blocks. Sometimes I need to clean-up and remove many of them. But that requires a lot of clicking.

**Inconvenience**: removing _n_ layers requires _4n_ user actions (scrolling, selecting, clicking "Remove" button, clicking "Ok" button in confirmation dialog). E.g.: you need to remove 20 layers, so you have to make 80 annoying actions. The same is true and for blocks removal.

**Solution**: allowing selection of many layers at once and applying removal to all selected layers can significantly reduce user actions (down to the 3 in the best case scenario).

This pull request implements the solution. The following different item types are introduced:

* _Active item_ (current layer or block)
* _Selected item(s)_

An _active item_ can be or not be a part of _selected items_. _Active item_ in list is depicted by bold font:

![01](https://user-images.githubusercontent.com/14307537/51805919-7bd38d00-2284-11e9-9e74-cc1d42b47ccf.png)

_Selected items_ are highlighted by color stripes as usual:

![02](https://user-images.githubusercontent.com/14307537/51805920-7bd38d00-2284-11e9-9978-0f863f89b0f6.png)

Items are selected by clicking on them and dragging up or down. By using keyboard modifier keys and different mouse keys different kinds of selections occur.

The following actions can be performed on a group of _selected items_:

* Removal
* Toggling visibility flag
* Toggling lock flag
* Toggling printer flag
* Toggling construction flag

![03](https://user-images.githubusercontent.com/14307537/51805921-7c6c2380-2284-11e9-9271-a9fe2e65fdf6.png)

All those action act on items as follows:

+ If there are _selected items_, an action performed on them;
+ If there are no _selected items_, an action performed on _active item_;
+ If there are no _selected items_ or _active item_ (e.g. hidden by filter), no action is performed.

If some _selected items_ are hidden by filter, no any action affects such hidden selections. But selections are still preserved and when filter is cleared become visible and can be affected by chosen actions.

Context menus of both lists were reordered and a couple of separators were added. The principle for grouping of actions in those menus is:

* Actions which act on all items
-- separator
* Actions which act on _selected items_ or _active item_
-- separator
* Actions which act only on _active item_ or which add a new item.


**Drawbacks**:

* Now right-clicking on an item does not make it active. This should be kept in mind when applying _active item_ dependent actions (e.g. edit layer attributes, rename block, etc.). To make an item active you should left-click it first.

* _Active item_ is not a _selected item_ initially and therefore is not highlighted as it was before. It is now only depicted by bold font and displayed in status bar. I believe this is just a matter of getting used to.

Despite those little drawbacks I hope the main features could be useful for all LibreCAD users.



