### PR TITLE
Update qg_commandedit.cpp

### DIFF
--- a/librecad/src/ui/qg_commandedit.cpp
+++ b/librecad/src/ui/qg_commandedit.cpp
@@ -330,7 +330,8 @@ void QG_CommandEdit::readCommandFile(const QString& path)
     {
         line = txt_stream.readLine();
         line.remove(" ");
-        processInput(line);
+        if (!line.startsWith("#"))
+            processInput(line);
     }
 }
 


### PR DESCRIPTION
# Allow comments in command files.

qg_commandedit.cpp has `void QG_CommandEdit::readCommandFile(const QString& path)` function to read command files. There is no provision to add comments in a command file. 

This request is to allows lines commencing with a hash ( # ) to be treated as a comment and ignored from being passed to the `processInput(line)` function.

Regards, Ian.