### PR TITLE
Fix for 'move to bottom' command with existing selection

### DIFF
--- a/librecad/src/ui/qg_actionhandler.cpp
+++ b/librecad/src/ui/qg_actionhandler.cpp
@@ -299,7 +299,12 @@ RS_ActionInterface* QG_ActionHandler::setCurrentAction(RS2::ActionType id) {
         break;
     case RS2::ActionOrderBottom:
         orderType = RS2::ActionOrderBottom;
-        a = new RS_ActionSelect(this, *document, *view, RS2::ActionOrderNoSelect);
+        if(!document->countSelected()){
+            a = new RS_ActionSelect(this, *document, *view, RS2::ActionOrderNoSelect);
+        }
+        else {
+            a = new RS_ActionOrder(*document, *view, orderType);
+        }
         break;
     case RS2::ActionOrderLower:
         orderType = RS2::ActionOrderLower;
@@ -310,12 +315,14 @@ RS_ActionInterface* QG_ActionHandler::setCurrentAction(RS2::ActionType id) {
         a = new RS_ActionSelect(this, *document, *view, RS2::ActionOrderNoSelect);
         break;
     case RS2::ActionOrderTop:
-		if(!document->countSelected()){
-			orderType = RS2::ActionOrderTop;
-			a = new RS_ActionSelect(this, *document, *view, RS2::ActionOrderNoSelect);
-			break;
-		}
-        // fall-through
+        orderType = RS2::ActionOrderTop;
+        if(!document->countSelected()){
+            a = new RS_ActionSelect(this, *document, *view, RS2::ActionOrderNoSelect);
+        }
+        else {
+            a = new RS_ActionOrder(*document, *view, orderType);
+        }
+        break;
     case RS2::ActionOrderNoSelect:
         a = new RS_ActionOrder(*document, *view, orderType);
         break;


### PR DESCRIPTION
Fixes #1040. The "Move to Bottom" command now works when there is an existing selection. Demo below:

![move-to-bottom-demo](https://user-images.githubusercontent.com/24422213/75705613-95b19000-5d20-11ea-91a8-d03fc1151452.gif)
