### PR TITLE
Use unique variable names to prevent multiple definition link errors

### DIFF
--- a/librecad/src/actions/rs_actiondrawcircletan1_2p.cpp
+++ b/librecad/src/actions/rs_actiondrawcircletan1_2p.cpp
@@ -38,7 +38,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 namespace{
 //list of entity types supported by current action
-auto enTypeList={RS2::EntityLine, RS2::EntityArc, RS2::EntityCircle};
+auto enTypeList1_2={RS2::EntityLine, RS2::EntityArc, RS2::EntityCircle};
 }
 
 struct RS_ActionDrawCircleTan1_2P::Points {
@@ -181,7 +181,7 @@ void RS_ActionDrawCircleTan1_2P::mouseMoveEvent(QMouseEvent* e) {
     }
     case SetCenter: {
 
-        //        RS_Entity*  en = catchEntity(e, enTypeList, RS2::ResolveAll);
+        //        RS_Entity*  en = catchEntity(e, enTypeList1_2, RS2::ResolveAll);
 		pPoints->coord= graphicView->toGraph(e->x(), e->y());
         //        circles[getStatus()]=static_cast<RS_Line*>(en);
         if(preparePreview()) {
@@ -272,7 +272,7 @@ bool RS_ActionDrawCircleTan1_2P::preparePreview(){
 
 RS_Entity* RS_ActionDrawCircleTan1_2P::catchCircle(QMouseEvent* e) {
 	RS_Entity* ret=nullptr;
-	RS_Entity* en = catchEntity(e,enTypeList, RS2::ResolveAll);
+	RS_Entity* en = catchEntity(e,enTypeList1_2, RS2::ResolveAll);
 	if (!en) return ret;
 	if (!en->isVisible()) return ret;
 	if (en->getParent()) {

--- a/librecad/src/actions/rs_actiondrawcircletan2.cpp
+++ b/librecad/src/actions/rs_actiondrawcircletan2.cpp
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "rs_debug.h"
 
 namespace {
-auto enTypeList={RS2::EntityLine, RS2::EntityArc, RS2::EntityCircle};
+auto enTypeList2={RS2::EntityLine, RS2::EntityArc, RS2::EntityCircle};
 }
 
 struct RS_ActionDrawCircleTan2::Points {
@@ -121,7 +121,7 @@ void RS_ActionDrawCircleTan2::mouseMoveEvent(QMouseEvent* e) {
 
     switch(getStatus() ){
     case SetCenter: {
-        //        RS_Entity*  en = catchEntity(e, enTypeList, RS2::ResolveAll);
+        //        RS_Entity*  en = catchEntity(e, enTypeList2, RS2::ResolveAll);
 		pPoints->coord= graphicView->toGraph(e->x(), e->y());
         //        circles[getStatus()]=static_cast<RS_Line*>(en);
         if(preparePreview()) {
@@ -166,7 +166,7 @@ bool RS_ActionDrawCircleTan2::preparePreview(){
 }
 
 RS_Entity* RS_ActionDrawCircleTan2::catchCircle(QMouseEvent* e) {
-    RS_Entity*  en = catchEntity(e,enTypeList, RS2::ResolveAll);
+    RS_Entity*  en = catchEntity(e,enTypeList2, RS2::ResolveAll);
 	if (!en) return nullptr;
 	if (!en->isVisible()) return nullptr;
 	for (int i=0;i<getStatus();i++) {

--- a/librecad/src/actions/rs_actiondrawcircletan2_1p.cpp
+++ b/librecad/src/actions/rs_actiondrawcircletan2_1p.cpp
@@ -36,7 +36,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "rs_debug.h"
 
 namespace {
-auto enTypeList={RS2::EntityLine, RS2::EntityArc, RS2::EntityCircle};
+auto enTypeList2_1={RS2::EntityLine, RS2::EntityArc, RS2::EntityCircle};
 }
 
 struct RS_ActionDrawCircleTan2_1P::Points {
@@ -184,7 +184,7 @@ bool RS_ActionDrawCircleTan2_1P::preparePreview(){
 
 RS_Entity* RS_ActionDrawCircleTan2_1P::catchCircle(QMouseEvent* e) {
 	RS_Entity* ret=nullptr;
-    RS_Entity*  en = catchEntity(e,enTypeList, RS2::ResolveAll);
+    RS_Entity*  en = catchEntity(e,enTypeList2_1, RS2::ResolveAll);
 	if (!en) return ret;
 	if (!en->isVisible()) return ret;
 	for(auto p: pPoints->circles){

--- a/librecad/src/actions/rs_actiondrawcircletan3.cpp
+++ b/librecad/src/actions/rs_actiondrawcircletan3.cpp
@@ -36,7 +36,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "rs_debug.h"
 
 namespace {
-auto enTypeList={RS2::EntityArc, RS2::EntityCircle, RS2::EntityLine, RS2::EntityPoint};
+auto enTypeList3={RS2::EntityArc, RS2::EntityCircle, RS2::EntityLine, RS2::EntityPoint};
 }
 
 struct RS_ActionDrawCircleTan3::Points {
@@ -125,7 +125,7 @@ void RS_ActionDrawCircleTan3::mouseMoveEvent(QMouseEvent* e) {
 
 	switch(getStatus() ){
 	case SetCenter: {
-		//        RS_Entity*  en = catchEntity(e, enTypeList, RS2::ResolveAll);
+		//        RS_Entity*  en = catchEntity(e, enTypeList3, RS2::ResolveAll);
 		pPoints->coord= graphicView->toGraph(e->x(), e->y());
 		//        circles[getStatus()]=static_cast<RS_Line*>(en);
 		deletePreview();
@@ -326,7 +326,7 @@ bool RS_ActionDrawCircleTan3::preparePreview(){
 
 RS_Entity* RS_ActionDrawCircleTan3::catchCircle(QMouseEvent* e) {
     RS_Entity* ret=nullptr;
-	RS_Entity*  en = catchEntity(e,enTypeList, RS2::ResolveAll);
+	RS_Entity*  en = catchEntity(e,enTypeList3, RS2::ResolveAll);
 	if (!en) return ret;
 	if (!en->isVisible()) return ret;
 	for(int i=0;i<getStatus();++i) {

--- a/librecad/src/actions/rs_actiondrawlinetangent1.cpp
+++ b/librecad/src/actions/rs_actiondrawlinetangent1.cpp
@@ -37,7 +37,7 @@
 #include "rs_debug.h"
 
 namespace{
-auto circleType={RS2::EntityArc, RS2::EntityCircle,
+auto circleType1={RS2::EntityArc, RS2::EntityCircle,
 				 RS2::EntityEllipse, RS2::EntitySplinePoints
 				};
 }
@@ -106,7 +106,7 @@ void RS_ActionDrawLineTangent1::mouseMoveEvent(QMouseEvent* e) {
 		break;
 
 	case SetCircle: {
-		RS_Entity* en = catchEntity(e, circleType, RS2::ResolveAll);
+		RS_Entity* en = catchEntity(e, circleType1, RS2::ResolveAll);
 		if (en && (en->isArc() ||
 				   en->rtti()==RS2::EntitySplinePoints)) {
 			if(circle){

--- a/librecad/src/actions/rs_actiondrawlinetangent2.cpp
+++ b/librecad/src/actions/rs_actiondrawlinetangent2.cpp
@@ -36,7 +36,7 @@
 #include "rs_debug.h"
 
 namespace{
-auto circleType={RS2::EntityArc, RS2::EntityCircle, RS2::EntityEllipse};
+auto circleType2={RS2::EntityArc, RS2::EntityCircle, RS2::EntityEllipse};
 }
 
 RS_ActionDrawLineTangent2::RS_ActionDrawLineTangent2(
@@ -100,7 +100,7 @@ void RS_ActionDrawLineTangent2::mouseMoveEvent(QMouseEvent* e) {
 //    RS_DEBUG->print("RS_ActionDrawLineTangent2::mouseMoveEvent begin");
 	e->accept();
     if(getStatus() != SetCircle2) return;
-	RS_Entity* en= catchEntity(e, circleType, RS2::ResolveAll);
+	RS_Entity* en= catchEntity(e, circleType2, RS2::ResolveAll);
 	if(!en || en==circle1) return;
 	if(circle2){
 		circle2->setHighlighted(false);
@@ -140,7 +140,7 @@ void RS_ActionDrawLineTangent2::mouseReleaseEvent(QMouseEvent* e) {
     switch (getStatus()) {
     case SetCircle1:
     {
-        circle1 = catchEntity(e, circleType, RS2::ResolveAll);
+        circle1 = catchEntity(e, circleType2, RS2::ResolveAll);
 		if(!circle1) return;
         circle1->setHighlighted(true);
 		graphicView->drawEntity(circle1);


### PR DESCRIPTION
First noticed in Fedora 30. 

All of these files define the same named variable for list of entity types (enTypeList):
librecad/src/actions/rs_actiondrawcircletan1_2p.cpp
librecad/src/actions/rs_actiondrawcircletan2_1p.cpp
librecad/src/actions/rs_actiondrawcircletan2.cpp
librecad/src/actions/rs_actiondrawcircletan3.cpp

Additionally, these two files define the same named variable for circleType:
librecad/src/actions/rs_actiondrawlinetangent1.cpp
librecad/src/actions/rs_actiondrawlinetangent2.cpp

That variable gets exposed as a symbol in the compiled object files, and they conflict at link time:

/usr/bin/ld: ../../generated/librecad/obj/rs_actiondrawcircletan2_1p.o:(.rodata+0x0): multiple definition of `_ZGRN12_GLOBAL__N_110enTypeListE_'; ../../generated/librecad/obj/rs_actiondrawcircletan1_2p.o:(.rodata+0x0): first defined here
/usr/bin/ld: ../../generated/librecad/obj/rs_actiondrawcircletan2.o:(.rodata+0x0): multiple definition of `_ZGRN12_GLOBAL__N_110enTypeListE_'; ../../generated/librecad/obj/rs_actiondrawcircletan1_2p.o:(.rodata+0x0): first defined here
/usr/bin/ld: ../../generated/librecad/obj/rs_actiondrawcircletan3.o:(.rodata+0x0): multiple definition of `_ZGRN12_GLOBAL__N_110enTypeListE_'; ../../generated/librecad/obj/rs_actiondrawcircletan1_2p.o:(.rodata+0x0): first defined here
/usr/bin/ld: ../../generated/librecad/obj/rs_actiondrawlinerelangle.o:(.rodata+0x0): multiple definition of `_ZGRN12_GLOBAL__N_110enTypeListE_'; ../../generated/librecad/obj/rs_actiondrawcircletan1_2p.o:(.rodata+0x0): first defined here
/usr/bin/ld: ../../generated/librecad/obj/rs_actiondrawlinetangent2.o:(.rodata+0x0): multiple definition of `_ZGRN12_GLOBAL__N_110circleTypeE_'; ../../generated/librecad/obj/rs_actiondrawlinetangent1.o:(.rodata+0x0): first defined here
collect2: error: ld returned 1 exit status

By renaming these two variables to be unique across the codebase, we avoid the linking error. This PR makes that change, using the existing naming schema provided by those files.

