### PR TITLE
Fix for #1080 and #755

### DIFF
--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -228,16 +228,17 @@ bool RS_Modification::changeAttributes(RS_AttributesData& data) {
             bool applyDeep = e->isContainer() &&
                 (data.applyPenBlockDeep || data.applyLayerBlockDeep);
 
+            bool skipUndo = applyDeep && e->rtti() == RS2::EntityInsert;
             // Because of Undo does not work currently for modified Block-deep
             // entities, in order to prevent empty Undo entry, the line
-            // below is checking for 'applyDeep' and does not clone 'e' for
+            // below is checking for 'skipUndo' and does not clone 'e' for
             // Inserts.
             //
             // FIXME: After implementing Undo for modified Block-deep entities
             //        change to:
             // RS_Entity* clone = e->clone();
             //
-            RS_Entity* clone = applyDeep ? e : e->clone();
+            RS_Entity* clone = skipUndo ? e : e->clone();
 
             clone->setSelected(false);
             RS_Pen pen = clone->getPen(false);
@@ -277,9 +278,9 @@ bool RS_Modification::changeAttributes(RS_AttributesData& data) {
             //}
 
             clone->update();
-            // FIXME: Remove check for 'applyDeep' after implementing Undo for
+            // FIXME: Remove check for 'skipUndo' after implementing Undo for
             //        modified Block-deep entities.
-            if (!applyDeep) {
+            if (!skipUndo) {
                 addList.push_back(clone);
             }
         } else {

--- a/librecad/src/lib/modification/rs_modification.h
+++ b/librecad/src/lib/modification/rs_modification.h
@@ -181,8 +181,7 @@ public:
         bool changeColor;
         bool changeLineType;
         bool changeWidth;
-        bool applyPenBlockDeep;
-        bool applyLayerBlockDeep;
+        bool applyBlockDeep;
 };
 
 
@@ -232,7 +231,7 @@ public:
 	void remove();
 	void revertDirection();
 	bool changeAttributes(RS_AttributesData& data);
-    bool changeAttributes(RS_AttributesData& data, RS_EntityContainer* container, std::vector<RS_Entity*> addList);
+    bool changeAttributes(RS_AttributesData& data, RS_EntityContainer* container);
 
         void copy(const RS_Vector& ref, const bool cut);
 private:

--- a/librecad/src/lib/modification/rs_modification.h
+++ b/librecad/src/lib/modification/rs_modification.h
@@ -181,6 +181,8 @@ public:
         bool changeColor;
         bool changeLineType;
         bool changeWidth;
+        bool applyPenBlockDeep;
+        bool applyLayerBlockDeep;
 };
 
 

--- a/librecad/src/ui/forms/qg_dlgattributes.cpp
+++ b/librecad/src/ui/forms/qg_dlgattributes.cpp
@@ -83,5 +83,8 @@ void QG_DlgAttributes::updateData() {
     data->changeWidth = !wPen->isWidthUnchanged();
 
     data->changeLayer = !cbLayer->isUnchanged();
+
+    data->applyPenBlockDeep = cbPenBlockDeep->isChecked();
+    data->applyLayerBlockDeep = cbLayerBlockDeep->isChecked();
 }
 

--- a/librecad/src/ui/forms/qg_dlgattributes.cpp
+++ b/librecad/src/ui/forms/qg_dlgattributes.cpp
@@ -84,7 +84,6 @@ void QG_DlgAttributes::updateData() {
 
     data->changeLayer = !cbLayer->isUnchanged();
 
-    data->applyPenBlockDeep = cbPenBlockDeep->isChecked();
-    data->applyLayerBlockDeep = cbLayerBlockDeep->isChecked();
+    data->applyBlockDeep = cbBlockDeep->isChecked();
 }
 

--- a/librecad/src/ui/forms/qg_dlgattributes.ui
+++ b/librecad/src/ui/forms/qg_dlgattributes.ui
@@ -64,26 +64,13 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="cbLayerBlockDeep">
+        <widget class="QCheckBox" name="cbBlockDeep">
          <property name="toolTip">
-          <string>Apply Layer attribute also to all sub-entities of selected Insert.
-This recursively modifies all entities of the Block itself and
-CAN NOT be undone.</string>
+          <string>Apply attributes also to all sub-entities of selected INSERT.
+This recursively modifies all entities of the Block itself.</string>
          </property>
          <property name="text">
-          <string>Apply Layer Block-deep (EXPERIMENTAL, NO UNDO!)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbPenBlockDeep">
-         <property name="toolTip">
-          <string>Apply Pen attributes also to all sub-entities of selected Insert.
-This recursively modifies all entities of the Block itself and
-CAN NOT be undone.</string>
-         </property>
-         <property name="text">
-          <string>Apply Pen Block-deep (EXPERIMENTAL, NO UNDO!)</string>
+          <string>Apply attributes Block-deep</string>
          </property>
         </widget>
        </item>

--- a/librecad/src/ui/forms/qg_dlgattributes.ui
+++ b/librecad/src/ui/forms/qg_dlgattributes.ui
@@ -63,6 +63,30 @@
          </property>
         </widget>
        </item>
+       <item>
+        <widget class="QCheckBox" name="cbLayerBlockDeep">
+         <property name="toolTip">
+          <string>Apply Layer attribute also to all sub-entities of selected Insert.
+This recursively modifies all entities of the Block itself and
+CAN NOT be undone.</string>
+         </property>
+         <property name="text">
+          <string>Apply Layer Block-deep (EXPERIMENTAL, NO UNDO!)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbPenBlockDeep">
+         <property name="toolTip">
+          <string>Apply Pen attributes also to all sub-entities of selected Insert.
+This recursively modifies all entities of the Block itself and
+CAN NOT be undone.</string>
+         </property>
+         <property name="text">
+          <string>Apply Pen Block-deep (EXPERIMENTAL, NO UNDO!)</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
     </layout>


### PR DESCRIPTION
This tries to extend #762, fixes #1080, makes cautious approach for #755. User now has options to choose if he/she wants to apply attributes recursively to INSERTs.


UPDATED, see https://github.com/LibreCAD/LibreCAD/pull/1088#issuecomment-486094751

<!-- ![1](https://user-images.githubusercontent.com/14307537/56516271-ac089000-6542-11e9-93be-5be55b51300c.jpg) -->

<del>Unfortunately, I tried but failed to implement Undo for modified recursively Block entities. Anyway, I think this is a little bit better for the moment than bare #762.</del>