### PR TITLE
(WIP) Make PDF Print/Export work without having to use Print Preview first

### DIFF
--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -2259,6 +2259,8 @@ void QC_ApplicationWindow::slotFilePrint(bool printPDF) {
         return;
     }
 
+    graphic->fitToPage();
+
     statusBar()->showMessage(tr("Printing..."));
     QPrinter printer(QPrinter::HighResolution);
 


### PR DESCRIPTION
Fixes #751.

Exporting/Printing PDF files now works without having to use Print Preview first. Tested on Ubuntu 18.04.