### PR TITLE
Print Preview: Line width scaling

### DIFF
--- a/librecad/res/icons/icons.qrc
+++ b/librecad/res/icons/icons.qrc
@@ -200,5 +200,6 @@
         <file>noprint.svg</file>
         <file>close_all.svg</file>
         <file>save_all.svg</file>
+        <file>scaleLineWidth.svg</file>
     </qresource>
 </RCC>

--- a/librecad/res/icons/scaleLineWidth.svg
+++ b/librecad/res/icons/scaleLineWidth.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="256"
+   height="256"
+   viewBox="0 0 72.248892 72.248892"
+   id="svg4295"
+   version="1.1"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14"
+   sodipodi:docname="scaleLineWidth.svg"
+   inkscape:export-filename="D:\LC_Recources\icons\scale.png"
+   inkscape:export-xdpi="11.25"
+   inkscape:export-ydpi="11.25">
+  <metadata
+     id="metadata4325">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4323" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1364"
+     inkscape:window-height="725"
+     id="namedview4321"
+     showgrid="true"
+     units="px"
+     inkscape:snap-grids="true"
+     inkscape:zoom="1.8613281"
+     inkscape:cx="37.166193"
+     inkscape:cy="137.66745"
+     inkscape:window-x="0"
+     inkscape:window-y="20"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4295"
+     inkscape:object-nodes="true"
+     inkscape:snap-object-midpoints="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4867" />
+  </sodipodi:namedview>
+  <path
+     style="opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.82222223;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 10.922,33.866668 H 34.064224 V 65.108669"
+     id="rect4140-6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:5.64444447;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 10.922,10.809115 h 46.848892 l -6e-6,54.017332"
+     id="path4697"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="fill:#00ff7f;fill-rule:evenodd;stroke:#000000;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 31.60889,18.062221 50.292002,36.745333 V 18.062223 Z"
+     id="path4703"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
+</svg>

