### PR TITLE
added auto-zoom after inserting an image

### DIFF
--- a/librecad/src/actions/rs_actiondrawimage.cpp
+++ b/librecad/src/actions/rs_actiondrawimage.cpp
@@ -107,6 +107,7 @@ void RS_ActionDrawImage::trigger() {
     }
 
     graphicView->redraw(RS2::RedrawDrawing);
+    graphicView->zoomAuto();
     finish(false);
 }
 


### PR DESCRIPTION
Added auto-zoom after redrawing the inserted image in "RS_ActionDrawImage::trigger"  function. 
Due to "Can't import SVG???" #1162  - This does not completly resolve  author's request  (according to the project wiki SVG cannot be open), but now there should be no confusion ("where is my image?!")  after insertion.