### PR TITLE
Add ability to copy objects and mini dialog to set options to Align p…

### DIFF
--- a/librecad/src/main/doc_plugin_interface.h
+++ b/librecad/src/main/doc_plugin_interface.h
@@ -60,10 +60,10 @@ public:
     virtual void getPolylineData(QList<Plug_VertexData> *data);
     virtual void updatePolylineData(QList<Plug_VertexData> *data);
 
-	virtual void move(QPointF offset);
-	virtual void moveRotate(QPointF const& offset, QPointF const& center, double angle);
-	virtual void rotate(QPointF center, double angle);
-    virtual void scale(QPointF center, QPointF factor);
+    virtual void move(QPointF offset, DPI::Disposition disp = DPI::DELETE_ORIGINAL);
+    virtual void moveRotate(QPointF const& offset, QPointF const& center, double angle, DPI::Disposition disp = DPI::DELETE_ORIGINAL);
+    virtual void rotate(QPointF center, double angle, DPI::Disposition disp = DPI::DELETE_ORIGINAL);
+    virtual void scale(QPointF center, QPointF factor, DPI::Disposition disp = DPI::DELETE_ORIGINAL);
     virtual QString intColor2str(int color);
 private:
     RS_Entity* entity;
@@ -125,7 +125,7 @@ public:
     QString realToStr(const qreal num, const int units = 0, const int prec = 0);
 
     //method to handle undo in Plugin_Entity 
-    bool addToUndo(RS_Entity* current, RS_Entity* modified);
+    bool addToUndo(RS_Entity* current, RS_Entity* modified, DPI::Disposition how);
 private:
     RS_Document *doc;
     RS_Graphic *docGr;

--- a/librecad/src/plugins/document_interface.h
+++ b/librecad/src/plugins/document_interface.h
@@ -48,8 +48,13 @@ namespace DPI {
         HAlignRight     /*!< Right */
     };
 
+    //! Options for what to do with originals in a modification
+    enum Disposition {
+	DELETE_ORIGINAL,
+	KEEP_ORIGINAL
+    };
 
