### PR TITLE
Continuous build on Linux, Windows, MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ core.*
 *.vcxproj
 *.vcxproj.filters
 *.sln
+
+# AppImage generated directories
+AppImage/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,7 @@ stages:
     steps:
 
     - bash: |
+        sudo apt-get update
         sudo apt-get -qq install \
             qt5-default \
             qtbase5-dev \
@@ -78,17 +79,21 @@ stages:
     - task: PublishBuildArtifacts@1
       inputs:
         pathToPublish: $(Build.ArtifactStagingDirectory)
-        artifactName: AppImage
+        artifactName: LibreCAD_Linux
 
 
   - job: WindowsBuild
     displayName: 'Windows build'
-    #condition: False  # disable this job for now
+    condition: False  # disable this job for now
 
     pool:
       vmImage: 'windows-2019'
 
     steps:
+
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.8'
 
     - bash: |
         set -e
@@ -101,7 +106,7 @@ stages:
         BOOST_URL="https://sourceforge.net/projects/boost/files/boost"
         BOOST_URL="$BOOST_URL/$BOOST_VERSION/$BOOST_ZIP/download"
 
-        echo "set Qt_DIR=C:\Qt\Qt$QT_VERSION\\$QT_VERSION" > ./scripts/custom-windows.bat
+        echo "set Qt_DIR=C:\Qt\\$QT_VERSION"               > ./scripts/custom-windows.bat
         echo 'set NSIS_DIR=C:\Program Files (x86)\NSIS'   >> ./scripts/custom-windows.bat
         echo 'set MINGW_VER=mingw73_64'                   >> ./scripts/custom-windows.bat
 
@@ -116,7 +121,7 @@ stages:
 
         mkdir /c/Qt /c/boost
 
-        pip install 'aqtinstall==0.4.1'
+        pip install 'aqtinstall==0.7'
         python -m aqt install -O /c/Qt $QT_VERSION windows desktop win64_mingw73
 
         cd /c/boost
@@ -141,7 +146,7 @@ stages:
     - task: PublishBuildArtifacts@1
       inputs:
         pathToPublish: $(Build.ArtifactStagingDirectory)
-        artifactName: WindowsPackage
+        artifactName: LibreCAD_Windows
 
 
   - job: MacOSBuild
@@ -218,7 +223,7 @@ stages:
     - task: PublishBuildArtifacts@1
       inputs:
         pathToPublish: $(Build.ArtifactStagingDirectory)
