### PR TITLE
Angle constraint with pressed "shift" key also for moving and copying entities

### DIFF
--- a/librecad/src/actions/rs_actiondefault.cpp
+++ b/librecad/src/actions/rs_actiondefault.cpp
@@ -35,6 +35,10 @@
 #include "rs_preview.h"
 #include "rs_debug.h"
 
+#include "rs_line.h"
+#include "cmath"
+#include "rs_coordinateevent.h"
+
 struct RS_ActionDefault::Points {
 	RS_Vector v1;
 	RS_Vector v2;
@@ -156,10 +160,23 @@ void RS_ActionDefault::mouseMoveEvent(QMouseEvent* e) {
 		pPoints->v2 = snapPoint(e);
 		RS_DIALOGFACTORY->updateCoordinateWidget(pPoints->v2, pPoints->v2 - graphicView->getRelativeZero());
 
+        if(e->modifiers() & Qt::ShiftModifier)
+        {
+            mouse = snapToAngle(mouse, pPoints->v1, 15.);
+            pPoints->v2 = mouse;
+        }
 
         deletePreview();
         preview->addSelectionFrom(*container);
 		preview->moveRef(pPoints->v1, pPoints->v2 - pPoints->v1);
+
+        if(e->modifiers() & Qt::ShiftModifier)
+        {
+            auto line = new RS_Line(pPoints->v1, mouse);
+            preview->addEntity(line);
+            line->setSelected(true);
+        }
+
         drawPreview();
         break;
 
@@ -167,9 +184,23 @@ void RS_ActionDefault::mouseMoveEvent(QMouseEvent* e) {
 		pPoints->v2 = snapPoint(e);
 		RS_DIALOGFACTORY->updateCoordinateWidget(pPoints->v2, pPoints->v2 - graphicView->getRelativeZero());
 
+        if(e->modifiers() & Qt::ShiftModifier)
+        {
+            mouse = snapToAngle(mouse, pPoints->v1, 15.);
+            pPoints->v2 = mouse;
+        }
+
         deletePreview();
         preview->addSelectionFrom(*container);
 		preview->move(pPoints->v2 - pPoints->v1);
+
+        if(e->modifiers() & Qt::ShiftModifier)
+        {
+            auto line = new RS_Line(pPoints->v1, mouse);
+            preview->addEntity(line);
+            line->setSelected(true);
+        }
+
         drawPreview();
         break;
 
@@ -222,6 +253,10 @@ void RS_ActionDefault::mousePressEvent(QMouseEvent* e) {
 
         case Moving: {
 			pPoints->v2 = snapPoint(e);
+            if(e->modifiers() & Qt::ShiftModifier)
+            {
+                pPoints->v2 = snapToAngle(pPoints->v2, pPoints->v1, 15.);
+            }
             deletePreview();
             RS_Modification m(*container, graphicView);
             RS_MoveData data;
@@ -239,6 +274,10 @@ void RS_ActionDefault::mousePressEvent(QMouseEvent* e) {
 
         case MovingRef: {
 			pPoints->v2 = snapPoint(e);
+            if(e->modifiers() & Qt::ShiftModifier)
+            {
+                pPoints->v2 = snapToAngle(pPoints->v2, pPoints->v1, 15.);
+            }
             deletePreview();
             RS_Modification m(*container, graphicView);
             RS_MoveRefData data;
@@ -317,7 +356,6 @@ void RS_ActionDefault::mouseReleaseEvent(QMouseEvent* e) {
         case Panning:
             setStatus(Neutral);
             break;
-
         default:
             break;
 
@@ -387,5 +425,7 @@ void RS_ActionDefault::updateMouseCursor() {
         break;
     }
 }
+
+
 
 // EOF

--- a/librecad/src/actions/rs_actiondefault.h
+++ b/librecad/src/actions/rs_actiondefault.h
@@ -79,6 +79,7 @@ protected:
 	struct Points;
 	std::unique_ptr<Points> pPoints;
     RS2::SnapRestriction restrBak;
+private:
 
 };
 

--- a/librecad/src/actions/rs_actiondrawline.cpp
+++ b/librecad/src/actions/rs_actiondrawline.cpp
@@ -106,29 +106,6 @@ void RS_ActionDrawLine::trigger() {
                     line->getId());
 }
 
-RS_Vector RS_ActionDrawLine::snapToAngle(const RS_Vector &currentCoord)
-{
-    if(getStatus() != SetEndpoint)
-    {
-        RS_DEBUG->print(RS_Debug::D_WARNING, "Trying to snap to angle when not setting EndPoint!");
-        return currentCoord;
-    }
-    if(snapMode.restriction != RS2::RestrictNothing ||
-            snapMode.snapGrid) {
-        return currentCoord;
-    }
-	double angle = pPoints->data.startpoint.angleTo(currentCoord)*180.0/M_PI;
-    /*Snapping to angle(15*) if shift key is pressed*/
-    const double angularResolution=15.;
-    angle -= remainder(angle,angularResolution);
-    angle *= M_PI/180.;
-	RS_Vector res = RS_Vector::polar(pPoints->data.startpoint.distanceTo(currentCoord),
-                 angle);
-	res += pPoints->data.startpoint;
-    snapPoint(res, true);
-    return res;
-}
-
 
 
 void RS_ActionDrawLine::mouseMoveEvent(QMouseEvent* e)
@@ -138,7 +115,7 @@ void RS_ActionDrawLine::mouseMoveEvent(QMouseEvent* e)
 
         /*Snapping to angle(15*) if shift key is pressed*/
         if(e->modifiers() & Qt::ShiftModifier)
-            mouse = snapToAngle(mouse);
+            mouse = snapToAngle(mouse, pPoints->data.startpoint, 15.);
 
         deletePreview();
         auto line = new RS_Line(pPoints->data.startpoint, mouse);
@@ -155,7 +132,7 @@ void RS_ActionDrawLine::mouseReleaseEvent(QMouseEvent* e) {
 
         /*Snapping to angle(15*) if shift key is pressed*/
         if((e->modifiers() & Qt::ShiftModifier) && getStatus() == SetEndpoint )
-            snapped = snapToAngle(snapped);
+            snapped = snapToAngle(snapped, pPoints->data.startpoint, 15.);
         RS_CoordinateEvent ce(snapped);
         coordinateEvent(&ce);
     } else if (e->button()==Qt::RightButton) {

--- a/librecad/src/actions/rs_actiondrawline.h
+++ b/librecad/src/actions/rs_actiondrawline.h
@@ -75,7 +75,6 @@ public:
 	void redo();
 
 protected:
-	RS_Vector snapToAngle(const RS_Vector& currentCoord);
 	struct Points;
 	std::unique_ptr<Points> pPoints;
 };

--- a/librecad/src/actions/rs_actionmodifymirror.cpp
+++ b/librecad/src/actions/rs_actionmodifymirror.cpp
@@ -37,18 +37,18 @@
 #include "rs_debug.h"
 
 struct RS_ActionModifyMirror::Points {
-	RS_MirrorData data;
-	RS_Vector axisPoint1;
-	RS_Vector axisPoint2;
+    RS_MirrorData data;
+    RS_Vector axisPoint1;
+    RS_Vector axisPoint2;
 };
 
 RS_ActionModifyMirror::RS_ActionModifyMirror(RS_EntityContainer& container,
         RS_GraphicView& graphicView)
         :RS_PreviewActionInterface("Mirror Entities",
-						   container, graphicView)
-		, pPoints(new Points{})
+                           container, graphicView)
+        , pPoints(new Points{})
 {
-	actionType=RS2::ActionModifyMirror;
+    actionType=RS2::ActionModifyMirror;
 }
 
 RS_ActionModifyMirror::~RS_ActionModifyMirror() = default;
@@ -62,10 +62,10 @@ void RS_ActionModifyMirror::trigger() {
     RS_DEBUG->print("RS_ActionModifyMirror::trigger()");
 
     RS_Modification m(*container, graphicView);
-	m.mirror(pPoints->data);
+    m.mirror(pPoints->data);
 
-	RS_DIALOGFACTORY->updateSelectionWidget(
-				container->countSelected(), container->totalSelectedLength());
+    RS_DIALOGFACTORY->updateSelectionWidget(
+                container->countSelected(), container->totalSelectedLength());
 }
 
 void RS_ActionModifyMirror::mouseMoveEvent(QMouseEvent* e) {
@@ -77,19 +77,23 @@ void RS_ActionModifyMirror::mouseMoveEvent(QMouseEvent* e) {
         RS_Vector mouse = snapPoint(e);
         switch (getStatus()) {
         case SetAxisPoint1:
-			pPoints->axisPoint1 = mouse;
+            pPoints->axisPoint1 = mouse;
             break;
 
         case SetAxisPoint2:
-			if (pPoints->axisPoint1.valid) {
-				pPoints->axisPoint2 = mouse;
+            if (pPoints->axisPoint1.valid)
+            {
+                if(e->modifiers() & Qt::ShiftModifier)
+                    mouse = snapToAngle(mouse, pPoints->axisPoint1, 15.);
+
+                pPoints->axisPoint2 = mouse;
 
                 deletePreview();
                 preview->addSelectionFrom(*container);
-				preview->mirror(pPoints->axisPoint1, pPoints->axisPoint2);
+                preview->mirror(pPoints->axisPoint1, pPoints->axisPoint2);
 
-				preview->addEntity(new RS_Line{preview.get(),
-											   pPoints->axisPoint1, pPoints->axisPoint2});
+                preview->addEntity(new RS_Line{preview.get(),
+                                               pPoints->axisPoint1, pPoints->axisPoint2});
 
                 drawPreview();
             }
@@ -103,9 +107,15 @@ void RS_ActionModifyMirror::mouseMoveEvent(QMouseEvent* e) {
     RS_DEBUG->print("RS_ActionModifyMirror::mouseMoveEvent end");
 }
 
+
 void RS_ActionModifyMirror::mouseReleaseEvent(QMouseEvent* e) {
-    if (e->button()==Qt::LeftButton) {
-        RS_CoordinateEvent ce(snapPoint(e));
+    if (e->button()==Qt::LeftButton)
+    {
+        RS_Vector snapped = snapPoint(e);
+        if((e->modifiers() & Qt::ShiftModifier) && getStatus() == SetAxisPoint2 )
+            snapped = snapToAngle(snapped, pPoints->axisPoint1, 15.);
+
+        RS_CoordinateEvent ce(snapped);
         coordinateEvent(&ce);
 
     } else if (e->button()==Qt::RightButton) {
@@ -113,6 +123,7 @@ void RS_ActionModifyMirror::mouseReleaseEvent(QMouseEvent* e) {
         init(getStatus()-1);
     }
 }
+
 
 void RS_ActionModifyMirror::coordinateEvent(RS_CoordinateEvent* e) {
     if (e==NULL) {
@@ -123,18 +134,18 @@ void RS_ActionModifyMirror::coordinateEvent(RS_CoordinateEvent* e) {
 
         switch (getStatus()) {
         case SetAxisPoint1:
-			pPoints->axisPoint1 = mouse;
+            pPoints->axisPoint1 = mouse;
             setStatus(SetAxisPoint2);
                 graphicView->moveRelativeZero(mouse);
             break;
 
         case SetAxisPoint2:
-			pPoints->axisPoint2 = mouse;
+            pPoints->axisPoint2 = mouse;
             setStatus(ShowDialog);
                 graphicView->moveRelativeZero(mouse);
-				if (RS_DIALOGFACTORY->requestMirrorDialog(pPoints->data)) {
-					pPoints->data.axisPoint1 = pPoints->axisPoint1;
-					pPoints->data.axisPoint2 = pPoints->axisPoint2;
+                if (RS_DIALOGFACTORY->requestMirrorDialog(pPoints->data)) {
+                    pPoints->data.axisPoint1 = pPoints->axisPoint1;
+                    pPoints->data.axisPoint2 = pPoints->axisPoint2;
                     deletePreview();
                     trigger();
                     finish(false);
@@ -147,25 +158,25 @@ void RS_ActionModifyMirror::coordinateEvent(RS_CoordinateEvent* e) {
 }
 
 void RS_ActionModifyMirror::updateMouseButtonHints() {
-	switch (getStatus()) {
-	/*case Select:
-				RS_DIALOGFACTORY->updateMouseWidget(tr("Pick entities to move"),
-											   tr("Cancel"));
-				break;*/
-	case SetAxisPoint1:
-		RS_DIALOGFACTORY->updateMouseWidget(
-					tr("Specify first point of mirror line"),
-					tr("Cancel"));
-		break;
-	case SetAxisPoint2:
-		RS_DIALOGFACTORY->updateMouseWidget(
-					tr("Specify second point of mirror line"),
-					tr("Back"));
-		break;
-	default:
-		RS_DIALOGFACTORY->updateMouseWidget();
-		break;
-	}
+    switch (getStatus()) {
+    /*case Select:
+                RS_DIALOGFACTORY->updateMouseWidget(tr("Pick entities to move"),
+                                               tr("Cancel"));
+                break;*/
+    case SetAxisPoint1:
+        RS_DIALOGFACTORY->updateMouseWidget(
+                    tr("Specify first point of mirror line"),
+                    tr("Cancel"));
+        break;
+    case SetAxisPoint2:
+        RS_DIALOGFACTORY->updateMouseWidget(
+                    tr("Specify second point of mirror line"),
+                    tr("Back"));
+        break;
+    default:
+        RS_DIALOGFACTORY->updateMouseWidget();
+        break;
+    }
 }
 
 void RS_ActionModifyMirror::updateMouseCursor() {

--- a/librecad/src/actions/rs_actionmodifymove.cpp
+++ b/librecad/src/actions/rs_actionmodifymove.cpp
@@ -90,7 +90,6 @@ void RS_ActionModifyMove::mouseMoveEvent(QMouseEvent* e) {
                     mouse = snapToAngle(mouse, pPoints->referencePoint, 15.);
 
 
-
 				pPoints->targetPoint = mouse;
 
                 deletePreview();
@@ -122,10 +121,9 @@ void RS_ActionModifyMove::mouseMoveEvent(QMouseEvent* e) {
 
 
 void RS_ActionModifyMove::mouseReleaseEvent(QMouseEvent* e) {
-    if (e->button()==Qt::LeftButton) {
+    if (e->button()==Qt::LeftButton)
+    {
         RS_Vector snapped = snapPoint(e);
-
-
         if((e->modifiers() & Qt::ShiftModifier) && getStatus() == SetTargetPoint )
             snapped = snapToAngle(snapped, pPoints->referencePoint, 15.);
 

--- a/librecad/src/actions/rs_actionmodifymove.cpp
+++ b/librecad/src/actions/rs_actionmodifymove.cpp
@@ -24,9 +24,12 @@
 **
 **********************************************************************/
 
+
+
+#include<cmath>
+#include <QAction>
 #include "rs_actionmodifymove.h"
 
-#include <QAction>
 #include <QMouseEvent>
 #include "rs_dialogfactory.h"
 #include "rs_graphicview.h"
@@ -34,6 +37,18 @@
 #include "rs_modification.h"
 #include "rs_preview.h"
 #include "rs_debug.h"
+
+#include "rs_line.h"
+//#include "rs_pen.h"
+
+/*
+#include <QMouseEvent>
+#include "rs_actioneditundo.h"
+#include "rs_commands.h"
+#include "rs_commandevent.h"
+*/
+
+
 
 struct RS_ActionModifyMove::Points {
 	RS_MoveData data;
@@ -64,27 +79,68 @@ void RS_ActionModifyMove::trigger() {
 }
 
 
+RS_Vector RS_ActionModifyMove::snapToAngle(const RS_Vector &currentCoord)
+{
+    if(getStatus() != SetTargetPoint)
+    {
+        RS_DEBUG->print(RS_Debug::D_WARNING, "Trying to snap to angle when not setting EndPoint!");
+        return currentCoord;
+    }
+
+    if(snapMode.restriction != RS2::RestrictNothing || snapMode.snapGrid)
+    {
+        return currentCoord;
+    }
+    double angle = pPoints->referencePoint.angleTo(currentCoord)*180.0/M_PI;
+    /*Snapping to angle(15*) if shift key is pressed*/
+    const double angularResolution=15.;
+    angle -= remainder(angle,angularResolution);
+    angle *= M_PI/180.;
+    RS_Vector res = RS_Vector::polar(pPoints->referencePoint.distanceTo(currentCoord),angle);
+    res += pPoints->referencePoint;
+    snapPoint(res, true);
+    return res;
+}
+
 
 void RS_ActionModifyMove::mouseMoveEvent(QMouseEvent* e) {
     RS_DEBUG->print("RS_ActionModifyMove::mouseMoveEvent begin");
 
-    if (getStatus()==SetReferencePoint ||
-            getStatus()==SetTargetPoint) {
+    if (getStatus()==SetReferencePoint || getStatus()==SetTargetPoint)
+    {
 
         RS_Vector mouse = snapPoint(e);
-        switch (getStatus()) {
+        switch (getStatus())
+        {
         case SetReferencePoint:
 			pPoints->referencePoint = mouse;
             break;
 
         case SetTargetPoint:
-			if (pPoints->referencePoint.valid) {
+            if (pPoints->referencePoint.valid)
+            {
+                if(e->modifiers() & Qt::ShiftModifier)
+                    mouse = snapToAngle(mouse);
+
 				pPoints->targetPoint = mouse;
 
                 deletePreview();
                 preview->addSelectionFrom(*container);
 				preview->move(pPoints->targetPoint-pPoints->referencePoint);
+
+                if(e->modifiers() & Qt::ShiftModifier)
+                {
+                    auto line = new RS_Line(pPoints->referencePoint, mouse);
+                    preview->addEntity(line);
+                    RS_Vector factor(2,2);
+                    line->scale(line->getMiddlePoint(), factor);
+                    line->setLayerToActive();
+                    line->setPenToActive();
+
+                }
                 drawPreview();
+
+
             }
             break;
 
@@ -100,13 +156,23 @@ void RS_ActionModifyMove::mouseMoveEvent(QMouseEvent* e) {
 
 void RS_ActionModifyMove::mouseReleaseEvent(QMouseEvent* e) {
     if (e->button()==Qt::LeftButton) {
-        RS_CoordinateEvent ce(snapPoint(e));
+        RS_Vector snapped = snapPoint(e);
+
+
+        if((e->modifiers() & Qt::ShiftModifier) && getStatus() == SetTargetPoint )
+            snapped = snapToAngle(snapped);
+
+
+        RS_CoordinateEvent ce(snapped);
         coordinateEvent(&ce);
     } else if (e->button()==Qt::RightButton) {
         deletePreview();
         init(getStatus()-1);
     }
 }
+
+
+
 
 void RS_ActionModifyMove::coordinateEvent(RS_CoordinateEvent* e) {
 

--- a/librecad/src/actions/rs_actionmodifymove.h
+++ b/librecad/src/actions/rs_actionmodifymove.h
@@ -68,7 +68,7 @@ public:
 private:
 	struct Points;
 	std::unique_ptr<Points> pPoints;
-    RS_Vector snapToAngle(const RS_Vector &currentCoord);
+    //RS_Vector snapToAngle(const RS_Vector &currentCoord);
 };
 
 #endif

--- a/librecad/src/actions/rs_actionmodifymove.h
+++ b/librecad/src/actions/rs_actionmodifymove.h
@@ -63,9 +63,12 @@ public:
 	void updateMouseButtonHints() override;
 	void updateMouseCursor() override;
 
+
+
 private:
 	struct Points;
 	std::unique_ptr<Points> pPoints;
+    RS_Vector snapToAngle(const RS_Vector &currentCoord);
 };
 
 #endif

--- a/librecad/src/lib/actions/rs_snapper.cpp
+++ b/librecad/src/lib/actions/rs_snapper.cpp
@@ -969,3 +969,22 @@ RS_SnapMode RS_Snapper::intToSnapMode(unsigned int ret)
     }
    return s;
 }
+
+
+RS_Vector RS_Snapper::snapToAngle(const RS_Vector &currentCoord, const RS_Vector &referenceCoord, const double angularResolution)
+{
+
+    if(snapMode.restriction != RS2::RestrictNothing || snapMode.snapGrid)
+    {
+        return currentCoord;
+    }
+
+    double angle = referenceCoord.angleTo(currentCoord)*180.0/M_PI;
+    angle -= remainder(angle,angularResolution);
+    angle *= M_PI/180.;
+    RS_Vector res = RS_Vector::polar(referenceCoord.distanceTo(currentCoord),angle);
+    res += referenceCoord;
+    snapPoint(res, true);
+    return res;
+}
+

--- a/librecad/src/lib/actions/rs_snapper.cpp
+++ b/librecad/src/lib/actions/rs_snapper.cpp
@@ -321,6 +321,9 @@ RS_Vector RS_Snapper::snapPoint(const RS_Vector& coord, bool setSpot)
     }
     return coord;
 }
+
+
+
 double RS_Snapper::getSnapRange() const
 {
 	if(graphicView )
@@ -929,6 +932,7 @@ unsigned int RS_Snapper::snapModeToInt(const RS_SnapMode& s)
     ret <<=1;ret |= s.snapCenter;
     ret <<=1;ret |= s.snapOnEntity;
     ret <<=1;ret |= s.snapIntersection;
+    ret <<=1;ret |= s.snapAngle;
    return ret;
 }
 /**
@@ -954,6 +958,9 @@ RS_SnapMode RS_Snapper::intToSnapMode(unsigned int ret)
     ret >>= 1;
     s.snapFree =ret & binaryOne;
     ret >>= 1;
+    s.snapAngle =ret & binaryOne;
+    ret >>= 1;
+
     switch (ret) {
     case 1:
             s.restriction=RS2::RestrictHorizontal;
@@ -984,7 +991,21 @@ RS_Vector RS_Snapper::snapToAngle(const RS_Vector &currentCoord, const RS_Vector
     angle *= M_PI/180.;
     RS_Vector res = RS_Vector::polar(referenceCoord.distanceTo(currentCoord),angle);
     res += referenceCoord;
-    snapPoint(res, true);
-    return res;
+
+    if (snapMode.snapOnEntity)
+    {
+        RS_Vector t(false);
+        //RS_Vector mouseCoord = graphicView->toGraph(currentCoord.x(), currentCoord.y());
+        t = container->getNearestVirtualIntersection(res,angle,nullptr);
+
+        pImpData->snapSpot = t;
+        snapPoint(pImpData->snapSpot, true);
+        return t;
+    }
+    else
+    {
+        snapPoint(res, true);
+        return res;
+    }
 }
 

--- a/librecad/src/lib/actions/rs_snapper.h
+++ b/librecad/src/lib/actions/rs_snapper.h
@@ -51,7 +51,7 @@ struct RS_SnapMode {
 	bool snapDistance= false;       /// Whether to snap to distance from endpoints or not.
 	bool snapCenter= false;       /// Whether to snap to centers or not.
 	bool snapIntersection= false; /// Whether to snap to intersections or not.
-
+    bool snapAngle=false;         /// Whether to snap along line under certain angle
 	bool snapOnEntity= false;     /// Whether to snap to entities or not.
 
 	RS2::SnapRestriction restriction= RS2::RestrictNothing; /// The restriction on the free snap.
@@ -136,7 +136,7 @@ public:
     RS_Vector snapDist(const RS_Vector& coord);
     RS_Vector snapIntersection(const RS_Vector& coord);
     //RS_Vector snapDirect(RS_Vector coord, bool abs);
-    RS_Vector snapToAngle(const RS_Vector &currentCoord, const RS_Vector &referenceCoord, const double angularResolution);
+    RS_Vector snapToAngle(const RS_Vector &coord, const RS_Vector &ref_coord, const double ang_res);
 
     RS_Vector restrictOrthogonal(const RS_Vector& coord);
     RS_Vector restrictHorizontal(const RS_Vector& coord);

--- a/librecad/src/lib/actions/rs_snapper.h
+++ b/librecad/src/lib/actions/rs_snapper.h
@@ -136,6 +136,7 @@ public:
     RS_Vector snapDist(const RS_Vector& coord);
     RS_Vector snapIntersection(const RS_Vector& coord);
     //RS_Vector snapDirect(RS_Vector coord, bool abs);
+    RS_Vector snapToAngle(const RS_Vector &currentCoord, const RS_Vector &referenceCoord, const double angularResolution);
 
     RS_Vector restrictOrthogonal(const RS_Vector& coord);
     RS_Vector restrictHorizontal(const RS_Vector& coord);

--- a/librecad/src/lib/engine/rs_entitycontainer.cpp
+++ b/librecad/src/lib/engine/rs_entitycontainer.cpp
@@ -44,6 +44,7 @@
 #include "rs_solid.h"
 #include "rs_information.h"
 #include "rs_graphicview.h"
+#include "rs_constructionline.h"
 
 bool RS_EntityContainer::autoUpdateBorders = true;
 
@@ -1342,6 +1343,42 @@ RS_Vector RS_EntityContainer::getNearestIntersection(const RS_Vector& coord,
     return closestPoint;
 }
 
+RS_Vector RS_EntityContainer::getNearestVirtualIntersection(const RS_Vector& coord,
+                                                            const double& angle,
+                                                            double* dist)
+{
+
+    RS_Vector point;                // endpoint found
+    RS_VectorSolutions sol;
+    RS_Entity* closestEntity;
+    RS_Vector second_coord;
+
+    second_coord.set(angle);
+    closestEntity = getNearestEntity(coord, nullptr, RS2::ResolveAllButTextImage);
+
+    if (closestEntity)
+    {
+            RS_ConstructionLineData data(coord,coord + second_coord);
+            auto line = new RS_ConstructionLine(this,data);
+
+            sol = RS_Information::getIntersection(closestEntity,line,true);
+            if (sol.getVector().empty())
+            {
+                return coord;
+            }
+            else
+            {
+                point=sol.getClosest(coord,dist,nullptr);
+                return point;
+            }
+    }
+    else
+    {
+        return coord;
+    }
+
+
+}
 
 
 RS_Vector RS_EntityContainer::getNearestRef(const RS_Vector& coord,

--- a/librecad/src/lib/engine/rs_entitycontainer.h
+++ b/librecad/src/lib/engine/rs_entitycontainer.h
@@ -164,6 +164,9 @@ public:
 									 double* dist = nullptr) const override;
 	RS_Vector getNearestIntersection(const RS_Vector& coord,
 			double* dist = nullptr);
+    RS_Vector getNearestVirtualIntersection(const RS_Vector& coord,
+                                            const double& angle,
+                                            double* dist);
 	RS_Vector getNearestRef(const RS_Vector& coord,
 									 double* dist = nullptr) const override;
 	RS_Vector getNearestSelectedRef(const RS_Vector& coord,

--- a/librecad/src/lib/engine/rs_line.cpp
+++ b/librecad/src/lib/engine/rs_line.cpp
@@ -174,7 +174,51 @@ RS_Vector RS_Line::getNearestPointOnEntity(const RS_Vector& coord,
     return vpc;
 }
 
-    RS_Vector RS_Line::getMiddlePoint()const
+/*
+RS_Vector RS_Line::getPointOnEntityAlongLine(const RS_Vector& coord,const double angle,
+                                           bool onEntity,
+                                           double* dist,
+                                           RS_Entity** entity) const
+{
+    if (entity)
+    {
+        *entity = const_cast<RS_Line*>(this);
+    }
+
+
+    RS_Vector direction {data.endpoint - data.startpoint};
+    RS_Vector vpc {coord - data.startpoint};
+    double a {direction.squared()};
+
+    if( a < RS_TOLERANCE2)
+    {
+        //line too short
+        vpc = getMiddlePoint();
+    }
+    else
+    {
+        //find projection on line
+        const double t {RS_Vector::dotP( vpc, direction) / a};
+        if( !isConstruction()   && onEntity  && ( t <= -RS_TOLERANCE || t >= 1. + RS_TOLERANCE ) )
+        {
+            //projection point not within range, find the nearest endpoint
+            return getNearestEndpoint( coord, dist);
+        }
+
+        vpc = data.startpoint + direction * t;
+    }
+
+    if (dist)
+    {
+        *dist = vpc.distanceTo( coord);
+    }
+
+    return vpc;
+}
+*/
+
+
+RS_Vector RS_Line::getMiddlePoint()const
 {
         return (getStartpoint() + getEndpoint())*0.5;
 }

--- a/librecad/src/lib/engine/rs_line.h
+++ b/librecad/src/lib/engine/rs_line.h
@@ -171,6 +171,7 @@ public:
                                       bool onEntity = true,
                                       double* dist = nullptr,
                                       RS_Entity** entity=nullptr) const override;
+    //RS_Vector getPointOnEntityAlongLine(const RS_Vector& coord,const double angle,bool onEntity,double* dist,RS_Entity** entity) const;
     RS_Vector getNearestMiddle(const RS_Vector& coord,
                                double* dist = nullptr,
                                int middlePoints = 1) const override;


### PR DESCRIPTION
 The LibreCAD has a great feature: when drawing a line by a mouse and holding the "shift" key during placing the line endpoint, one can move the cursor only along certain angles (0°, 15°, 30°, 45°, etc.).

This code modification enables this feature also for moving and copying entities. I. e. when the reference point is selected and the entity is moved, by pressing the "Shift" key one can move the reference point (and the entity) only along the certain angles (0°, 15°, 30°, 45°, etc.) measured from the original reference point position.