-   //! Entity's type.
+    //! Entity's type.
     enum ETYPE {
         POINT,
         LINE,
@@ -242,24 +247,34 @@ public:
     //! Move the entity.
     /*!
     *  \param offset move the entity by the given QPointF.
+    *  \param disp whether to delete the original entity or keep it
     */
-    virtual void move(QPointF offset) = 0;
+    virtual void move(QPointF offset, DPI::Disposition disp = DPI::DELETE_ORIGINAL ) = 0;
 
-	virtual void moveRotate(QPointF const& offset, QPointF const& center, double angle)=0;
+    //! Move and rotate the entity.
+    /*!
+    *  \param offset move the entity by the given QPointF.
+    *  \param center center of rotation
+    *  \param angle angle to rotate
+    *  \param disp whether to delete the original entity or keep it
+    */
+    virtual void moveRotate(QPointF const& offset, QPointF const& center, double angle, DPI::Disposition disp = DPI::DELETE_ORIGINAL) = 0;
 
     //! rotate the entity.
     /*!
     *  \param center center of rotation.
     *  \param angle angle to rotate.
+    *  \param disp whether to delete the original entity or keep it
     */
-    virtual void rotate(QPointF center, double angle) = 0;
+    virtual void rotate(QPointF center, double angle, DPI::Disposition disp = DPI::DELETE_ORIGINAL) = 0;
 
     //! Scale the entity.
     /*!
     *  \param center base point for scale.
     *  \param factor scale factor.
+    *  \param disp whether to delete the original entity or keep it
     */
-    virtual void scale(QPointF center, QPointF factor) = 0;
+    virtual void scale(QPointF center, QPointF factor, DPI::Disposition disp = DPI::DELETE_ORIGINAL) = 0;
 
     //! Utility: Get color as string.
     /*!

--- a/plugins/align/align.cpp
+++ b/plugins/align/align.cpp
@@ -15,6 +15,10 @@
 #include "align.h"
 #include <cmath>
 
+#include <QCheckBox>
+#include <QMessageBox>
+#include <QSettings>
+
 QString LC_Align::name() const
  {
      return (tr("Align"));
@@ -24,7 +28,8 @@ PluginCapabilities LC_Align::getCapabilities() const
 {
     PluginCapabilities pluginCapabilities;
     pluginCapabilities.menuEntryPoints
-            << PluginMenuLocation("plugins_menu", tr("Align"));
+            << PluginMenuLocation("plugins_menu", tr("Align"))
+	    << PluginMenuLocation("plugins_menu", tr("Align settings..."));
     return pluginCapabilities;
 }
 
@@ -32,21 +37,59 @@ void LC_Align::execComm(Document_Interface *doc,
                              QWidget *parent, QString cmd)
 {
     Q_UNUSED(parent);
-    Q_UNUSED(cmd);
+
+    /* First load the settings */
+    QSettings settings(QSettings::IniFormat, QSettings::UserScope,
+		       "LibreCAD", "align_plugin");
+    bool keep_orig = settings.value("keep_original", false).toBool();
+    bool base_first = settings.value("base_first", false).toBool();
+    bool acting = true;
+
+    if (cmd.length() > 6) { // cheapo settings dialog, could be improved
+        QCheckBox* cbkeep = new QCheckBox(tr("Keep original objects"));
+        QCheckBox* cbbase = new QCheckBox(tr("Specify base points first"));
+	cbkeep->setChecked(keep_orig);
+	cbbase->setChecked(base_first);
+        QMessageBox setdlg;
+	setdlg.setWindowTitle(tr("Align Settings"));
+	setdlg.addButton(cbkeep, QMessageBox::ActionRole);
+	setdlg.addButton(cbbase, QMessageBox::ActionRole);
+	setdlg.setText(tr("Click on options to set/unset,\n"
+			  "Ok to accept and start alignment."));
+	setdlg.setDetailedText(
+	       tr("If 'Keep original objects' is checked,\n"
+		  "Align will copy rather than move the selected objects.\n\n"
+		  "If 'Specify base points first' is checked,\n"
+		  "Align will prompt for the alignment points in the order\n"
+		  "first base, second base, first target, second target.")
+			       );
+	QPushButton* okpushbtn = setdlg.addButton(QMessageBox::Ok);
+	QAbstractButton* okbtn = (QAbstractButton*)okpushbtn;
+	while (acting) {
+	    setdlg.exec();
+	    keep_orig = cbkeep->isChecked();
+	    base_first = cbbase->isChecked();
+	    if (setdlg.clickedButton() == okbtn) acting = false;
+	}
+	settings.setValue("keep_original", keep_orig);
+	settings.setValue("base_first", base_first);
+    }
     QPointF base1, base2, target1, target2;
     QList<Plug_Entity *> obj;
     bool yes  = doc->getSelect(&obj);
     if (!yes || obj.isEmpty()) return;
     yes = doc->getPoint(&base1, QString(tr("first base point:")));
-    if (yes) {
+    while (yes) {
+        if (base_first)
+	     yes = doc->getPoint(&base2, QString(tr("second base point:")));
+	if (!yes) break;
         yes = doc->getPoint(&target1, QString(tr("first target point:")), &base1);
-        if (yes) {
-            yes = doc->getPoint(&base2, QString(tr("second base point:")));
-            if (yes) {
-                yes = doc->getPoint(&target2, QString(tr("second target point:")), &base2);
-            }
-        }
-
+	if (!yes) break;
+	if (!base_first)
+	    yes = doc->getPoint(&base2, QString(tr("second base point:")));
+	if (!yes) break;
+	yes = doc->getPoint(&target2, QString(tr("second target point:")), &base2);
+	break;
     }
     if (yes) {
         //first, move selection
@@ -60,8 +103,10 @@ void LC_Align::execComm(Document_Interface *doc,
                          target2.x() - target1.x());
         angle = atarget - abase;
         //end, rotate selection
+	DPI::Disposition whattodo =
+	    keep_orig ? DPI::KEEP_ORIGINAL : DPI::DELETE_ORIGINAL;
         for (int i = 0; i < obj.size(); ++i) {
-			obj.at(i)->moveRotate(movev, target1, angle);
+	    obj.at(i)->moveRotate(movev, target1, angle, whattodo);
         }
 
     }


### PR DESCRIPTION
…lugin

   Prior to this change, unlike built-in move and moverotate operations,
   the Align plugin could only move objects, not copy them. However, it
   is often useful to be able to keep the originals in an Align operation.

   This commit adds that functionality. The implementation required adding
   the capability to keep originals to the Document Interface.

   In addition, this commit adds the possibility to specify both base points
   of the alignment before the target points. This option significantly
   reduces mouse motion when the source of the alignment is far (in terms of
   screen real estate) from the target.

   Finally, to control these two options, this commit adds a tiny, simplistic
   settings dialog (slightly abusing QMessageBox), accessible separately from
   the Plugins menu (so that you can still use Align with the current settings
   without adding a dialog step). If the controls/settings for Align become
   any more complicated, the QMessageBox settings mechanism should be replaced
   with a more proper QDialog.