### PR TITLE
Unhighlight limiting entity after exiting Trim tool

### DIFF
--- a/librecad/src/actions/rs_actionmodifytrim.cpp
+++ b/librecad/src/actions/rs_actionmodifytrim.cpp
@@ -55,14 +55,7 @@ RS_ActionModifyTrim::RS_ActionModifyTrim(RS_EntityContainer& container,
 }
 
 RS_ActionModifyTrim::~RS_ActionModifyTrim(){
-	if (graphicView != nullptr && graphicView->isCleanUp()==false){
-		if (limitEntity!= nullptr){
-            if(limitEntity->isHighlighted()){
-                limitEntity->setHighlighted(false);
-                graphicView->drawEntity(limitEntity);
-            }
-        }
-    }
+    unhighlightLimitingEntity();
 }
 
 void RS_ActionModifyTrim::init(int status) {
@@ -73,7 +66,10 @@ void RS_ActionModifyTrim::init(int status) {
 
 }
 
-
+void RS_ActionModifyTrim::finish(bool updateTB) {
+    RS_PreviewActionInterface::finish(updateTB);
+    unhighlightLimitingEntity();
+}
 
 void RS_ActionModifyTrim::trigger() {
 
@@ -204,5 +200,16 @@ void RS_ActionModifyTrim::updateMouseButtonHints() {
 
 void RS_ActionModifyTrim::updateMouseCursor() {
     graphicView->setMouseCursor(RS2::SelectCursor);
+}
+
+void RS_ActionModifyTrim::unhighlightLimitingEntity() {
+    if (graphicView != nullptr && graphicView->isCleanUp()==false){
+        if (limitEntity!= nullptr){
+            if(limitEntity->isHighlighted()){
+                limitEntity->setHighlighted(false);
+                graphicView->drawEntity(limitEntity);
+            }
+        }
+    }
 }
 

--- a/librecad/src/actions/rs_actionmodifytrim.h
+++ b/librecad/src/actions/rs_actionmodifytrim.h
@@ -53,6 +53,7 @@ public:
 	~RS_ActionModifyTrim() override;
 
 	void init(int status=0) override;
+	void finish(bool updateTB=true) override;
 	void trigger() override;
 	void mouseMoveEvent(QMouseEvent* e) override;
 	void mouseReleaseEvent(QMouseEvent* e) override;
@@ -66,6 +67,8 @@ private:
 	struct Points;
 	std::unique_ptr<Points> pPoints;
 	bool both;
+
+	void unhighlightLimitingEntity();
 };
 
 #endif


### PR DESCRIPTION
Fixes #974, specifically the first comment with regard to the trim tool (https://github.com/LibreCAD/LibreCAD/issues/974#issue-314384893). Demo below:

![trim-unhighlight-demo](https://user-images.githubusercontent.com/24422213/75481172-7efcf780-5a07-11ea-99ee-d2fe2f459a56.gif)

I plan to submit a separate PR for the second comment (regarding orthogonal lines) shortly.