### PR TITLE
Handle fractional imperial dimensions

### DIFF
--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -264,25 +264,33 @@ double RS_Math::eval(const QString& expr, double def) {
  * various unit symbols into the current user unit (cm or inch)
  */
 QString RS_Math::derationalize(const QString& expr) {
-	RS_DEBUG->print("RS_Math::derationalize: '%s'", expr);
+	std::cout << "RS_Math::derationalize: " << expr.toStdString() << std::endl; 
 	QRegularExpression qreg(
-		R"(^(?:(?P<yards>\d+\.?\d*)(?:yards|yard|yd))?)"
+		R"(^(?P<sign>-?))"
+		R"((?:(?P<yards>\d+\.?\d*)(?:yards|yard|yd))?)"
 		R"((?:(?P<feet>\d+\.?\d*)(?:feet|foot|ft|'))?)"
 		R"((?:(?P<inches>\d+\.?\d*)[-+]?)"
 		R"((?P<fraction>(?P<numerator>\d+)\/(?P<denominator>\d+))?(?:inches|inch|in|"|))?)"
 	);
 	QRegularExpressionMatch match = qreg.match(expr);
 	if (match.hasMatch()){
+		std::cout << "RS_Math:derationalize: matches: " << match.capturedTexts().join(", ").toStdString() << std::endl;
 		double total = 0.0;
-		QString num = (match.captured("numerator") != "") ? match.captured("numerator") : "0.0";
-		QString denom = (match.captured("denominator") != "") ? match.captured("denominator") : "0.0";
-		QString inches = (match.captured("inches") != "") ? match.captured("inches") : "0.0";
-		QString feet = (match.captured("feet") != "") ? match.captured("feet") : "0.0";
-		QString yards = (match.captured("yards") != "") ? match.captured("yards") : "0.0";
+		int sign = (match.captured("sign").isNull() || match.captured("sign") == "") ? 1 : -1;
+		std::cout << "RS_Math:derationalize: matches: sign = " << sign <<std::endl;
+		QString num = (!match.captured("numerator").isNull()) ? match.captured("numerator") : "0.0";
+		QString denom = (!match.captured("denominator").isNull()) ? match.captured("denominator") : "1.0";
+		QString inches = (!match.captured("inches").isNull()) ? match.captured("inches") : "0.0";
+		QString feet = (!match.captured("feet").isNull()) ? match.captured("feet") : "0.0";
+		QString yards = (!match.captured("yards").isNull()) ? match.captured("yards") : "0.0";
+		std::cout << "RS_Math::derationalize: numerator: " << num.toStdString() << std::endl;
+		std::cout << "RS_Math::derationalize: denominator: " << denom.toStdString() << std::endl;
 		total += num.toDouble() / denom.toDouble();
+		std::cout << "RS_Math::derationalize: total after rationals: " << total << std::endl;
 		total += inches.toDouble();
-		total += feet.toDouble() * 12;
-		total += yards.toDouble() * 36;
+		total += feet.toDouble() * 12.0;
+		total += yards.toDouble() * 36.0;
+		total *= sign;
 		RS_DEBUG->print("RS_Math::derationalize: '%f'", total);
 		return QString("%1").arg(total);		
 	}

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -31,6 +31,8 @@
 #include <cmath>
 #include <muParser.h>
 #include <QString>
+#include <QRegularExpression>
+#include <QRegularExpressionMatch>
 #include <QDebug>
 
 #include "rs_math.h"
