### PR TITLE
Unhighlight entity after exiting Orthogonal Line tool

### DIFF
--- a/librecad/src/actions/rs_actiondrawlinerelangle.cpp
+++ b/librecad/src/actions/rs_actiondrawlinerelangle.cpp
@@ -64,6 +64,11 @@ RS2::ActionType RS_ActionDrawLineRelAngle::rtti() const{
 		return RS2::ActionDrawLineRelAngle;
 }
 
+void RS_ActionDrawLineRelAngle::finish(bool updateTB) {
+    unhighlightEntity();
+    RS_PreviewActionInterface::finish(updateTB);
+}
+
 void RS_ActionDrawLineRelAngle::trigger() {
     RS_PreviewActionInterface::trigger();
 
@@ -336,6 +341,14 @@ void RS_ActionDrawLineRelAngle::updateMouseCursor()
             break;
         default:
             break;
+    }
+}
+
+void RS_ActionDrawLineRelAngle::unhighlightEntity()
+{
+    if (entity) {
+        entity->setHighlighted(false);
+        graphicView->drawEntity(entity);
     }
 }
 

--- a/librecad/src/actions/rs_actiondrawlinerelangle.h
+++ b/librecad/src/actions/rs_actiondrawlinerelangle.h
@@ -56,6 +56,7 @@ public:
 	
 	RS2::ActionType rtti() const override;
 
+    void finish(bool updateTB = true) override;
 	void trigger() override;
 
 	void mouseMoveEvent(QMouseEvent* e) override;
@@ -113,6 +114,8 @@ private:
 
     //list of entity types supported by current action
     const std::initializer_list<RS2::EntityType> enTypeList {RS2::EntityLine, RS2::EntityArc, RS2::EntityCircle,RS2::EntityEllipse};
+
+    void unhighlightEntity();
 };
 
 #endif


### PR DESCRIPTION
Fixes #974, comment #2 regarding the Orthogonal Line tool (https://github.com/LibreCAD/LibreCAD/issues/974#issuecomment-382777737). Demo below:

![ortho-unhighlight-demo](https://user-images.githubusercontent.com/24422213/75482089-fda66480-5a08-11ea-9c72-115b9b6a140a.gif)