--- a/librecad/src/actions/rs_actionprintpreview.cpp
+++ b/librecad/src/actions/rs_actionprintpreview.cpp
@@ -50,7 +50,6 @@ RS_ActionPrintPreview::RS_ActionPrintPreview(RS_EntityContainer& container,
     :RS_ActionInterface("Print Preview",
 						container, graphicView)
 	, hasOptions(false)
-	, scaleFixed(false)
 	, m_bPaperOffset(false)
 	, pPoints(new Points{})
 {
@@ -301,6 +300,11 @@ double RS_ActionPrintPreview::getScale() const{
     return ret;
 }
 
+
+void RS_ActionPrintPreview::setLineWidthScaling(bool state) {
+    graphicView->setLineWidthScaling(state);
+    graphicView->redraw();
+}
 
 
 void RS_ActionPrintPreview::setBlackWhite(bool bw) {

--- a/librecad/src/actions/rs_actionprintpreview.h
+++ b/librecad/src/actions/rs_actionprintpreview.h
@@ -74,6 +74,7 @@ public:
     void printWarning(const QString& s);
     void calcPagesNum();
 
+    void setLineWidthScaling(bool state);
 	void setBlackWhite(bool bw);
     RS2::Unit getUnit();
     void setPaperScaleFixed(bool fixed);
@@ -83,7 +84,6 @@ public:
 private:
 
 	bool hasOptions;
-	bool scaleFixed;
 	bool m_bPaperOffset;
 	struct Points;
 	std::unique_ptr<Points> pPoints;

--- a/librecad/src/lib/gui/rs_graphicview.cpp
+++ b/librecad/src/lib/gui/rs_graphicview.cpp
@@ -979,9 +979,8 @@ void RS_GraphicView::setPenForEntity(RS_Painter *painter,RS_Entity *e)
 		w = 0;
 	}
 
-#if 1 /*TRUE*/
 	// - Scale pen width.
-	// - Notes: pen width is not scaled on print and print preview.
+	// - By default pen width is not scaled on print and print preview.
 	//   This is the standard (AutoCAD like) behaviour.
 	// bug# 3437941
 	// ------------------------------------------------------------
@@ -996,7 +995,7 @@ void RS_GraphicView::setPenForEntity(RS_Painter *painter,RS_Entity *e)
 		{
 			uf = RS_Units::convert(1.0, RS2::Millimeter, graphic->getUnit());
 
-			if (	(isPrinting() || isPrintPreview()) &&
+			if ((isPrinting() || isPrintPreview()) && !scaleLineWidth &&
 					graphic->getPaperScale() > RS_TOLERANCE )
 			{
 				wf = 1.0 / graphic->getPaperScale();
@@ -1010,27 +1009,6 @@ void RS_GraphicView::setPenForEntity(RS_Painter *painter,RS_Entity *e)
 		//		pen.setWidth(RS2::Width00);
 		pen.setScreenWidth(0);
 	}
-
-#else
-
-	// - Scale pen width.
-	// - Notes: pen width is scaled on print and print preview.
-	//   This is not the standard (AutoCAD like) behaviour.
-	// --------------------------------------------------------
-	if (!draftMode)
-	{
-		double	uf = 1.0;	//	Unit factor.
-
-		RS_Graphic* graphic = container->getGraphic();
-
-        if (graphic)
-			uf = RS_Units::convert(1.0, RS2::Millimeter, graphic->getUnit());
-
-		pen.setScreenWidth(toGuiDX(w / 100.0 * uf));
-	}
-	else
-		pen.setScreenWidth(0);
-#endif
 
 	// prevent drawing with 1-width which is slow:
 	if (RS_Math::round(pen.getScreenWidth())==1) {

--- a/librecad/src/lib/gui/rs_graphicview.h
+++ b/librecad/src/lib/gui/rs_graphicview.h
@@ -373,6 +373,15 @@ public:
     bool isPanning() const;
     void setPanning(bool state);
 
+    void setLineWidthScaling(bool state){
+        scaleLineWidth = state;
+    }
+
+    bool getLineWidthScaling(){
+        return scaleLineWidth;
+    }
+
+
 protected:
 
     RS_EntityContainer* container{nullptr}; // Holds a pointer to all the enties
@@ -452,6 +461,8 @@ private:
 	bool m_bIsCleanUp=false;
 
     bool panning;
+
+	bool scaleLineWidth;
 
 signals:
     void relative_zero_changed(const RS_Vector&);

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -2429,6 +2429,7 @@ void QC_ApplicationWindow::slotFilePrint(bool printPDF) {
         RS_StaticGraphicView gv(printer.width(), printer.height(), &painter);
         gv.setPrinting(true);
         gv.setBorders(0,0,0,0);
+        gv.setLineWidthScaling(w->getGraphicView()->getLineWidthScaling());
 
         double fx = printerFx * RS_Units::getFactorToMM(graphic->getUnit());
         double fy = printerFy * RS_Units::getFactorToMM(graphic->getUnit());

--- a/librecad/src/ui/forms/qg_printpreviewoptions.cpp
+++ b/librecad/src/ui/forms/qg_printpreviewoptions.cpp
@@ -89,6 +89,7 @@ void QG_PrintPreviewOptions::init() {
             << "25000:1" << "50000:1" << "75000:1" << "100000:1";
     RS_SETTINGS->beginGroup("/PrintPreview");
     updateDisabled= RS_SETTINGS->readNumEntry("/PrintScaleFixed", 0)!=0;
+    scaleLineWidth= RS_SETTINGS->readNumEntry("/ScaleLineWidth", 0)!=0;
     blackWhiteDisabled= RS_SETTINGS->readNumEntry("/BlackWhiteSet", 0)!=0;
     RS_SETTINGS->endGroup();
 	action=nullptr;
@@ -99,6 +100,7 @@ void QG_PrintPreviewOptions::init() {
 void QG_PrintPreviewOptions::saveSettings() {
     RS_SETTINGS->beginGroup("/PrintPreview");
     RS_SETTINGS->writeEntry("/PrintScaleFixed", updateDisabled?1:0);
+    RS_SETTINGS->writeEntry("/ScaleLineWidth", QString(scaleLineWidth?"1":"0"));
     RS_SETTINGS->writeEntry("/BlackWhiteSet", QString(blackWhiteDisabled?"1":"0"));
 	RS_SETTINGS->writeEntry("/PrintScaleValue", ui->cbScale->currentText());
     RS_SETTINGS->endGroup();
@@ -166,6 +168,7 @@ void QG_PrintPreviewOptions::setAction(RS_ActionInterface* a, bool update) {
             setScaleFixed(updateDisabled);
         }
         setBlackWhite(blackWhiteDisabled);
+        setLineWidthScaling(scaleLineWidth);
 
     } else {
         RS_DEBUG->print(RS_Debug::D_ERROR,
@@ -186,6 +189,16 @@ void QG_PrintPreviewOptions::updateData() {
 void QG_PrintPreviewOptions::center() {
     if (action) {
         action->center();
+    }
+}
+
+void QG_PrintPreviewOptions::setLineWidthScaling(bool state) {
+    if (action) {
+        if(ui->bScaleLineWidth->isChecked() != state) {
+            ui->bScaleLineWidth->setChecked(state);
+        }
+        scaleLineWidth = state;
+        action->setLineWidthScaling(state);
     }
 }
 

--- a/librecad/src/ui/forms/qg_printpreviewoptions.h
+++ b/librecad/src/ui/forms/qg_printpreviewoptions.h
@@ -47,6 +47,7 @@ public slots:
     virtual void setAction( RS_ActionInterface * a, bool update );
     virtual void updateData();
     virtual void center();
+    virtual void setLineWidthScaling( bool state );
     virtual void setBlackWhite( bool on );
     virtual void fit();
     virtual void scale( const QString & s );
@@ -70,6 +71,7 @@ private:
 	QStringList imperialScales;
     QStringList metricScales;
     bool updateDisabled{false};
+    bool scaleLineWidth;
     bool blackWhiteDisabled;
     int defaultScales;
 	std::unique_ptr<Ui::Ui_PrintPreviewOptions> ui;

--- a/librecad/src/ui/forms/qg_printpreviewoptions.ui
+++ b/librecad/src/ui/forms/qg_printpreviewoptions.ui
@@ -102,6 +102,35 @@
     </spacer>
    </item>
    <item>
+    <widget class="QToolButton" name="bScaleLineWidth">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>Apply Print Scale to line width</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="../../../res/icons/icons.qrc">
+       <normaloff>:/icons/scaleLineWidth.svg</normaloff>:/icons/scaleLineWidth.svg</iconset>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QToolButton" name="bBlackWhite">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
@@ -191,7 +220,7 @@
       </sizepolicy>
      </property>
      <property name="toolTip">
-      <string>Calculate number of pages needed to contain the drawing.</string>
+      <string>Calculate number of pages needed to contain the drawing</string>
      </property>
      <property name="text">
       <string/>
@@ -236,6 +265,22 @@
    <signal>clicked()</signal>
    <receiver>Ui_PrintPreviewOptions</receiver>
    <slot>center()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>bScaleLineWidth</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>Ui_PrintPreviewOptions</receiver>
+   <slot>setLineWidthScaling(bool)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>


### PR DESCRIPTION
By default pen width is not scaled on print and print preview.
This is the standard (AutoCAD like) behavior.
But some times it may be useful to enable the pen width scaling when
printing A1 drawing on A4 paper in testing purposes, for example.