### PR TITLE
Create equidistant polylines in currently selected layer

### DIFF
--- a/librecad/src/actions/rs_actionpolylineequidistant.cpp
+++ b/librecad/src/actions/rs_actionpolylineequidistant.cpp
@@ -154,7 +154,7 @@ bool RS_ActionPolylineEquidistant::makeContour() {
 
     for (int num=1; num<=number || (number==0 && num<=1); num++) {
         RS_Polyline* newPolyline = new RS_Polyline(container);
-        newPolyline->setLayer(((RS_Polyline*)originalEntity)->getLayer());
+        newPolyline->setLayerToActive();
         newPolyline->setPen(((RS_Polyline*)originalEntity)->getPen());
 
         bool first = true;


### PR DESCRIPTION
Fixes #682. Equidistant polylines are now created in the currently selected layer.