### PR TITLE
Code cleanup and deprecated functions

### DIFF
--- a/libraries/jwwlib/src/dl_attributes.h
+++ b/libraries/jwwlib/src/dl_attributes.h
@@ -156,20 +156,6 @@ public:
         }
     }
 
-
-
-    /**
-     * Copies attributes (deep copies) from another attribute object.
-     */
-    DL_Attributes operator = (const DL_Attributes& attrib) {
-        setLayer(attrib.layer);
-        setColor(attrib.color);
-        setWidth(attrib.width);
-        setLineType(attrib.lineType);
-
-        return *this;
-    }
-
 private:
     string layer;
     int color;

--- a/libraries/jwwlib/src/dl_extrusion.h
+++ b/libraries/jwwlib/src/dl_extrusion.h
@@ -43,17 +43,8 @@ public:
      * Default constructor.
      */
     DL_Extrusion() {
-		direction = new double[3];
         setDirection(0.0, 0.0, 1.0);
         setElevation(0.0);
-    }
-
-
-    /**
-     * Destructor.
-     */
-	~DL_Extrusion() {
-		delete direction ;
     }
 
 
@@ -61,36 +52,25 @@ public:
      * Constructor for DXF extrusion.
      *
      * @param direction Vector of axis along which the entity shall be extruded
-	 *                  this is also the Z axis of the Entity coordinate system
+     *                  this is also the Z axis of the Entity coordinate system
      * @param elevation Distance of the entities XY plane from the origin of the
-	 *                  world coordinate system
+     *                  world coordinate system
      */
     DL_Extrusion(double dx, double dy, double dz, double elevation) {
-		direction = new double[3];
-		setDirection(dx, dy, dz);
+        setDirection(dx, dy, dz);
         setElevation(elevation);
     }
 
 
 
     /**
-     * Sets the direction vector. 
+     * Sets the direction vector.
      */
     void setDirection(double dx, double dy, double dz) {
-		direction[0]=dx;
+        direction[0]=dx;
         direction[1]=dy;
         direction[2]=dz;
     }
-
-
-
-    /**
-     * @return direction vector.
-     */
-    double* getDirection() const {
-        return direction;
-    }
-
 
 
     /**
@@ -122,21 +102,9 @@ public:
 
 
 
-    /**
-     * Copies extrusion (deep copies) from another extrusion object.
-     */
-    DL_Extrusion operator = (const DL_Extrusion& extru) {
-        setDirection(extru.direction[0], extru.direction[1], extru.direction[2]);
-        setElevation(extru.elevation);
-
-        return *this;
-    }
-
-
-
 private:
-	double *direction;
-	double elevation;
+    double direction[3];
+    double elevation;
 };
 
 #endif

--- a/libraries/libdxfrw/src/drw_base.h
+++ b/libraries/libdxfrw/src/drw_base.h
@@ -152,10 +152,6 @@ public:
     DRW_Coord():x(0), y(0),z(0) {}
     DRW_Coord(double ix, double iy, double iz): x(ix), y(iy),z(iz){}
 
-     DRW_Coord& operator = (const DRW_Coord& data) {
-        x = data.x;  y = data.y;  z = data.z;
-        return *this;
-    }
 /*!< convert to unitary vector */
     void unitize(){
         double dist;

--- a/librecad/src/lib/engine/rs_settings.h
+++ b/librecad/src/lib/engine/rs_settings.h
@@ -87,10 +87,10 @@ public:
     bool writeEntry(const QString& key, const QVariant& value);
     bool writeEntry(const QString& key, const QString& value);
     QString readEntry(const QString& key,
-                        const QString& def = QString::null,
+                        const QString& def = QString(),
                         bool* ok = 0);
     QByteArray readByteArrayEntry(const QString& key,
-                        const QString& def = QString::null,
+                        const QString& def = QString(),
                         bool* ok = 0);
 	int readNumEntry(const QString& key, int def=0);
     void clear_all();

--- a/librecad/src/lib/engine/rs_vector.cpp
+++ b/librecad/src/lib/engine/rs_vector.cpp
@@ -841,13 +841,6 @@ RS_VectorSolutions RS_VectorSolutions::flipXY(void) const
         return ret;
 }
 