-        artifactName: MacOSPackage
+        artifactName: LibreCAD_MacOS
 
 
 #- stage: TestStage

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,264 @@
+#
+# Azure Pipelines for LibreCAD.
+#
+# Build a fresh Linux, Windows and MacOS versions of LibreCAD continuously on
+# every change to master branch. Built packages will be available for download.
+
+
+# Branches to monitor
+trigger:
+- master
+#- play_with_azure
+
+
+# Don't run on pull requests
+pr: none
+
+
+# Azure Pipelines have retention policy to keep artifacts and attachments
+# for 30 days by default. If at that period no new pushes to monitored
+# branches occur all previously built files will be deleted. In order
+# to have files (almost) always present we can schedule a monthly build.
+schedules:
+- cron: "0 0 1 * *"
+  displayName: 'Monthly build'
+  branches:
+    include:
+    - master
+    #- play_with_azure
+  always: true
+
+
+stages:
+
+- stage: BuildStage
+  displayName: 'Build stage'
+
+
+  jobs:
+
+  - job: LinuxBuild
+    displayName: 'Linux build'
+    #condition: False  # disable this job for now
+
+    pool:
+      vmImage: 'ubuntu-16.04'
+
+    steps:
+
+    - bash: |
+        sudo apt-get -qq install \
+            qt5-default \
+            qtbase5-dev \
+            libqt5svg5-dev \
+            qttools5-dev \
+            qttools5-dev-tools \
+            libmuparser-dev \
+            libboost-dev \
+            libfreetype6-dev \
+            libicu-dev \
+            pkg-config
+      displayName: 'Install dependencies'
+
+    - bash: |
+        qmake -r librecad.pro CONFIG+=debug_and_release \
+        && make release -j$(nproc)
+      displayName: 'Build from source'
+
+    - bash: |
+        ./scripts/build-appimage.sh
+      displayName: 'Build AppImage'
+
+    - task: CopyFiles@2
+      inputs:
+        sourceFolder: './AppImage'
+        contents: '*.AppImage'
+        targetFolder: $(Build.ArtifactStagingDirectory)
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: $(Build.ArtifactStagingDirectory)
+        artifactName: AppImage
+
+
+  - job: WindowsBuild
+    displayName: 'Windows build'
+    #condition: False  # disable this job for now
+
+    pool:
+      vmImage: 'windows-2019'
+
+    steps:
+
+    - bash: |
+        set -e
+
+        QT_VERSION="5.13.1"
+
+        BOOST_VERSION="1.60.0"
+        BOOST_ZIP="boost_$(echo $BOOST_VERSION | sed 's|\.|_|g').7z"
+        BOOST_DIR="/boost/boost_$(echo $BOOST_VERSION | sed 's|\.|_|g')"
+        BOOST_URL="https://sourceforge.net/projects/boost/files/boost"
+        BOOST_URL="$BOOST_URL/$BOOST_VERSION/$BOOST_ZIP/download"
+
+        echo "set Qt_DIR=C:\Qt\Qt$QT_VERSION\\$QT_VERSION" > ./scripts/custom-windows.bat
+        echo 'set NSIS_DIR=C:\Program Files (x86)\NSIS'   >> ./scripts/custom-windows.bat
+        echo 'set MINGW_VER=mingw73_64'                   >> ./scripts/custom-windows.bat
+
+        echo "BOOST_DIR = C:$BOOST_DIR/"    >> ./librecad/src/custom.pro
+        echo "BOOST_LIBDIR = C:$BOOST_DIR/" >> ./librecad/src/custom.pro
+
+        # @xanderdin:
+        # I have no idea of how to install NSIS from this script,
+        # so erasing everything from build-win-setup.bat to prevent
+        # any attempts of building Windows Installer for now.
+        echo '' > ./scripts/build-win-setup.bat
+
+        mkdir /c/Qt /c/boost
+
+        pip install 'aqtinstall==0.4.1'
+        python -m aqt install -O /c/Qt $QT_VERSION windows desktop win64_mingw73
+
+        cd /c/boost
+        curl -L -o ./$BOOST_ZIP "$BOOST_URL"
+        7z x ./$BOOST_ZIP
+      displayName: 'Install dependencies'
+
+    - script: |
+        cd .\scripts
+        build-windows.bat
+      displayName: 'Build from source'
+
+    - bash: |
+        7z a -r LibreCAD_$(git describe --tags).7z ./windows
+      displayName: 'Package built files'
+
+    - task: CopyFiles@2
+      inputs:
+        contents: '*.7z'
+        targetFolder: $(Build.ArtifactStagingDirectory)
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: $(Build.ArtifactStagingDirectory)
+        artifactName: WindowsPackage
+
+
+  - job: MacOSBuild
+    displayName: 'MacOS build'
+    #condition: False  # disable this job for now
+
+    pool:
+      vmImage: 'macos-10.14'
+
+    steps:
+
+    - bash: |
+        set -e
+
+        brew install \
+            boost@1.60 \
+            gcc@9 \
+            qt5
+
+        brew link qt5 --force
+
+        echo "BOOST_DIR = /usr/local/opt/boost@1.60/"    >> ./librecad/src/custom.pro
+        echo "BOOST_LIBDIR = /usr/local/opt/boost@1.60/" >> ./librecad/src/custom.pro
+        echo "QT_CONFIG -= no-pkg-config"                >> ./librecad/src/custom.pro
+
+        #sudo ln -s /usr/local/bin/gcc-9 /usr/local/bin/gcc
+        #sudo ln -s /usr/local/bin/gcc-9 /usr/local/bin/cc
+        #sudo ln -s /usr/local/bin/g++-9 /usr/local/bin/g++
+        #sudo ln -s /usr/local/bin/g++-9 /usr/local/bin/c++
+        #sudo ln -s /usr/local/bin/gcc-ar-9 /usr/local/bin/gcc-ar
+        #sudo ln -s /usr/local/bin/gcc-ar-9 /usr/local/bin/ar
+        #sudo ln -s /usr/local/bin/gcc-nm-9 /usr/local/bin/gcc-nm
+        #sudo ln -s /usr/local/bin/gcc-nm-9 /usr/local/bin/nm
+        #sudo ln -s /usr/local/bin/gcc-ranlib-9 /usr/local/bin/gcc-ranlib
+        #sudo ln -s /usr/local/bin/gcc-ranlib-9 /usr/local/bin/ranlib
+
+        # @xanderdin:
+        # Dirty hack, but this is the only way I found it to work.
+        # Default clang always fails during compilation process.
+        # When trying to use gcc, qmake always ignores its locations.
+        # By looking into .qmake.stash I discovered that qmake always
+        # forces using gcc from
+        #
+        # /Applications/Xcode_10.2.1.app/Contents/Developer/usr/bin/
+        #
+        # So, forcing gcc to be at that location.
+        sudo ln -f -s /usr/local/bin/gcc-9 /Applications/Xcode_10.2.1.app/Contents/Developer/usr/bin/gcc
+        sudo ln -f -s /usr/local/bin/gcc-9 /Applications/Xcode_10.2.1.app/Contents/Developer/usr/bin/cc
+        sudo ln -f -s /usr/local/bin/g++-9 /Applications/Xcode_10.2.1.app/Contents/Developer/usr/bin/g++
+        sudo ln -f -s /usr/local/bin/g++-9 /Applications/Xcode_10.2.1.app/Contents/Developer/usr/bin/c++
+        sudo ln -f -s /usr/local/bin/gcc-ar-9 /Applications/Xcode_10.2.1.app/Contents/Developer/usr/bin/ar
+        sudo ln -f -s /usr/local/bin/gcc-nm-9 /Applications/Xcode_10.2.1.app/Contents/Developer/usr/bin/nm
+        sudo ln -f -s /usr/local/bin/gcc-ranlib-9 /Applications/Xcode_10.2.1.app/Contents/Developer/usr/bin/ranlib
+      displayName: 'Install dependencies'
+
+    - bash: |
+        set -e
+        #qmake librecad.pro -r -spec macx-g++ CONFIG+=debug_and_release
+        #qmake librecad.pro -r -spec macx-g++
+        #qmake librecad.pro -r -spec macx-clang CONFIG+=debug_and_release
+        #qmake librecad.pro -r -spec macx-clang
+        #make release -j$(sysctl -n hw.ncpu)
+        #make -j$(sysctl -n hw.ncpu)
+        ./scripts/build-osx.sh -q="-spec macx-g++"
+        #cat ./.qmake.stash
+      displayName: 'Build from source'
+
+    - task: CopyFiles@2
+      inputs:
+        contents: '*.dmg'
+        targetFolder: $(Build.ArtifactStagingDirectory)
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: $(Build.ArtifactStagingDirectory)
+        artifactName: MacOSPackage
+
+
+#- stage: TestStage
+#  displayName: 'Test Stage'
+#  # TODO: ...
+#
+#
+#- stage: DeployStage
+#  displayName: 'Deploy stage'
+#  # TODO: ...
+#
+#  jobs:
+#
+#  - deployment: UploadFiles
+#    displayName: 'Upload all packages'
+#    condition: False  # disable this job for now
+#
+#    pool:
+#      vmImage: 'ubuntu-16.04'
+#
+#    environment: 'librecad-dev'
+#    strategy:
+#      runOnce:
+#        deploy:
+#          steps:
+#
+#          - task: DownloadBuildArtifacts@0
+#            inputs:
+#              buildType: 'current'
+#              downloadPath: '$(System.ArtifactsDirectory)'
+#
+#          # See: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/curl-upload-files?view=azure-devops
+#          - task: cURLUploader@2
+#            inputs:
+#              files: '$(System.ArtifactsDirectory)/*'
+#              #authType: 'ServiceEndpoint' # Optional. Options: serviceEndpoint, userAndPass
+#              #serviceEndpoint: # Required when authType == ServiceEndpoint
+#              #username: # Optional
+#              #password: # Optional
+#              #url: # Required when authType == UserAndPass
+#              #remotePath: 'upload/$(Build.BuildId)/' # Optional
+#              #options: # Optional
+#              #redirectStderr: true # Optional
+#

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -188,6 +188,7 @@ stages:
         # /Applications/Xcode_10.2.1.app/Contents/Developer/usr/bin/
         #
         # So, forcing gcc to be at that location.
