### PR TITLE
- fix #1098 Add a preference to allow whitespace in command interface

### DIFF
--- a/librecad/src/actions/rs_actionzoompan.cpp
+++ b/librecad/src/actions/rs_actionzoompan.cpp
@@ -98,9 +98,12 @@ void RS_ActionZoomPan::mousePressEvent(QMouseEvent* e) {
 
 
 
-void RS_ActionZoomPan::mouseReleaseEvent(QMouseEvent* /*e*/) {
-        setStatus(SetPanEnd);
-        trigger();
+void RS_ActionZoomPan::mouseReleaseEvent(QMouseEvent* e) {
+	if (e->button() == Qt::MiddleButton)
+		setStatus(SetPanEnd);
+	else
+		setStatus(SetPanStart);
+	trigger();
     //RS_DEBUG->print("RS_ActionZoomPan::mousePressEvent(): %f %f", v1.x, v1.y);
 }
 

--- a/librecad/src/ui/forms/qg_commandwidget.cpp
+++ b/librecad/src/ui/forms/qg_commandwidget.cpp
@@ -37,7 +37,6 @@
 #include "rs_commandevent.h"
 #include "rs_system.h"
 #include "rs_utility.h"
-#include "rs_settings.h"
 
 /*
  *  Constructs a QG_CommandWidget as a child of 'parent', with the

--- a/librecad/src/ui/forms/qg_commandwidget.cpp
+++ b/librecad/src/ui/forms/qg_commandwidget.cpp
@@ -37,6 +37,7 @@
 #include "rs_commandevent.h"
 #include "rs_system.h"
 #include "rs_utility.h"
+#include "rs_settings.h"
 
 /*
  *  Constructs a QG_CommandWidget as a child of 'parent', with the
@@ -77,6 +78,13 @@ QG_CommandWidget::QG_CommandWidget(QWidget* parent, const char* name, Qt::Window
     auto a3 = new QAction(QObject::tr("Paste Multiple Commands"), this);
     connect(a3, &QAction::triggered, leCommand, &QG_CommandEdit::modifiedPaste);
     options_button->addAction(a3);
+
+	auto a4 = new QAction(QObject::tr("Allow Whitespace"), this);
+	connect(a4, &QAction::triggered, this, &QG_CommandWidget::allowWhiteSpaceToggle);
+	a4->setObjectName("allow_whitespace");
+	a4->setCheckable(true);
+    a4->setChecked(RS_SETTINGS->readNumEntry("/command_interface_allow_whitespace", true));
+	options_button->addAction(a4);
 
     options_button->setStyleSheet("QToolButton::menu-indicator { image: none; }");
 }
@@ -283,6 +291,14 @@ void QG_CommandWidget::chooseCommandFile()
     {
         leCommand->readCommandFile(path);
     }
+}
+
+void QG_CommandWidget::allowWhiteSpaceToggle()
+{
+	auto action = findChild<QAction*>("allow_whitespace");
+    bool value = !RS_SETTINGS->readNumEntry("/command_interface_allow_whitespace", true);
+	RS_SETTINGS->writeEntry("/command_interface_allow_whitespace", value);
+	action->setChecked(value);
 }
 
 void QG_CommandWidget::handleKeycode(QString code)

--- a/librecad/src/ui/forms/qg_commandwidget.cpp
+++ b/librecad/src/ui/forms/qg_commandwidget.cpp
@@ -58,7 +58,7 @@ QG_CommandWidget::QG_CommandWidget(QWidget* parent, const char* name, Qt::Window
     connect(leCommand, SIGNAL(message(QString)), this, SLOT(appendHistory(QString)));
     connect(leCommand, &QG_CommandEdit::keycode, this, &QG_CommandWidget::handleKeycode);
 
-    auto a1 = new QAction(QObject::tr("Keycode Mode"), this);
+    auto a1 = new QAction(QObject::tr("Keycode mode"), this);
     a1->setObjectName("keycode_action");
     a1->setCheckable(true);
     connect(a1, &QAction::toggled, this, &QG_CommandWidget::setKeycodeMode);
@@ -71,19 +71,19 @@ QG_CommandWidget::QG_CommandWidget(QWidget* parent, const char* name, Qt::Window
         a1->setChecked(true);
     }
 
-    auto a2 = new QAction(QObject::tr("Load Command File"), this);
+    auto a2 = new QAction(QObject::tr("Load command file"), this);
     connect(a2, &QAction::triggered, this, &QG_CommandWidget::chooseCommandFile);
     options_button->addAction(a2);
 
-    auto a3 = new QAction(QObject::tr("Paste Multiple Commands"), this);
+    auto a3 = new QAction(QObject::tr("Paste multiple commands"), this);
     connect(a3, &QAction::triggered, leCommand, &QG_CommandEdit::modifiedPaste);
     options_button->addAction(a3);
 
-	auto a4 = new QAction(QObject::tr("Allow Whitespace"), this);
+	auto a4 = new QAction(QObject::tr("Evaluate when SPACE BAR is pressed"), this);
 	connect(a4, &QAction::triggered, this, &QG_CommandWidget::allowWhiteSpaceToggle);
 	a4->setObjectName("allow_whitespace");
 	a4->setCheckable(true);
-    a4->setChecked(RS_SETTINGS->readNumEntry("/command_interface_allow_whitespace", true));
+    a4->setChecked(!RS_SETTINGS->readNumEntry("/command_interface_allow_whitespace", true));
 	options_button->addAction(a4);
 
     options_button->setStyleSheet("QToolButton::menu-indicator { image: none; }");

--- a/librecad/src/ui/forms/qg_commandwidget.cpp
+++ b/librecad/src/ui/forms/qg_commandwidget.cpp
@@ -79,13 +79,6 @@ QG_CommandWidget::QG_CommandWidget(QWidget* parent, const char* name, Qt::Window
     connect(a3, &QAction::triggered, leCommand, &QG_CommandEdit::modifiedPaste);
     options_button->addAction(a3);
 
-	auto a4 = new QAction(QObject::tr("Evaluate when SPACE BAR is pressed"), this);
-	connect(a4, &QAction::triggered, this, &QG_CommandWidget::allowWhiteSpaceToggle);
-	a4->setObjectName("allow_whitespace");
-	a4->setCheckable(true);
-    a4->setChecked(!RS_SETTINGS->readNumEntry("/command_interface_allow_whitespace", true));
-	options_button->addAction(a4);
-
     options_button->setStyleSheet("QToolButton::menu-indicator { image: none; }");
 }
 
@@ -291,14 +284,6 @@ void QG_CommandWidget::chooseCommandFile()
     {
         leCommand->readCommandFile(path);
     }
-}
-
-void QG_CommandWidget::allowWhiteSpaceToggle()
-{
-	auto action = findChild<QAction*>("allow_whitespace");
-    bool value = !RS_SETTINGS->readNumEntry("/command_interface_allow_whitespace", true);
-	RS_SETTINGS->writeEntry("/command_interface_allow_whitespace", value);
-	action->setChecked(value);
 }
 
 void QG_CommandWidget::handleKeycode(QString code)

--- a/librecad/src/ui/forms/qg_commandwidget.h
+++ b/librecad/src/ui/forms/qg_commandwidget.h
@@ -56,6 +56,7 @@ public slots:
 protected slots:
     virtual void languageChange();
     virtual void chooseCommandFile();
+	virtual void allowWhiteSpaceToggle();
 
 private:
     QG_ActionHandler* actionHandler;

--- a/librecad/src/ui/forms/qg_commandwidget.h
+++ b/librecad/src/ui/forms/qg_commandwidget.h
@@ -56,7 +56,6 @@ public slots:
 protected slots:
     virtual void languageChange();
     virtual void chooseCommandFile();
-	virtual void allowWhiteSpaceToggle();
 
 private:
     QG_ActionHandler* actionHandler;

--- a/librecad/src/ui/forms/qg_dlgoptionsgeneral.cpp
+++ b/librecad/src/ui/forms/qg_dlgoptionsgeneral.cpp
@@ -200,10 +200,8 @@ void QG_DlgOptionsGeneral::init()
     cad_toolbars_checkbox->setChecked(RS_SETTINGS->readNumEntry("/EnableCADToolbars", 1));
     RS_SETTINGS->endGroup();
 
-	//RS_SETTINGS->beginGroup("/Keyboard");
 	cbEvaluateOnSpace->setChecked(RS_SETTINGS->readNumEntry("/Keyboard/EvaluateCommandOnSpace", false));
 	cbToggleFreeSnapOnSpace->setChecked(RS_SETTINGS->readNumEntry("/Keyboard/ToggleFreeSnapOnSpace", false));
-	//RS_SETTINGS->endGroup();
 
     restartNeeded = false;
 }
@@ -296,10 +294,8 @@ void QG_DlgOptionsGeneral::ok()
         RS_SETTINGS->writeEntry("/EnableCADToolbars", cad_toolbars_checkbox->isChecked()?1:0);
         RS_SETTINGS->endGroup();
 
-		//RS_SETTINGS->beginGroup("/Keyboard");
 		RS_SETTINGS->writeEntry("/Keyboard/EvaluateCommandOnSpace", cbEvaluateOnSpace->isChecked() ? 1 : 0);
 		RS_SETTINGS->writeEntry("/Keyboard/ToggleFreeSnapOnSpace", cbToggleFreeSnapOnSpace->isChecked() ? 1 : 0);
-		//RS_SETTINGS->endGroup();
     }
 	
 	if (restartNeeded==true) {

--- a/librecad/src/ui/forms/qg_dlgoptionsgeneral.cpp
+++ b/librecad/src/ui/forms/qg_dlgoptionsgeneral.cpp
@@ -200,6 +200,11 @@ void QG_DlgOptionsGeneral::init()
     cad_toolbars_checkbox->setChecked(RS_SETTINGS->readNumEntry("/EnableCADToolbars", 1));
     RS_SETTINGS->endGroup();
 
+	//RS_SETTINGS->beginGroup("/Keyboard");
+	cbEvaluateOnSpace->setChecked(RS_SETTINGS->readNumEntry("/Keyboard/EvaluateCommandOnSpace", false));
+	cbToggleFreeSnapOnSpace->setChecked(RS_SETTINGS->readNumEntry("/Keyboard/ToggleFreeSnapOnSpace", false));
+	//RS_SETTINGS->endGroup();
+
     restartNeeded = false;
 }
 
@@ -290,10 +295,14 @@ void QG_DlgOptionsGeneral::ok()
         RS_SETTINGS->writeEntry("/EnableLeftSidebar", left_sidebar_checkbox->isChecked()?1:0);
         RS_SETTINGS->writeEntry("/EnableCADToolbars", cad_toolbars_checkbox->isChecked()?1:0);
         RS_SETTINGS->endGroup();
+
+		//RS_SETTINGS->beginGroup("/Keyboard");
+		RS_SETTINGS->writeEntry("/Keyboard/EvaluateCommandOnSpace", cbEvaluateOnSpace->isChecked() ? 1 : 0);
+		RS_SETTINGS->writeEntry("/Keyboard/ToggleFreeSnapOnSpace", cbToggleFreeSnapOnSpace->isChecked() ? 1 : 0);
+		//RS_SETTINGS->endGroup();
     }
-
-
-    if (restartNeeded==true) {
+	
+	if (restartNeeded==true) {
         QMessageBox::warning( this, tr("Preferences"),
                               tr("Please restart the application to apply all changes."),
                               QMessageBox::Ok,

--- a/librecad/src/ui/forms/qg_dlgoptionsgeneral.ui
+++ b/librecad/src/ui/forms/qg_dlgoptionsgeneral.ui
@@ -39,7 +39,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tab_1">
       <attribute name="title">
@@ -892,151 +892,6 @@
        <string>&amp;Defaults</string>
       </attribute>
       <layout class="QGridLayout">
-       <item row="1" column="1">
-        <widget class="QGroupBox" name="groupBox_2">
-         <property name="title">
-          <string>Startup</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <item>
-           <widget class="QCheckBox" name="cbSplash">
-            <property name="text">
-             <string>Display loading screen</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="tab_mode_check_box">
-            <property name="text">
-             <string>Start in tab mode</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="maximize_checkbox">
-            <property name="text">
-             <string>Start with main window maximized</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="left_sidebar_checkbox">
-            <property name="text">
-             <string>Enable CAD dockwidgets</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="cad_toolbars_checkbox">
-            <property name="text">
-             <string>Enable CAD toolbars</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="0" column="1">
-        <widget class="QGroupBox" name="groupBox_3">
-         <property name="title">
-          <string>Clear Settings</string>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
-          <item>
-           <widget class="QPushButton" name="pb_clear_geometry">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>restores program geometry/layout to original state</string>
-            </property>
-            <property name="text">
-             <string>Layout</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="pb_clear_all">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>restores the program to its original state</string>
-            </property>
-            <property name="text">
-             <string>All</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QGroupBox" name="buttonGroup5">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>70</height>
-          </size>
-         </property>
-         <property name="title">
-          <string>Defaults for new drawings</string>
-         </property>
-         <layout class="QHBoxLayout">
-          <item>
-           <widget class="QLabel" name="lUnit">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>&amp;Unit:</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-            <property name="buddy">
-             <cstring>cbUnit</cstring>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="cbUnit">
-            <property name="toolTip">
-             <string>Drawing unit.</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
        <item row="1" column="0">
         <widget class="QGroupBox" name="groupBox">
          <property name="sizePolicy">
@@ -1133,6 +988,177 @@
             </property>
             <property name="text">
              <string>Invert zoom direction</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="1">
+        <widget class="QGroupBox" name="groupBox_3">
+         <property name="title">
+          <string>Clear Settings</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QPushButton" name="pb_clear_geometry">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>restores program geometry/layout to original state</string>
+            </property>
+            <property name="text">
+             <string>Layout</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pb_clear_all">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>restores the program to its original state</string>
+            </property>
+            <property name="text">
+             <string>All</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QGroupBox" name="groupBox_2">
+         <property name="title">
+          <string>Startup</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QCheckBox" name="cbSplash">
+            <property name="text">
+             <string>Display loading screen</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="tab_mode_check_box">
+            <property name="text">
+             <string>Start in tab mode</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="maximize_checkbox">
+            <property name="text">
+             <string>Start with main window maximized</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="left_sidebar_checkbox">
+            <property name="text">
+             <string>Enable CAD dockwidgets</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cad_toolbars_checkbox">
+            <property name="text">
+             <string>Enable CAD toolbars</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QGroupBox" name="buttonGroup5">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>70</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Defaults for new drawings</string>
+         </property>
+         <layout class="QHBoxLayout">
+          <item>
+           <widget class="QLabel" name="lUnit">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>&amp;Unit:</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+            <property name="buddy">
+             <cstring>cbUnit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="cbUnit">
+            <property name="toolTip">
+             <string>Drawing unit.</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QGroupBox" name="groupBox_4">
+         <property name="title">
+          <string>Keyboard Settings</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <widget class="QCheckBox" name="cbEvaluateOnSpace">
+            <property name="text">
+             <string>Evaluate commands when SPACE BAR is pressed</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbToggleFreeSnapOnSpace">
+            <property name="toolTip">
+             <string>Toggle free snap mode when the SPACE BAR is pressed and the command window is empty</string>
+            </property>
+            <property name="text">
+             <string>Toggle free snap mode when SPACE BAR is pressed</string>
             </property>
            </widget>
           </item>

--- a/librecad/src/ui/forms/qg_dlgoptionsgeneral.ui
+++ b/librecad/src/ui/forms/qg_dlgoptionsgeneral.ui
@@ -39,7 +39,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab_1">
       <attribute name="title">

--- a/librecad/src/ui/qg_actionhandler.cpp
+++ b/librecad/src/ui/qg_actionhandler.cpp
@@ -167,6 +167,7 @@
 #include "qg_snaptoolbar.h"
 #include "rs_debug.h"
 #include "rs_layer.h"
+#include "rs_settings.h"
 
 /**
  * Constructor
@@ -1114,7 +1115,8 @@ bool QG_ActionHandler::command(const QString& cmd)
 
     if (cmd.isEmpty())
     {
-        slotSnapFree();
+		if (RS_SETTINGS->readNumEntry("/Keyboard/ToggleFreeSnapOnSpace", true))
+			slotSnapFree();
         return true;
     }
 

--- a/librecad/src/ui/qg_commandedit.cpp
+++ b/librecad/src/ui/qg_commandedit.cpp
@@ -147,9 +147,10 @@ void QG_CommandEdit::keyPressEvent(QKeyEvent* e)
             processInput(text());
             break;
 		case Qt::Key_Space:
-            if (!RS_SETTINGS->readNumEntry("/command_interface_allow_whitespace", true))
+			if (RS_SETTINGS->readNumEntry("/Keyboard/EvaluateCommandOnSpace", true) ||
+				(text().isEmpty() && RS_SETTINGS->readNumEntry("/Keyboard/ToggleFreeSnapOnSpace", true)))
 				processInput(text());
-            else
+            else if (!text().isEmpty())
                 QLineEdit::keyPressEvent(e);
 			break;
         case Qt::Key_Escape:

--- a/librecad/src/ui/qg_commandedit.cpp
+++ b/librecad/src/ui/qg_commandedit.cpp
@@ -34,6 +34,7 @@
 #include <QClipboard>
 
 #include <rs_math.h>
+#include <rs_settings.h>
 
 
 /**
@@ -142,11 +143,15 @@ void QG_CommandEdit::keyPressEvent(QKeyEvent* e)
             break;
 
         case Qt::Key_Enter:
-        case Qt::Key_Space:
         case Qt::Key_Return:
             processInput(text());
-
             break;
+		case Qt::Key_Space:
+            if (!RS_SETTINGS->readNumEntry("/command_interface_allow_whitespace", true))
+				processInput(text());
+            else
+                QLineEdit::keyPressEvent(e);
+			break;
         case Qt::Key_Escape:
             if (text().isEmpty()) {
                 emit escape();


### PR DESCRIPTION
- add new preference to allow whitespace in the command interface (the 2.1.3 behavior)
- add new checkable button to command interface popup menu to toggle the pref
- check the pref before interpreting space as eval trigger