### PR TITLE
Skip re-saving already saved settings values

### DIFF
--- a/librecad/src/lib/engine/rs_settings.cpp
+++ b/librecad/src/lib/engine/rs_settings.cpp
@@ -94,6 +94,14 @@ bool RS_Settings::writeEntry(const QString& key, double value) {
 }
 
 bool RS_Settings::writeEntry(const QString& key, const QVariant& value) {
+
+    // Skip writing operations if the key is found in the cache and
+    // its value is the same as the new one (it was already written).
+    QVariant ret = readEntryCache(key);
+    if (ret.isValid() && ret == value) {
+        return true;
+    }
+
 	QSettings s(companyKey, appKey);
     // RVT_PORT not supported anymore s.insertSearchPath(QSettings::Windows, companyKey);
 


### PR DESCRIPTION
As mentioned here: https://github.com/LibreCAD/LibreCAD/issues/859#issuecomment-471971179. There are also other things in LibreCAD that would benefit from this change. For example, clicking OK button in Application Preferences dialog was making it hung for 3-4 seconds on my computer before actual closing. After this change it closes instantly.