+        sudo xcode-select -s /Applications/Xcode_10.2.1.app/Contents/Developer
         sudo ln -f -s /usr/local/bin/gcc-9 /Applications/Xcode_10.2.1.app/Contents/Developer/usr/bin/gcc
         sudo ln -f -s /usr/local/bin/gcc-9 /Applications/Xcode_10.2.1.app/Contents/Developer/usr/bin/cc
         sudo ln -f -s /usr/local/bin/g++-9 /Applications/Xcode_10.2.1.app/Contents/Developer/usr/bin/g++

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+#
+# Build LibreCAD AppImage
+#
+
+set -e
+set -x
+
+ARCH=$(arch)
+
+# LibreCAD (LC_) directories
+LC_ROOTDIR=$(dirname "$0")
+LC_ROOTDIR=$(realpath "$LC_ROOTDIR")
+LC_UNIXDIR="$LC_ROOTDIR/../unix"
+LC_DESKTOP="$LC_ROOTDIR/../desktop"
+
+# AppImage (AI_) directories
+AI_ROOTDIR="$LC_ROOTDIR/../AppImage"
+AI_TOOLDIR="$AI_ROOTDIR/tools"
+AI_APP_DIR="$AI_ROOTDIR/AppDir"
+
+# linuxdeployqt tool (LT_)
+LT_VERSION="6"
+LT_TOOLIMG="linuxdeployqt-$LT_VERSION-$ARCH.AppImage"
+LT_LINKURL="https://github.com/probonopd/linuxdeployqt/releases/download"
+LT_LINKURL="$LT_LINKURL/$LT_VERSION/$LT_TOOLIMG"
+
+
+# Version for this AppImage
+export VERSION=$(git describe --tags)
+
+
+# Clean old AppDir if it exists
+[ -d "$AI_APP_DIR" ] && rm -rf "$AI_APP_DIR"
+
+# Create directories
+mkdir -p "$AI_ROOTDIR" "$AI_TOOLDIR" "$AI_APP_DIR"
+mkdir -p "$AI_APP_DIR/usr/bin"
+
+# Copy LibreCAD files
+cp -a "$LC_UNIXDIR"/* "$AI_APP_DIR/usr/bin/"
+
+# Strip binaries
+find "$AI_APP_DIR/usr/bin/" -type f -perm /a+x -exec strip {} \;
+
+# Desktop file
+cp -a "$LC_DESKTOP/librecad.desktop" "$AI_APP_DIR/"
+
+# linuxdeployqt tool refuses to process this desktop file because
+# of a missing ';'. Fixing this.
+sed -i -e 's|^MimeType=image/vnd.dxf$|&;|' "$AI_APP_DIR/librecad.desktop"
+
+# Icon file
+cp -a "$LC_DESKTOP/graphics_icons_and_splash/Icon LibreCAD/Icon_Librecad.svg" \
+    "$AI_APP_DIR/librecad.svg"
+
+
+# Create AppRun file
+cat << EOF > "$AI_APP_DIR/AppRun"
+#!/bin/sh
+#
+# AppRun file for LibreCAD AppImage. It allows running either librecad
+# or ttf2lff binaries. Command line arguments are also supported.
+#
+# To see LibreCAD arguments list, run:
+#
+# ./LibreCAD-$VERSION-$ARCH.AppImage --help
+#
+#
+# To see ttf2lff arguments list, run:
+#
+# ./LibreCAD-$VERSION-$ARCH.AppImage ttf2lff --help
+#
+#
+# To see dxf2pdf arguments list (part of librecad binary), run:
+#
+# ./LibreCAD-$VERSION-$ARCH.AppImage dxf2pdf --help
+#
+
+if [ "ttf2lff" = "\$1" ]; then
+    shift
+    exec \$APPDIR/usr/bin/ttf2lff \$@
+else
+    exec \$APPDIR/usr/bin/librecad \$@
+fi
+EOF
+chmod +x "$AI_APP_DIR/AppRun"
+
+
+# Get linuxdeployqt tool if it doesn't exist already
+if [ ! -e "$AI_TOOLDIR/$LT_TOOLIMG" ]; then
+    wget -P "$AI_TOOLDIR/" "$LT_LINKURL"
+    chmod +x "$AI_TOOLDIR/$LT_TOOLIMG"
+fi
+
+
+# Build AppImage
+pushd "$AI_ROOTDIR" >/dev/null
+"$AI_TOOLDIR/$LT_TOOLIMG" \
+    "$AI_APP_DIR/usr/bin/librecad" \
+    -appimage \
+    -bundle-non-qt-libs
+popd >/dev/null
+echo 'Done.'
+


### PR DESCRIPTION
Hey guys, it looks like there's a demand for fresh continuous builds of LibreCAD and AppImage packages (#858). Here's my solution (if you don't mind connecting [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) to the project). It shouldn't affect current TravisCI configuration and can be run in parallel.

Azure Pipelines docs are [here](https://docs.microsoft.com/en-us/azure/devops/pipelines/?toc=%2Fazure%2Fdevops%2Fpipelines%2Ftoc.json&bc=%2Fazure%2Fdevops%2Fboards%2Fpipelines%2Fbreadcrumb%2Ftoc.json&view=azure-devops). It is free for open source projects and provides quite enough resources and a bunch of features. I experimented a little bit with those and created configuration for LibreCAD.

### What it does:

On every change of master branch a parallel build is triggered for Linux, Windows and MacOS. After successful build there will be packages for those OSes available for download:

**AppImage** -- for Linux
**7z archive** -- for Windows (I failed to create windows installer so far)
**DMG package** -- for MacOS.

My experimental pipeline from this configuration is available [here](https://dev.azure.com/xanderdin/PlayWithAzure/_build?definitionId=1). 
You can navigate to the [last successful build](https://dev.azure.com/xanderdin/PlayWithAzure/_build/results?buildId=121) and see and download built packages by pressing **Artifacts** button.

![1](https://user-images.githubusercontent.com/14307537/63849315-81b85a80-c99a-11e9-93e2-24b595e742d5.jpg)

I tested generated AppImage on Debian, Ubuntu, openSUSE, Fedora. All work fine.
I didn't test packages for Windows and MacOS because I haven't those OSes at my disposition.

Generated AppImage also fully supports running console tools (ttf2lff, dxf2pdf).