@@ -262,7 +264,24 @@ double RS_Math::eval(const QString& expr, double def) {
  * various unit symbols into the current user unit (cm or inch)
  */
 QString RS_Math::derationalize(const QString& expr) {
-	return expr;
+	RS_DEBUG->print("RS_Math::derationalize: '%s'", expr);
+	QRegularExpression qreg(
+		R"(^(?:(?P<yards>\d+\.?\d*)(?:yards|yard|yd))?)"
+		R"((?:(?P<feet>\d+\.?\d*)(?:feet|foot|ft|'))?)"
+		R"((?:(?P<inches>\d+\.?\d*)[-+]?)"
+		R"((?P<fraction>(?P<numerator>\d+)\/(?P<denominator>\d+))?(?:inches|inch|in|"|))?)"
+	);
+	QRegularExpressionMatch match = qreg.match(expr);
+	if (match.hasMatch()){
+		double total = 0.0;
+		double inches = (match.captured("inches") != "") ? match.captured("inches") : 0.0;
+		total += inches;
+		RS_DEBUG->print("RS_Math::derationalize: '%f'", total);
+		return QString("%1").arg(total);		
+	}
+	else {
+		return expr;
+	}
 }
 
 /**

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -274,8 +274,15 @@ QString RS_Math::derationalize(const QString& expr) {
 	QRegularExpressionMatch match = qreg.match(expr);
 	if (match.hasMatch()){
 		double total = 0.0;
-		double inches = (match.captured("inches") != "") ? match.captured("inches") : 0.0;
-		total += inches;
+		QString num = (match.captured("numerator") != "") ? match.captured("numerator") : "0.0";
+		QString denom = (match.captured("denominator") != "") ? match.captured("denominator") : "0.0";
+		QString inches = (match.captured("inches") != "") ? match.captured("inches") : "0.0";
+		QString feet = (match.captured("feet") != "") ? match.captured("feet") : "0.0";
+		QString yards = (match.captured("yards") != "") ? match.captured("yards") : "0.0";
+		total += num.toDouble() / denom.toDouble();
+		total += inches.toDouble();
+		total += feet.toDouble() * 12;
+		total += yards.toDouble() * 36;
 		RS_DEBUG->print("RS_Math::derationalize: '%f'", total);
 		return QString("%1").arg(total);		
 	}

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -257,6 +257,13 @@ double RS_Math::eval(const QString& expr, double def) {
     return res;
 }
 
+/**
+ * Convert a string containing rational numbers (fractions) and / or
+ * various unit symbols into the current user unit (cm or inch)
+ */
+QString RS_Math::derationalize(const QString& expr) {
+	return expr;
+}
 
 /**
  * Evaluates a mathematical expression and returns the result.
@@ -269,14 +276,15 @@ double RS_Math::eval(const QString& expr, bool* ok) {
         *ok = false;
         return 0.0;
     }
+    QString derationalized = derationalize(expr)
     double ret(0.);
     try{
         mu::Parser p;
         p.DefineConst(_T("pi"),M_PI);
 #ifdef _UNICODE
-        p.SetExpr(expr.toStdWString());
+        p.SetExpr(derationalized.toStdWString());
 #else
-        p.SetExpr(expr.toStdString());
+        p.SetExpr(derationalized.toStdString());
 #endif
         ret=p.Eval();
         *ok=true;

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -288,12 +288,12 @@ double RS_Math::convert_unit(const QRegularExpressionMatch& match, const QString
  * Note: only the gui cares about units, so all matched symbols are used naively.
  */
 QString RS_Math::derationalize(const QString& expr) {
-	RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Math::derationalize: '%s'", expr.toLatin1().data());
+	RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Math::derationalize: expr = '%s'", expr.toLatin1().data());
 
 	QRegularExpressionMatch match = unitreg.match(expr);
 	if (match.hasMatch()){
 		RS_DEBUG->print(RS_Debug::D_DEBUGGING,
-			"RS_Math::derationalize: '%s'", match.capturedTexts().join(", ").toLatin1().data());
+			"RS_Math::derationalize: matches = '%s'", match.capturedTexts().join(", ").toLatin1().data());
 		double total = 0.0;
 		int sign = (match.captured("sign").isNull() || match.captured("sign") == "") ? 1 : -1;
 
@@ -310,7 +310,7 @@ QString RS_Math::derationalize(const QString& expr) {
         total += convert_unit(match, "numer", 1.0, 0.0) / convert_unit(match, "denom", 1.0, 1.0);
 		total *= sign;
 
-		RS_DEBUG->print("RS_Math::derationalize: total is '%f'", total);
+		RS_DEBUG->print("RS_Math::derationalize: total = '%f'", total);
 		return QString("%1").arg(total);		
 	}
 	else {

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -47,14 +47,19 @@
 namespace {
 constexpr double m_piX2 = M_PI*2; //2*PI
 const QRegularExpression unitreg(
-		R"((?P<sign>^-?))"
+		/*R"((?P<sign>^-?))"
+        R"((?:(?:(?P<degrees>\d+\.?\d*)(?:degree[s]?|deg|[Dd]|°)))"
+            R"((?:(?P<minutes>\d+\.?\d*)(?:minute[s]?|min|[Mm]|'))?)"
+            R"((?:(?P<seconds>\d+\.?\d*)(?:second[s]?|sec|[Ss]|"))?))"
 		R"((?:(?P<meters>\d+\.?\d*)(?:meters|meter|m(?![m])))?)" // negative look-behind for "mm"
 		R"((?:(?P<yards>\d+\.?\d*)(?:yards|yard|yd))?)"
-		R"((?:(?P<feet>\d+\.?\d*)(?:feet|foot|ft|'))?)"
+		R"((?:(?P<feet>\d+\.?\d*)(?:feet|foot|ft|')))"
 		R"((?:(?P<base>\d+\.?\d*)[-+]?)"
             R"((?:(?P<numer>\d+)\/(?P<denom>\d+))?)"
-        R"((?:inches|inch|in|cm|"|))?)"
+        R"((?:inches|inch|in|cm|"))?)"
 		R"((?:(?P<milis>\d+\.?\d*)(?:|foot|ft|'))?)"
+        */
+        R"((?P<sign>^-?)(?:(?:(?:(?P<degrees>\d+\.?\d*)(?:degree[s]?|deg|[Dd]|°))(?:(?P<minutes>\d+\.?\d*)(?:minute[s]?|min|[Mm]|'))?(?:(?P<seconds>\d+\.?\d*)(?:second[s]?|sec|[Ss]|"))?$)|(?:(?:(?P<meters>\d+\.?\d*)(?:meter[s]?|m(?![m])))?(?:(?P<centis>\d+\.?\d*)(?:centimeter[s]?|centi|cm))?(?:(?P<millis>\d+\.?\d*)(?:millimeter[s]?|mm))?$)|(?:(?:(?P<yards>\d+\.?\d*)(?:yards|yard|yd))?(?:(?P<feet>\d+\.?\d*)(?:feet|foot|ft|'))?(?:(?P<inches>\d+\.?\d*)[-+]?(?:(?P<numer>\d+)\/(?P<denom>\d+))?(?:inches|inch|in|"))?$)))"
 	);
 }
 
@@ -293,12 +298,16 @@ QString RS_Math::derationalize(const QString& expr) {
 		int sign = (match.captured("sign").isNull() || match.captured("sign") == "") ? 1 : -1;
 
         // convert_unit(<match obj ref>, <regex group name>, <unit->base conversion factor>, <default value>)
+        total += convert_unit(match, "degrees", 1.0, 0.0);
+        total += convert_unit(match, "minutes", 1/60.0, 0.0);
+        total += convert_unit(match, "seconds", 1/3600.0, 0.0);
         total += convert_unit(match, "meters", 100.0, 0.0);
+        total += convert_unit(match, "centis", 1.0, 0.0);
+        total += convert_unit(match, "millis", 0.1, 0.0);
         total += convert_unit(match, "yards", 36.0, 0.0);
         total += convert_unit(match, "feet", 12.0, 0.0);
-        total += convert_unit(match, "base", 1.0, 0.0);
+        total += convert_unit(match, "inches", 1.0, 0.0);
         total += convert_unit(match, "numer", 1.0, 0.0) / convert_unit(match, "denom", 1.0, 1.0);
-        total += convert_unit(match, "milis", 0.1, 0.0);
 		total *= sign;
 
 		RS_DEBUG->print("RS_Math::derationalize: total is '%f'", total);

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -45,21 +45,20 @@
 
 
 namespace {
-constexpr double m_piX2 = M_PI*2; //2*PI
-const QRegularExpression unitreg(
-		/*R"((?P<sign>^-?))"
-        R"((?:(?:(?P<degrees>\d+\.?\d*)(?:degree[s]?|deg|[Dd]|°)))"
+    constexpr double m_piX2 = M_PI*2; //2*PI
+    const QRegularExpression unitreg(
+        R"((?P<sign>^-?))"
+        R"((?:(?:(?:(?P<degrees>\d+\.?\d*)(?:degree[s]?|deg|[Dd]|°)))"  // DMS
             R"((?:(?P<minutes>\d+\.?\d*)(?:minute[s]?|min|[Mm]|'))?)"
-            R"((?:(?P<seconds>\d+\.?\d*)(?:second[s]?|sec|[Ss]|"))?))"
-		R"((?:(?P<meters>\d+\.?\d*)(?:meters|meter|m(?![m])))?)" // negative look-behind for "mm"
-		R"((?:(?P<yards>\d+\.?\d*)(?:yards|yard|yd))?)"
-		R"((?:(?P<feet>\d+\.?\d*)(?:feet|foot|ft|')))"
-		R"((?:(?P<base>\d+\.?\d*)[-+]?)"
-            R"((?:(?P<numer>\d+)\/(?P<denom>\d+))?)"
-        R"((?:inches|inch|in|cm|"))?)"
-		R"((?:(?P<milis>\d+\.?\d*)(?:|foot|ft|'))?)"
-        */
-        R"((?P<sign>^-?)(?:(?:(?:(?P<degrees>\d+\.?\d*)(?:degree[s]?|deg|[Dd]|°))(?:(?P<minutes>\d+\.?\d*)(?:minute[s]?|min|[Mm]|'))?(?:(?P<seconds>\d+\.?\d*)(?:second[s]?|sec|[Ss]|"))?$)|(?:(?:(?P<meters>\d+\.?\d*)(?:meter[s]?|m(?![m])))?(?:(?P<centis>\d+\.?\d*)(?:centimeter[s]?|centi|cm))?(?:(?P<millis>\d+\.?\d*)(?:millimeter[s]?|mm))?$)|(?:(?:(?P<yards>\d+\.?\d*)(?:yards|yard|yd))?(?:(?P<feet>\d+\.?\d*)(?:feet|foot|ft|'))?(?:(?P<inches>\d+\.?\d*)[-+]?(?:(?P<numer>\d+)\/(?P<denom>\d+))?(?:inches|inch|in|"))?$)))"
+            R"((?:(?P<seconds>\d+\.?\d*)(?:second[s]?|sec|[Ss]|"))?$)|)"
+        R"((?:(?:(?P<meters>\d+\.?\d*)(?:meter[s]?|m(?![m])))?)"        // Metric
+            R"((?:(?P<centis>\d+\.?\d*)(?:centimeter[s]?|centi|cm))?)"
+            R"((?:(?P<millis>\d+\.?\d*)(?:millimeter[s]?|mm))?$)|)"
+        R"((?:(?:(?P<yards>\d+\.?\d*)(?:yards|yard|yd))?)"              // Imperial
+            R"((?:(?P<feet>\d+\.?\d*)(?:feet|foot|ft|'))?)"
+            R"((?:(?P<inches>\d+\.?\d*)[-+]?)"
+                R"((?:(?P<numer>\d+)\/(?P<denom>\d+))?)"                // rational inches
+            R"((?:inches|inch|in|"))?$)))"
 	);
 }
 

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -276,7 +276,9 @@ double RS_Math::eval(const QString& expr, bool* ok) {
         *ok = false;
         return 0.0;
     }
