### PR TITLE
Fix persistence of the angle in a MoveRotate operation

### DIFF
--- a/librecad/src/ui/forms/qg_moverotateoptions.cpp
+++ b/librecad/src/ui/forms/qg_moverotateoptions.cpp
@@ -44,7 +44,7 @@ QG_MoveRotateOptions::QG_MoveRotateOptions(QWidget* parent, Qt::WindowFlags fl)
 
 void QG_MoveRotateOptions::saveSettings() {
     RS_SETTINGS->beginGroup("/Modify");
-	RS_SETTINGS->writeEntry("/MoveRotate", ui->leAngle->text());
+	RS_SETTINGS->writeEntry("/MoveRotateAngle", ui->leAngle->text());
     RS_SETTINGS->endGroup();
 }
 
@@ -58,7 +58,7 @@ void QG_MoveRotateOptions::setAction(RS_ActionInterface* a, bool update) {
             sa = QString("%1").arg(RS_Math::rad2deg(action->getAngle()));
         } else {
             RS_SETTINGS->beginGroup("/Modify");
-            sa = RS_SETTINGS->readEntry("/MoveRotate", "30");
+            sa = RS_SETTINGS->readEntry("/MoveRotateAngle", "30");
             RS_SETTINGS->endGroup();
             action->setAngle(RS_Math::deg2rad(sa.toDouble()));
         }
@@ -92,4 +92,3 @@ void QG_MoveRotateOptions::languageChange()
 {
 	ui->retranslateUi(this);
 }
-


### PR DESCRIPTION
    Prior to this change, because of an inconsistency between
    librecad/src/ui/forms/qg_moverotateoptions.cpp using "MoveRotate" for
    the name of the settings holding the angle but
    librecad/src/ui/forms/qg_lg_moverotate.cpp using "MoveRotateAngle", the
    previously used value of this angle would not show up in the next
    invocation of the MoveRotate dialog; rather, it would always be 30 degrees.

    This commit fixes this unhelpful behavior by conforming both files
    to use "MoveRotateAngle" as the name of the setting. Now the previously
    used value of the angle does show up in the next invocation of the dialog.