-RS_VectorSolutions RS_VectorSolutions::operator = (const RS_VectorSolutions& s) {
-    setTangent(s.isTangent());
-    vector=s.vector;
-
-    return *this;
-}
-
 std::ostream& operator << (std::ostream& os,
                            const RS_VectorSolutions& s) {
 	for (const RS_Vector& vp: s){

--- a/librecad/src/lib/engine/rs_vector.h
+++ b/librecad/src/lib/engine/rs_vector.h
@@ -196,8 +196,6 @@ void set(size_t i, const RS_Vector& v);
     /** switch x,y for all vectors */
     RS_VectorSolutions flipXY(void) const;
 
-    RS_VectorSolutions operator = (const RS_VectorSolutions& s);
-
     friend std::ostream& operator << (std::ostream& os,
                                       const RS_VectorSolutions& s);
 

--- a/librecad/src/lib/filters/rs_filterdxf1.cpp
+++ b/librecad/src/lib/filters/rs_filterdxf1.cpp
@@ -1646,7 +1646,7 @@ QString RS_FilterDXF1::getBufLine() {
     QString str;
 
     if (fBufP >= (int)fSize)
-        return QString::null;
+        return QString();
 
     ret = &fBuf[fBufP];
 
@@ -1655,7 +1655,7 @@ QString RS_FilterDXF1::getBufLine() {
         while (++fBufP < (int)fSize && fBuf[fBufP] == '\0')
             ;
         if (fBufP >= (int)fSize)
-            return QString::null;
+            return QString();
         ret = &fBuf[fBufP];
 }*/
 

--- a/librecad/src/lib/gui/rs_dialogfactoryinterface.h
+++ b/librecad/src/lib/gui/rs_dialogfactoryinterface.h
@@ -86,7 +86,7 @@ public:
          * window for the given document or for a new document isf no document
          * is given.
          */
-//    virtual RS_GraphicView* requestNewDocument(const QString& fileName = QString::null,
+//    virtual RS_GraphicView* requestNewDocument(const QString& fileName = QString(),
 //                        RS_Document* doc=NULL) = 0;
 
     /**
@@ -386,8 +386,8 @@ public:
      * @param left Help text for the left mouse button.
      * @param right Help text for the right mouse button.
 	 */
-	virtual void updateMouseWidget(const QString& = QString::null,
-								   const QString& = QString::null)=0;
+	virtual void updateMouseWidget(const QString& = QString(),
+								   const QString& = QString())=0;
     virtual void updateArcTangentialOptions(const double& d, bool byRadius)=0;
 
     /**

--- a/librecad/src/lib/gui/rs_mainwindowinterface.h
+++ b/librecad/src/lib/gui/rs_mainwindowinterface.h
@@ -45,7 +45,7 @@ public:
 	virtual RS_GraphicView* getGraphicView() = 0;
 	virtual RS_Document* getDocument() = 0;
 
-	virtual void createNewDocument(const QString& fileName = QString::null, RS_Document* doc=nullptr) = 0;
+	virtual void createNewDocument(const QString& fileName = QString(), RS_Document* doc=nullptr) = 0;
 
 };
 

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -3005,7 +3005,7 @@ void QC_ApplicationWindow::createNewDocument(
         const QString& fileName, RS_Document* doc) {
 
     slotFileNew(doc);
-    if (fileName!=QString::null && getDocument()) {
+    if (fileName!=QString() && getDocument()) {
         getDocument()->setFilename(fileName);
     }
 }

--- a/librecad/src/main/qc_applicationwindow.h
+++ b/librecad/src/main/qc_applicationwindow.h
@@ -272,7 +272,7 @@ public:
     /**
      * Creates a new document. Implementation from RS_MainWindowInterface.
      */
-	void createNewDocument(const QString& fileName = QString::null, RS_Document* doc=nullptr);
+	void createNewDocument(const QString& fileName = QString(), RS_Document* doc=nullptr);
 
     void redrawAll();
     void updateGrids();

--- a/librecad/src/ui/forms/qg_dlgmtext.cpp
+++ b/librecad/src/ui/forms/qg_dlgmtext.cpp
@@ -411,7 +411,7 @@ void QG_DlgMText::defaultChanged(bool) {
 }
 
 void QG_DlgMText::loadText() {
-    QString fn = QFileDialog::getOpenFileName( this, QString::null, QString::null);
+    QString fn = QFileDialog::getOpenFileName( this, QString(), QString());
     if (!fn.isEmpty()) {
         load(fn);
     }
@@ -428,7 +428,7 @@ void QG_DlgMText::load(const QString& fn) {
 }
 
 void QG_DlgMText::saveText() {
-    QString fn = QFileDialog::getSaveFileName(this, QString::null, QString::null);
+    QString fn = QFileDialog::getSaveFileName(this, QString(), QString());
     if (!fn.isEmpty()) {
         save(fn);
     }

--- a/librecad/src/ui/forms/qg_dlgtext.cpp
+++ b/librecad/src/ui/forms/qg_dlgtext.cpp
@@ -393,7 +393,7 @@ void QG_DlgText::setFont(const QString& f) {
 }*/
 
 void QG_DlgText::loadText() {
-    QString fn = QFileDialog::getOpenFileName( this, QString::null, QString::null);
+    QString fn = QFileDialog::getOpenFileName( this, QString(), QString());
     if (!fn.isEmpty()) {
         load(fn);
     }
@@ -410,7 +410,7 @@ void QG_DlgText::load(const QString& fn) {
 }
 
 void QG_DlgText::saveText() {
-    QString fn = QFileDialog::getSaveFileName(this, QString::null, QString::null);
+    QString fn = QFileDialog::getSaveFileName(this, QString(), QString());
     if (!fn.isEmpty()) {
         save(fn);
     }

--- a/librecad/src/ui/qg_blockwidget.cpp
+++ b/librecad/src/ui/qg_blockwidget.cpp
@@ -34,6 +34,8 @@
 #include <QLineEdit>
 #include <QContextMenuEvent>
 
+#include <algorithm>
+
 #include "qg_blockwidget.h"
 #include "rs_blocklist.h"
 #include "qg_actionhandler.h"
@@ -76,7 +78,7 @@ void QG_BlockModel::setBlockList(RS_BlockList* bl) {
         if ( !bl->at(i)->isUndone() )
             listBlock.append(bl->at(i));
     }
-    qSort ( listBlock.begin(), listBlock.end(), blockLessThan );
+    std::sort(listBlock.begin(), listBlock.end(), blockLessThan);
 //called to force redraw
     endResetModel();
 }

--- a/librecad/src/ui/qg_dialogfactory.h
+++ b/librecad/src/ui/qg_dialogfactory.h
@@ -228,8 +228,8 @@ public:
 	 * \param left mouse hint for left button
 	 * \param right mouse hint for right button
 	 */
-	void updateMouseWidget(const QString& left=QString::null,
-								   const QString& right=QString::null) override;
+	void updateMouseWidget(const QString& left=QString(),
+								   const QString& right=QString()) override;
 	void updateSelectionWidget(int num, double length) override;//updated for total number of selected, and total length of selected
 	void commandMessage(const QString& message) override;
 


### PR DESCRIPTION
The changes done here are mostly fixing deprecated usages of Qt functions and some basic changes that greatly reduce the number of warnings that show during compilation.