-    QString derationalized = derationalize(expr)
+
+    QString derationalized = derationalize(expr);
+
     double ret(0.);
     try{
         mu::Parser p;

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -48,7 +48,7 @@ namespace {
 constexpr double m_piX2 = M_PI*2; //2*PI
 const QRegularExpression unitreg(
 		R"((?P<sign>^-?))"
-		R"((?:(?P<meters>\d+\.?\d*)(?:meters|meter|m))?)"
+		R"((?:(?P<meters>\d+\.?\d*)(?:meters|meter|m(?![m])))?)" // negative look-behind for "mm"
 		R"((?:(?P<yards>\d+\.?\d*)(?:yards|yard|yd))?)"
 		R"((?:(?P<feet>\d+\.?\d*)(?:feet|foot|ft|'))?)"
 		R"((?:(?P<base>\d+\.?\d*)[-+]?)"

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -292,6 +292,7 @@ QString RS_Math::derationalize(const QString& expr) {
 		double total = 0.0;
 		int sign = (match.captured("sign").isNull() || match.captured("sign") == "") ? 1 : -1;
 
+        // convert_unit(<match obj ref>, <regex group name>, <unit->base conversion factor>, <default value>)
         total += convert_unit(match, "meters", 100.0, 0.0);
         total += convert_unit(match, "yards", 36.0, 0.0);
         total += convert_unit(match, "feet", 12.0, 0.0);

--- a/librecad/src/lib/math/rs_math.h
+++ b/librecad/src/lib/math/rs_math.h
@@ -32,6 +32,7 @@
 class RS_Vector;
 class RS_VectorSolutions;
 class QString;
+class QRegularExpressionMatch;
 
 /**
  * Math functions.
@@ -74,6 +75,7 @@ public:
     static bool isSameDirection(double dir1, double dir2, double tol);
 
     //! \convert measurement strings with rationals or unit symbols to current unit
+    static double convert_unit(const QRegularExpressionMatch&, const QString&, double, double);
     static QString derationalize(const QString& expr);
 
 	//! \{ \brief evaluate a math string

--- a/librecad/src/lib/math/rs_math.h
+++ b/librecad/src/lib/math/rs_math.h
@@ -73,6 +73,9 @@ public:
     static bool isAngleReadable(double angle);
     static bool isSameDirection(double dir1, double dir2, double tol);
 
+    //! \convert measurement strings with rationals or unit symbols to current unit
+    static QString derationalize(const QString& expr);
+
 	//! \{ \brief evaluate a math string
     static double eval(const QString& expr, double def=0.0);
     static double eval(const QString& expr, bool* ok);


### PR DESCRIPTION
Implementation for https://sourceforge.net/p/librecad/feature-requests/41/
Adds the ability to parse commands containing unit symbols.

The idea behind this implementation was to add a few new measurement specification parsing options based on the number of feature requests I found, and to make it possible (and not too difficult) to add further parsing options in the future as needed.

Accepted command patterns (Negative symbol "-" may precede measurement string):
1) DMS with required degree and optional minutes/seconds:
- Degrees: degree[s] | deg | [Dd] | ° <required, else not matched>
- Minutes: minute[s] | min | [Mm] | ' <optional>
- Seconds: second[s] | sec | [Ss] | " <optional>
2) Metric string containing meters, centimeters, millimeters:
- Meters: meter[s] | m <optional>
- centimeters: centimeter[s] | centi | cm <optional>
- millimeters: millimeter[s] | milli | mm <optional>
3) Imperial with rational inch parts, e.g. "11ft6-7/8in":
- Yards: yard[s] | yd <optional>
- Feet: feet | foot | ft | ' <optional>
- Inches: inches | inch | in | " <optional>
-- Rational inch part: [-+]NN/DD <optional, must precede unit symbol>

Provisos:
1) Arithmetic operators are not allowed within measurements containing unit symbols (parsing would be too complex).
2) DMS, Metric, and Imperial measurement unit symbols may not be combined or mixed.
3) If no unit symbols are used, assumes the command is using default units for the GUI.
3) If no unit symbol is provided, or none of the above patterns match, the original command will be passed through to p.eval() unchanged, possibly causing syntax errors.
3) Currently there is no unit testing of the new functions.

I would like to add some basic unit tests so that future changes to the regex or logic can be vetted, but I'm not sure how to run the existing tests.  Is QT Creator required?

Many thanks!