### PR TITLE
Fix argument of RS_GraphicView::setBackground in export

### DIFF
--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -2159,9 +2159,9 @@ bool QC_ApplicationWindow::slotFileExport(const QString& name,
 
 	RS_StaticGraphicView gv(size.width(), size.height(), &painter, &borders);
     if (black) {
-		gv.setBackground(Qt::black);
+		gv.setBackground(QColor(Qt::black));
     } else {
-		gv.setBackground(Qt::white);
+		gv.setBackground(QColor(Qt::white));
     }
     gv.setContainer(graphic);
     gv.zoomAuto(false);


### PR DESCRIPTION
Qt::black is an enum value and it caused RS_Color(unsigned int f) constructor to be called (but its int argument should be flags and not a color from Qt's enum). So basically the meaning of the int value was changed.

This change surely fixes this problem:
- draw a black line
- export as PNG
- Background: white
- Colouring: coloured
- problem: the exported PNG does not contain the line (it is blank)

This change may cause a fix in bugs #962 and #553 (or at least solve some confusion in these bugs).