### PR TITLE
Buttons to refresh Library Browser contents

### DIFF
--- a/librecad/src/ui/qg_librarywidget.cpp
+++ b/librecad/src/ui/qg_librarywidget.cpp
@@ -70,28 +70,21 @@ QG_LibraryWidget::QG_LibraryWidget(QWidget* parent, const char* name, Qt::Window
     bInsert = new QPushButton(tr("Insert"), this);
     vboxLayout->addWidget(bInsert);
 
-    dirModel = new QStandardItemModel;
-    iconModel = new QStandardItemModel;
-    QStringList directoryList = RS_SYSTEM->getDirectoryList("library");
-    for (int i = 0; i < directoryList.size(); ++i) {
-		appendTree(nullptr, directoryList.at(i));
-     }
+    QHBoxLayout *refreshButtonsLayout = new QHBoxLayout(this);
+    bRefresh = new QPushButton(tr("Refresh"), this);
+    refreshButtonsLayout->addWidget(bRefresh);
+    bRebuild = new QPushButton(tr("Rebuild"), this);
+    refreshButtonsLayout->addWidget(bRebuild);
+    vboxLayout->addLayout(refreshButtonsLayout);
 
-    RS_SETTINGS->beginGroup("/Paths");
-    QString customPath=RS_SETTINGS->readEntry("/Library", "");
-    RS_SETTINGS->endGroup();
-    if(customPath.size()>0){
-            //todo: make the custom path more flexible
-			appendTree(nullptr,customPath);
-    }
-    dirView->setModel(dirModel);
-    ivPreview->setModel(iconModel);
-    dirModel->setHorizontalHeaderLabels ( QStringList(tr("Directories")));
+    buildTree();
 
     connect(dirView, SIGNAL(expanded(QModelIndex)), this, SLOT(expandView(QModelIndex)));
     connect(dirView, SIGNAL(collapsed(QModelIndex)), this, SLOT(collapseView(QModelIndex)));
     connect(dirView, SIGNAL(clicked(QModelIndex)), this, SLOT(updatePreview(QModelIndex)));
     connect(bInsert, SIGNAL(clicked()), this, SLOT(insert()));
+    connect(bRefresh, SIGNAL(clicked()), this, SLOT(refresh()));
+    connect(bRebuild, SIGNAL(clicked()), this, SLOT(buildTree()));
 }
 
 /*
@@ -170,6 +163,50 @@ void QG_LibraryWidget::insert() {
     }
 }
 
+
+/**
+ * Refresh
+ */
+void QG_LibraryWidget::refresh() {
+    scanTree();
+    updatePreview(dirView->selectionModel()->currentIndex());
+}
+
+
+/**
+ * Scan library tree for new items
+ */
+void QG_LibraryWidget::scanTree() {
+    QStringList directoryList = RS_SYSTEM->getDirectoryList("library");
+    for (int i = 0; i < directoryList.size(); ++i) {
+        appendTree(nullptr, directoryList.at(i));
+    }
+
+    RS_SETTINGS->beginGroup("/Paths");
+    QString customPath=RS_SETTINGS->readEntry("/Library", "");
+    RS_SETTINGS->endGroup();
+    if(customPath.size()>0){
+        //todo: make the custom path more flexible
+        appendTree(nullptr,customPath);
+    }
+}
+
+
+/**
+ * (Re)build dirModel and iconModel from scratch
+ */
+void QG_LibraryWidget::buildTree() {
+    if (dirModel)
+        delete dirModel;
+    if (iconModel)
+        delete iconModel;
+    dirModel = new QStandardItemModel;
+    iconModel = new QStandardItemModel;
+    scanTree();
+    dirView->setModel(dirModel);
+    ivPreview->setModel(iconModel);
+    dirModel->setHorizontalHeaderLabels ( QStringList(tr("Directories")));
+}
 
 
 /**

--- a/librecad/src/ui/qg_librarywidget.h
+++ b/librecad/src/ui/qg_librarywidget.h
@@ -55,6 +55,9 @@ public slots:
     virtual void setActionHandler( QG_ActionHandler * ah );
     virtual void keyPressEvent( QKeyEvent * e );
     virtual void insert();
+    virtual void refresh();
+    virtual void scanTree();
+    virtual void buildTree();
     virtual void appendTree( QStandardItem * item, QString directory );
     virtual void updatePreview( QModelIndex idx );
     virtual void expandView( QModelIndex idx );
@@ -68,10 +71,12 @@ protected slots:
 
 private:
     QG_ActionHandler* actionHandler;
-    QStandardItemModel *dirModel;
-    QStandardItemModel *iconModel;
+    QStandardItemModel *dirModel {nullptr};
+    QStandardItemModel *iconModel {nullptr};
     QTreeView *dirView;
     QListView *ivPreview;
+    QPushButton *bRefresh;
+    QPushButton *bRebuild;
 };
 
 #endif // QG_LIBRARYWIDGET_H


### PR DESCRIPTION
This PR allows user to use newly added parts library items in Library Browser without restarting LibreCAD.

Two buttons were added:
* Refresh
* Rebuild

The 'Refresh' button allows user to see newly created directories and items in parts library. But it has a limitation -- it cannot remove deleted directories from the tree. This is where 'Rebuild' button is useful.

The 'Rebuild' button completely recreates directory structure. But it too has a limitation. After hitting this button the user loses his current position within expanded tree and gets an unexpanded tree.

So, both buttons have their usage scenarios and useful in one or another situations.

![01](https://user-images.githubusercontent.com/14307537/52049088-ed9a2800-255d-11e9-89d5-85b8590808d4.png)
