### PR TITLE
fix build with gcc 9

### DIFF
--- a/librecad/src/actions/rs_actiondrawcircletan1_2p.cpp
+++ b/librecad/src/actions/rs_actiondrawcircletan1_2p.cpp
@@ -38,7 +38,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 namespace{
 //list of entity types supported by current action
-auto enTypeList={RS2::EntityLine, RS2::EntityArc, RS2::EntityCircle};
+static auto enTypeList={RS2::EntityLine, RS2::EntityArc, RS2::EntityCircle};
 }
 
 struct RS_ActionDrawCircleTan1_2P::Points {

--- a/librecad/src/actions/rs_actiondrawcircletan2.cpp
+++ b/librecad/src/actions/rs_actiondrawcircletan2.cpp
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "rs_debug.h"
 
 namespace {
-auto enTypeList={RS2::EntityLine, RS2::EntityArc, RS2::EntityCircle};
+static auto enTypeList={RS2::EntityLine, RS2::EntityArc, RS2::EntityCircle};
 }
 
 struct RS_ActionDrawCircleTan2::Points {

--- a/librecad/src/actions/rs_actiondrawcircletan2_1p.cpp
+++ b/librecad/src/actions/rs_actiondrawcircletan2_1p.cpp
@@ -36,7 +36,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "rs_debug.h"
 
 namespace {
-auto enTypeList={RS2::EntityLine, RS2::EntityArc, RS2::EntityCircle};
+static auto enTypeList={RS2::EntityLine, RS2::EntityArc, RS2::EntityCircle};
 }
 
 struct RS_ActionDrawCircleTan2_1P::Points {

--- a/librecad/src/actions/rs_actiondrawcircletan3.cpp
+++ b/librecad/src/actions/rs_actiondrawcircletan3.cpp
@@ -36,7 +36,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "rs_debug.h"
 
 namespace {
-auto enTypeList={RS2::EntityArc, RS2::EntityCircle, RS2::EntityLine, RS2::EntityPoint};
+static auto enTypeList={RS2::EntityArc, RS2::EntityCircle, RS2::EntityLine, RS2::EntityPoint};
 }
 
 struct RS_ActionDrawCircleTan3::Points {

--- a/librecad/src/actions/rs_actiondrawlinerelangle.cpp
+++ b/librecad/src/actions/rs_actiondrawlinerelangle.cpp
@@ -39,7 +39,7 @@
 #include "rs_debug.h"
 
 namespace {
-auto enTypeList={RS2::EntityLine, RS2::EntityArc, RS2::EntityCircle,
+static auto enTypeList={RS2::EntityLine, RS2::EntityArc, RS2::EntityCircle,
 				 RS2::EntityEllipse};
 }
 

--- a/librecad/src/actions/rs_actiondrawlinetangent1.cpp
+++ b/librecad/src/actions/rs_actiondrawlinetangent1.cpp
@@ -37,7 +37,7 @@
 #include "rs_debug.h"
 
 namespace{
-auto circleType={RS2::EntityArc, RS2::EntityCircle,
+static auto circleType={RS2::EntityArc, RS2::EntityCircle,
 				 RS2::EntityEllipse, RS2::EntitySplinePoints
 				};
 }

--- a/librecad/src/actions/rs_actiondrawlinetangent2.cpp
+++ b/librecad/src/actions/rs_actiondrawlinetangent2.cpp
@@ -36,7 +36,7 @@
 #include "rs_debug.h"
 
 namespace{
-auto circleType={RS2::EntityArc, RS2::EntityCircle, RS2::EntityEllipse};
+static auto circleType={RS2::EntityArc, RS2::EntityCircle, RS2::EntityEllipse};
 }
 
 RS_ActionDrawLineTangent2::RS_ActionDrawLineTangent2(


### PR DESCRIPTION
These symbols were reported as multiply defined with gcc9. So make them
local to the translation unit.