### PR TITLE
Fix missing app name and icon on Wayland

### DIFF
--- a/librecad/src/main/main.cpp
+++ b/librecad/src/main/main.cpp
@@ -82,6 +82,10 @@ int main(int argc, char** argv)
     QCoreApplication::setApplicationName("LibreCAD");
     QCoreApplication::setApplicationVersion(XSTR(LC_VERSION));
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 7, 0))
+    QGuiApplication::setDesktopFileName("librecad.desktop");
+#endif
+
     QSettings settings;
 
     bool first_load = settings.value("Startup/FirstLoad", 1).toBool();


### PR DESCRIPTION
Wayland uses the .desktop file to find the app name and icon. Without it being specified the correct icon is not shown.

Tested on Gnome/Wayland.

References:

  - https://community.kde.org/Guidelines_and_HOWTOs/Wayland_Porting_Notes#Application_Icon
  - https://doc.qt.io/qt-5/qguiapplication.html#desktopFileName-prop