### PR TITLE
Feature/issue1108

### DIFF
--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -458,7 +458,7 @@ void QC_ApplicationWindow::setTabLayout(RS2::TabShape s, RS2::TabPosition p)
  * @return true success (or window was not modified)
  * @return false user cancelled (or window was null)
  */
-bool QC_ApplicationWindow::doSave(QC_MDIWindow * w)
+bool QC_ApplicationWindow::doSave(QC_MDIWindow * w, bool forceSaveAs)
 {
 	QString name, msg;
 	bool cancelled;
@@ -469,7 +469,8 @@ bool QC_ApplicationWindow::doSave(QC_MDIWindow * w)
 			doActivate(w); // show the user the drawing for save as
 		msg = name.isEmpty() ? tr("Saving drawing...") : tr("Saving drawing: %1").arg(name);
 		statusBar()->showMessage(msg);
-		if (w->slotFileSave(cancelled)) {
+		bool res = forceSaveAs ? w->slotFileSaveAs(cancelled) : w->slotFileSave(cancelled);
+		if (res) {
 			if (cancelled) {
 				statusBar()->showMessage(tr("Save cancelled"), 2000);
 				return false;
@@ -1897,7 +1898,8 @@ void QC_ApplicationWindow::slotFileSave() {
  */
 void QC_ApplicationWindow::slotFileSaveAs() {
     RS_DEBUG->print("QC_ApplicationWindow::slotFileSaveAs()");
-	slotFileSave();
+	if (doSave(getMDIWindow(), true))
+		recentFiles->updateRecentFilesMenu();
 }
 
 bool QC_ApplicationWindow::slotFileSaveAll()

--- a/librecad/src/main/qc_applicationwindow.h
+++ b/librecad/src/main/qc_applicationwindow.h
@@ -310,7 +310,7 @@ private:
 	// more helpers
 	void doArrangeWindows(RS2::SubWindowMode mode, bool actuallyDont = false);
 	void setTabLayout(RS2::TabShape s, RS2::TabPosition p);
-	bool doSave(QC_MDIWindow* w);
+	bool doSave(QC_MDIWindow* w, bool forceSaveAs = false);
 	void doClose(QC_MDIWindow* w, bool activateNext = true);
 	void doActivate(QMdiSubWindow* w);
 	int showCloseDialog(QC_MDIWindow* w, bool showSaveAll = false);


### PR DESCRIPTION
My previous pull request for issue 1108 introduced a regression for the Save As... function, and I didn't catch it until the pull request had already been merged.  Clicking on File > Save As did not show the dialog if the file was already saved.  This problem is now fixed.