### PR TITLE
Add commands

### DIFF
--- a/librecad/src/cmd/rs_commands.cpp
+++ b/librecad/src/cmd/rs_commands.cpp
@@ -417,7 +417,8 @@ RS_Commands::RS_Commands() {
         // Invert selection - GSS
         {
             {{"invertselect", QObject::tr("invertselect", "invert select")}},
-            {{"is", QObject::tr("is", "invert select")}},
+            {{"is", QObject::tr("is", "invert select")},
+             {"si", QObject::tr("si", "invert select")}},
             RS2::ActionSelectInvert
         },
         /* Remaining select tools are mouse-specific. */
@@ -432,6 +433,12 @@ RS_Commands::RS_Commands() {
             {{"da", QObject::tr("da", "dimension - aligned")}},
             RS2::ActionDimAligned
         },
+        //dimension linear
+        {
+            {{"dimlinear", QObject::tr("dimlinear", "dimension - linear")}},
+			{{"dl", QObject::tr("dl", "dimension - linear")}},
+            RS2::ActionDimLinear
+        },
         //dimension horizontal
         {
             {{"dimhorizontal", QObject::tr("dimhorizontal", "dimension - horizontal")}},
@@ -444,23 +451,11 @@ RS_Commands::RS_Commands() {
             {{"dv", QObject::tr("dv", "dimension - vertical")}},
             RS2::ActionDimLinearVer
         },
-        //dimension linear
-        {
-            {{"dimlinear", QObject::tr("dimlinear", "dimension - linear")}},
-			{{"dl", QObject::tr("dl", "dimension - linear")},
-             {"dr", QObject::tr("dr", "dimension - linear")}},
-            RS2::ActionDimLinear
-        },
-        //dimension angular
-        {
-            {{"dimangular", QObject::tr("dimangular", "dimension - angular")}},
-            {{"dan", QObject::tr("dan", "dimension - angular")}},
-            RS2::ActionDimAngular
-        },
         //dimension radius
         {
             {{"dimradial", QObject::tr("dimradial", "dimension - radial")}},
-            {{"dimradius", QObject::tr("dimradius", "dimension - radius")}},
+            {{"dimradius", QObject::tr("dimradius", "dimension - radius")},
+             {"dr", QObject::tr("dr", "dimension - linear")},
             RS2::ActionDimRadial
         },
         //dimension diameter
@@ -469,6 +464,12 @@ RS_Commands::RS_Commands() {
             {{"dimdiameter", QObject::tr("dimdiameter", "dimension - diametric")},
             {"dd", QObject::tr("dd", "dimension - diametric")}},
             RS2::ActionDimDiametric
+        },
+        //dimension angular
+        {
+            {{"dimangular", QObject::tr("dimangular", "dimension - angular")}},
+            {{"dan", QObject::tr("dan", "dimension - angular")}},
+            RS2::ActionDimAngular
         },
         //dimension leader
         {
@@ -607,7 +608,7 @@ RS_Commands::RS_Commands() {
             {{"area", QObject::tr("area", "measure area")}},
             {{"ar", QObject::tr("ar", "measure area")}},
             RS2::ActionInfoArea
-        }
+        },
 
         /* OTHER COMMANDS */
         //draw hatch
@@ -770,7 +771,7 @@ RS_Commands::RS_Commands() {
             {{"zoompan", QObject::tr("zoompan", "zoom - pan")}},
             {{"zp", QObject::tr("zp", "zoom - pan")}},
             RS2::ActionZoomPan
-        },
+        }
     };
 
     for(auto const& c0: commandList){

--- a/librecad/src/cmd/rs_commands.cpp
+++ b/librecad/src/cmd/rs_commands.cpp
@@ -452,7 +452,7 @@ RS_Commands::RS_Commands() {
         {
             {{"dimradial", QObject::tr("dimradial", "dimension - radial")}},
             {{"dimradius", QObject::tr("dimradius", "dimension - radius")},
-             {"dr", QObject::tr("dr", "dimension - linear")},
+             {"dr", QObject::tr("dr", "dimension - linear")}},
             RS2::ActionDimRadial
         },
         // dimension diameter
@@ -509,15 +509,15 @@ RS_Commands::RS_Commands() {
         // move and rotate - GSS
         {
             {{"moverotate", QObject::tr("moverotate", "modify - move rotate")}},
-            {{"mvro", QObject::tr("mvro", "modify - move rotate")}
-             {"mr", QObject::tr("mr", "modify - move rotate"},
+            {{"mvro", QObject::tr("mvro", "modify - move rotate")},
+             {"mr", QObject::tr("mr", "modify - move rotate")}},
             RS2::ActionModifyMoveRotate
         },
         // rotate two - GSS
         {
             {{"rotatetwo", QObject::tr("rotatetwo", "modify - rotate2")}},
             {{"ro2", QObject::tr("ro2", "modify - rotate2")},
-             {"r2", QObject::tr("r2", "modify - rotate2")},
+             {"r2", QObject::tr("r2", "modify - rotate2")}},
             RS2::ActionModifyRotate2
         },
         // revert

--- a/librecad/src/cmd/rs_commands.cpp
+++ b/librecad/src/cmd/rs_commands.cpp
@@ -401,22 +401,29 @@ RS_Commands::RS_Commands() {
             RS2::ActionPolylineSegment
          },
  
-/*  -- START DEBUG
-*/ //-- END DEBUG
-
         /* SELECT COMMANDS */
-        //Select all entities
+        // Select all entities
         {
             {{"selectall", QObject::tr("selectall", "Select all entities")}},
             {{"sa", QObject::tr("sa", "Select all entities")}},
             RS2::ActionSelectAll
         },
-        //DeSelect all entities
+        // DeSelect all entities
         {
             {{"deselectall", QObject::tr("deselectall", "deselect all entities")}},
             {{"tn", QObject::tr("tn", "deselect all entities")}},
             RS2::ActionDeselectAll
         },
+        // Invert selection - GSS
+        {
+            {{"invertselect", QObject::tr("invertselect", "invert select")}},
+            {{"is", QObject::tr("is", "invert select")}},
+            RS2::ActionSelectInvert
+        },
+        /* Remaining select tools are mouse-specific. */
+
+/*  -- START DEBUG
+*/ //-- END DEBUG
 
         /* DIMENSION COMMANDS */
         //dimension aligned

--- a/librecad/src/cmd/rs_commands.cpp
+++ b/librecad/src/cmd/rs_commands.cpp
@@ -400,81 +400,25 @@ RS_Commands::RS_Commands() {
             {{"join", QObject::tr("join", "pl join")}},
             RS2::ActionPolylineSegment
          },
-
+ 
 /*  -- START DEBUG
 */ //-- END DEBUG
 
-/* SELECT COMMANDS */
+        /* SELECT COMMANDS */
+        //Select all entities
+        {
+            {{"selectall", QObject::tr("selectall", "Select all entities")}},
+            {{"sa", QObject::tr("sa", "Select all entities")}},
+            RS2::ActionSelectAll
+        },
+        //DeSelect all entities
+        {
+            {{"deselectall", QObject::tr("deselectall", "deselect all entities")}},
+            {{"tn", QObject::tr("tn", "deselect all entities")}},
+            RS2::ActionDeselectAll
+        },
 
-
-        //draw hatch
-        {
-            {{"hatch", QObject::tr("hatch", "draw hatch")}},
-            {{"ha", QObject::tr("ha", "draw hatch")}},
-            RS2::ActionDrawHatchNoSelect
-        },
-        //draw mtext
-        {
-            {{"mtext", QObject::tr("mtext", "draw mtext")}},
-            {{"mtxt", QObject::tr("mtxt", "draw mtext")}},
-            RS2::ActionDrawMText
-        },
-        //draw text
-        {
-            {{"text", QObject::tr("text", "draw text")}},
-            {{"txt", QObject::tr("txt", "draw text")}},
-            RS2::ActionDrawText
-        },
-        //zoom redraw
-        {
-            {{"regen", QObject::tr("regen", "zoom - redraw")},
-             {"redraw", QObject::tr("redraw", "zoom - redraw")}},
-            {{"rg", QObject::tr("rg", "zoom - redraw")},
-            {"zr", QObject::tr("zr", "zoom - redraw")}},
-            RS2::ActionZoomRedraw
-        },
-        //zoom window
-        {
-            {{"zoomwindow", QObject::tr("zoomwindow", "zoom - window")}},
-            {{"zw", QObject::tr("zw", "zoom - window")}},
-            RS2::ActionZoomWindow
-        },
-        //zoom auto
-        {
-            {{"zoomauto", QObject::tr("zoomauto", "zoom - auto")}},
-            {{"za", QObject::tr("za", "zoom - auto")}},
-            RS2::ActionZoomAuto
-        },
-        //zoom pan
-        {
-            {{"zoompan", QObject::tr("zoompan", "zoom - pan")}},
-            {{"zp", QObject::tr("zp", "zoom - pan")}},
-            RS2::ActionZoomPan
-        },
-        //zoom previous
-        {
-            {{"zoomprevious", QObject::tr("zoomprevious", "zoom - previous")}},
-            {{"zv", QObject::tr("zv", "zoom - previous")}},
-            RS2::ActionZoomPrevious
-        },
-        //kill actions
-        {
-            {{"kill", QObject::tr("kill", "kill all actions")}},
-            {{"k", QObject::tr("k", "kill all actions")}},
-            RS2::ActionEditKillAllActions
-        },
-        //undo cycle
-        {
-            {{"undo", QObject::tr("undo", "undo cycle")}},
-            {{"u", QObject::tr("u", "undo cycle")}},
-            RS2::ActionEditUndo
-        },
-        //redo cycle
-        {
-            {{"redo", QObject::tr("redo", "redo cycle")}},
-            {{"r", QObject::tr("r", "redo cycle")}},
-            RS2::ActionEditRedo
-        },
+        /* DIMENSION COMMANDS */
         //dimension aligned
         {
             {{"dimaligned", QObject::tr("dimaligned", "dimension - aligned")}},
@@ -531,30 +475,8 @@ RS_Commands::RS_Commands() {
             {},
             RS2::ActionToolRegenerateDimensions
         },
-        //snap restrictions
-        {
-            {{"restrictnothing", QObject::tr("restrictnothing", "restrict - nothing")}},
-            {{"rn", QObject::tr("rn", "restrict - nothing")}},
-            RS2::ActionRestrictNothing
-        },
-        //snap orthogonal
-        {
-            {{"restrictorthogonal", QObject::tr("restrictorthogonal", "restrict - orthogonal")}},
-            {{"rr", QObject::tr("rr", "restrict - orthogonal")}},
-            RS2::ActionRestrictOrthogonal
-        },
-        //snap horizontal
-        {
-            {{"restricthorizontal", QObject::tr("restricthorizontal", "restrict - horizontal")}},
-            {{"rh", QObject::tr("rh", "restrict - horizontal")}},
-            RS2::ActionRestrictHorizontal
-        },
-        //snap vertical
-        {
-            {{"restrictvertical", QObject::tr("restrictvertical", "restrict - vertical")}},
-            {{"rv", QObject::tr("rv", "restrict - vertical")}},
-            RS2::ActionRestrictVertical
-        },
+
+        /* MODIFY COMMANDS */
         //move
         {
             {{"move", QObject::tr("move", "modify - move (copy)")}},
@@ -644,6 +566,63 @@ RS_Commands::RS_Commands() {
             {{"xp", QObject::tr("xp", "explode block/polyline into entities")}},
             RS2::ActionBlocksExplode
         },
+        //Modify Attributes
+        {
+            {{"modifyattr", QObject::tr("modifyattr", "modify attribute")}},            
+            {{"attr", QObject::tr("attr", "modify attribute")},
+            {"ma", QObject::tr("ma", "modify attribute")}},
+            RS2::ActionModifyAttributes
+        },
+        //Modify Properties
+        {
+            {{"properties", QObject::tr("properties", "modify properties")}},
+            {{"prop", QObject::tr("prop", "modify properties")},
+             {"mp", QObject::tr("mp", "modify properties")}},
+            RS2::ActionModifyEntity
+        },
+
+        /* INFO COMMANDS */
+        //Distance Point to Point
+        {
+            {{"distance", QObject::tr("distance", "distance point to point")}},
+            {{"dist", QObject::tr("dist", "distance point to point")},
+            {"dpp", QObject::tr("dpp", "distance point to point")}},
+            RS2::ActionInfoDist
+		},
+        //Measure angle
+        {
+            {{"angle", QObject::tr("angle", "measure angle")}},
+            {{"ang", QObject::tr("ang", "measure angle")}},
+            RS2::ActionInfoAngle
+        },
+        //Measure area
+        {
+            {{"area", QObject::tr("area", "measure area")}},
+            {{"ar", QObject::tr("ar", "measure area")}},
+            RS2::ActionInfoArea
+        }
+
+        /* OTHER COMMANDS */
+        //draw hatch
+        {
+            {{"hatch", QObject::tr("hatch", "draw hatch")}},
+            {{"ha", QObject::tr("ha", "draw hatch")}},
+            RS2::ActionDrawHatchNoSelect
+        },
+        //draw mtext
+        {
+            {{"mtext", QObject::tr("mtext", "draw mtext")}},
+            {{"mtxt", QObject::tr("mtxt", "draw mtext")}},
+            RS2::ActionDrawMText
+        },
+        //draw text
+        {
+            {{"text", QObject::tr("text", "draw text")}},
+            {{"txt", QObject::tr("txt", "draw text")}},
+            RS2::ActionDrawText
+        },
+
+        /* SNAP COMMANDS */
         //snap exclusive
         {
             {{"snapexcl", QObject::tr("snapexcl", "snap - excl")}},
@@ -707,51 +686,84 @@ RS_Commands::RS_Commands() {
             {{"rz", QObject::tr("rz", "set relative zero position")}},
             RS2::ActionSetRelativeZero
         },
-        //Select all entities
+        //snap restrictions
         {
-            {{"selectall", QObject::tr("selectall", "Select all entities")}},
-            {{"sa", QObject::tr("sa", "Select all entities")}},
-            RS2::ActionSelectAll
+            {{"restrictnothing", QObject::tr("restrictnothing", "restrict - nothing")}},
+            {{"rn", QObject::tr("rn", "restrict - nothing")}},
+            RS2::ActionRestrictNothing
         },
-        //DeSelect all entities
+        //snap orthogonal
         {
-            {{"deselectall", QObject::tr("deselectall", "deselect all entities")}},
-            {{"tn", QObject::tr("tn", "deselect all entities")}},
-            RS2::ActionDeselectAll
+            {{"restrictorthogonal", QObject::tr("restrictorthogonal", "restrict - orthogonal")}},
+            {{"rr", QObject::tr("rr", "restrict - orthogonal")}},
+            RS2::ActionRestrictOrthogonal
         },
-        //Modify Attributes
+        //snap horizontal
         {
-            {{"modifyattr", QObject::tr("modifyattr", "modify attribute")}},            
-            {{"attr", QObject::tr("attr", "modify attribute")},
-            {"ma", QObject::tr("ma", "modify attribute")}},
-            RS2::ActionModifyAttributes
+            {{"restricthorizontal", QObject::tr("restricthorizontal", "restrict - horizontal")}},
+            {{"rh", QObject::tr("rh", "restrict - horizontal")}},
+            RS2::ActionRestrictHorizontal
         },
-        //Modify Properties
+        //snap vertical
         {
-            {{"properties", QObject::tr("properties", "modify properties")}},
-            {{"prop", QObject::tr("prop", "modify properties")},
-             {"mp", QObject::tr("mp", "modify properties")}},
-            RS2::ActionModifyEntity
+            {{"restrictvertical", QObject::tr("restrictvertical", "restrict - vertical")}},
+            {{"rv", QObject::tr("rv", "restrict - vertical")}},
+            RS2::ActionRestrictVertical
         },
-        //Distance Point to Point
+
+        /* EDIT COMMANDS */
+        //kill actions
         {
-            {{"distance", QObject::tr("distance", "distance point to point")}},
-            {{"dist", QObject::tr("dist", "distance point to point")},
-            {"dpp", QObject::tr("dpp", "distance point to point")}},
-            RS2::ActionInfoDist
-		},
-        //Measure angle
-        {
-            {{"angle", QObject::tr("angle", "measure angle")}},
-            {{"ang", QObject::tr("ang", "measure angle")}},
-            RS2::ActionInfoAngle
+            {{"kill", QObject::tr("kill", "kill all actions")}},
+            {{"k", QObject::tr("k", "kill all actions")}},
+            RS2::ActionEditKillAllActions
         },
-        //Measure area
+        //undo cycle
         {
-            {{"area", QObject::tr("area", "measure area")}},
-            {{"ar", QObject::tr("ar", "measure area")}},
-            RS2::ActionInfoArea
-        }
+            {{"undo", QObject::tr("undo", "undo cycle")}},
+            {{"u", QObject::tr("u", "undo cycle")}},
+            RS2::ActionEditUndo
+        },
+        //redo cycle
+        {
+            {{"redo", QObject::tr("redo", "redo cycle")}},
+            {{"r", QObject::tr("r", "redo cycle")}},
+            RS2::ActionEditRedo
+        },
+
+        /* VIEW COMMANDS */
+        //zoom redraw
+        {
+            {{"regen", QObject::tr("regen", "zoom - redraw")},
+             {"redraw", QObject::tr("redraw", "zoom - redraw")}},
+            {{"rg", QObject::tr("rg", "zoom - redraw")},
+            {"zr", QObject::tr("zr", "zoom - redraw")}},
+            RS2::ActionZoomRedraw
+        },
+        //zoom auto
+        {
+            {{"zoomauto", QObject::tr("zoomauto", "zoom - auto")}},
+            {{"za", QObject::tr("za", "zoom - auto")}},
+            RS2::ActionZoomAuto
+        },
+        //zoom previous
+        {
+            {{"zoomprevious", QObject::tr("zoomprevious", "zoom - previous")}},
+            {{"zv", QObject::tr("zv", "zoom - previous")}},
+            RS2::ActionZoomPrevious
+        },
+        //zoom window
+        {
+            {{"zoomwindow", QObject::tr("zoomwindow", "zoom - window")}},
+            {{"zw", QObject::tr("zw", "zoom - window")}},
+            RS2::ActionZoomWindow
+        },
+        //zoom pan
+        {
+            {{"zoompan", QObject::tr("zoompan", "zoom - pan")}},
+            {{"zp", QObject::tr("zp", "zoom - pan")}},
+            RS2::ActionZoomPan
+        },
     };
 
     for(auto const& c0: commandList){

--- a/librecad/src/cmd/rs_commands.cpp
+++ b/librecad/src/cmd/rs_commands.cpp
@@ -78,37 +78,216 @@ RS_Commands* RS_Commands::instance() {
  */
 RS_Commands::RS_Commands() {
     std::initializer_list<LC_CommandItem> commandList={
+
+/* 
+        // draw entity command template
+        {
+// list all <full command, translation> pairs (category+targets, i.e "line2p")
+            {{"fullcmd", QObject::tr("fullcmd", "translationText")}},
+// list all <short command, translation> pairs (shortcategory[two characters or less]+targets, i.e "li2p", "l")
+            {{"shortcmd0", QObject::tr("shortcmd0", "translationText")},
+             {"shortcmdn", QObject::tr("shortcmdn", "translationText")}},
+//action type
+            RS2::ActionCommand
+        },
+*/
+
         //draw point
         {
-            //list all <full command, translation> pairs
             {{"point", QObject::tr("point", "draw point")}},
-
-            //list all <short command, translation> pairs
             {{"po", QObject::tr("po", "draw point")}},
-
-            //action type
             RS2::ActionDrawPoint
         },
-        //draw line
+
+        /* LINE COMMANDS */
+        // draw line
         {
             {{"line", QObject::tr("line", "draw line")}},
-            {{"li", QObject::tr("li", "draw line")},
+            {{"li2p", QObject::tr("li2p", "draw line")},
+             {"li", QObject::tr("li", "draw line")},
              {"l", QObject::tr("l", "draw line")}},
             RS2::ActionDrawLine
         },
-        //draw polyline
+        // draw line at angle - GSS
         {
-            {{"polyline", QObject::tr("polyline", "draw polyline")}},
-            {{"pl", QObject::tr("pl", "draw polyline")}},
-            RS2::ActionDrawPolyline
+            {{"lineangled", QObject::tr("lineangled", "angled line")}},
+            {{"la", QObject::tr("la", "angled line")}},
+            RS2::ActionDrawLineAngle
         },
-        //draw freehand line
+        // draw horizontal line
         {
-            {{"free", QObject::tr("free", "draw freehand line")}},
-            {{"fhl", QObject::tr("fhl", "draw freehand line")}},
-            RS2::ActionDrawLineFree
+            {{"horizontal", QObject::tr("horizontal", "horizontal line")}},
+            {{"hor", QObject::tr("hor", "horizontal line")}},
+            RS2::ActionDrawLineHorizontal
         },
-        //draw spline
+        // draw vertical line
+        {
+            {{"vertical", QObject::tr("vertical", "vertical line")}},
+            {{"ver", QObject::tr("ver", "vertical line")}},
+            RS2::ActionDrawLineVertical
+        },
+        // draw rectangle
+        {
+            {{"rectangle", QObject::tr("rectangle", "draw rectangle")}},
+            {{"rectang", QObject::tr("rectang", "draw rectangle")},
+             {"rect", QObject::tr("rect", "draw rectangle")},
+             {"rec", QObject::tr("rec", "draw rectangle")}},
+            RS2::ActionDrawLineRectangle
+        },
+        // draw parallel line
+        {
+            {{"offset", QObject::tr("offset", "create offset")},
+            {"parallel", QObject::tr("parallel", "create offset")}},
+            {{"o", QObject::tr("o", "create offset")},
+             {"pa", QObject::tr("pa", "create offset")}},
+            RS2::ActionDrawLineParallel
+        },
+        // draw parallel line through point
+        {
+            {{"ptp", QObject::tr("ptp", "parallel through point")}},
+            {{"pp", QObject::tr("pp", "parallel through point")}},
+            RS2::ActionDrawLineParallelThrough
+        },
+        // draw angle bisector
+        {
+            {{"bisect", QObject::tr("bisect", "angle bisector")}},
+            {{"bi", QObject::tr("bi", "angle bisector")}},
+            RS2::ActionDrawLineBisector
+        },
+        // draw line tangent to circle from point
+        {
+            {{"tangentpc", QObject::tr("tangentpc", "tangent point and circle")}},
+            {{"tanpc", QObject::tr("tanpc", "tangent point and circle")}},
+            RS2::ActionDrawLineTangent1
+        },
+        // draw line tangent to two existing circles - GSS
+        {
+            {{"tangentcc", QObject::tr("tangentcc", "tangent two circles")}},
+            {{"tancc", QObject::tr("tancc", "tangent two circles")}},
+            RS2::ActionDrawLineTangent2
+        },
+        // draw line tangent to an existing circle perpendicular to an existing line - GSS
+        {
+            {{"tangentoc", QObject::tr("tangentoc", "tangent line and circle")}},
+            {{"tanoc", QObject::tr("tanoc", "tangent line and circle")}},
+            RS2::ActionDrawLineOrthTan
+        },
+        // draw perpendicular line
+        {
+            {{"perp", QObject::tr("perp", "perpendicular line")}},
+            {{"ortho", QObject::tr("ortho", "perpendicular line")}},
+            RS2::ActionDrawLineOrthogonal
+        },
+        // draw line with relative angle - GSS
+        {
+            {{"linerel", QObject::tr("linerel", "relative line")}},
+            {{"lr", QObject::tr("lr", "relative line")}},
+            RS2::ActionDrawLineRelAngle
+        },
+        // draw polygon by centre & point - GSS
+        {
+            {{"polygoncencor", QObject::tr("polygoncencor", "polygon centre point")}},
+            {{"polycp", QObject::tr("polycp", "polygon centre point")},
+             {"pcp", QObject::tr("pcp", "polygon centre point")}},
+            RS2::ActionDrawLinePolygonCenCor
+        },
+        // draw polygon by centre & vertex - GSS
+        {
+            {{"polygoncentan", QObject::tr("polygoncentan", "polygon centre vertex")}},
+            {{"polyct", QObject::tr("polyct", "polygon centre vertex")}},
+            RS2::ActionDrawLinePolygonCenTan
+        },
+        // draw polygon by 2 vertices
+        {
+            {{"polygon2v", QObject::tr("polygon2v", "polygon by 2 vertices")}},
+            {{"poly2", QObject::tr("poly2", "polygon by 2 vertices")}},
+            RS2::ActionDrawLinePolygonCorCor
+        },
+
+        /* CIRCLE COMMANDS */
+        // draw circle
+        {
+            {{"circle", QObject::tr("circle", "draw circle")}},
+            {{"ci", QObject::tr("ci", "draw circle")}},
+            RS2::ActionDrawCircle
+        },        
+        // draw circle 2 point
+        {
+            {{"circle2", QObject::tr("circle2", "circle 2 points")}},
+            {{"c2p", QObject::tr("c2p", "circle 2 points")},
+             {"c2", QObject::tr("c2", "circle 2 points")}},
+            RS2::ActionDrawCircle2P
+        },
+        // draw circle 2 points and radius - GSS
+        {
+            {{"circle2pr", QObject::tr("circle2pr", "circle 2 points radius")}},
+            {{"c2pr", QObject::tr("c2pr", "circle 2 points radius")},
+             {"c2r", QObject::tr("c2r", "circle 2 points radius")}},
+            RS2::ActionDrawCircle2PR
+        },
+        // draw 3 point circle
+        {
+            {{"circle3", QObject::tr("circle3", "circle 3 points")}},
+            {{"c3p", QObject::tr("c3", "circle 3 points")},
+             {"c3", QObject::tr("c3", "circle 3 points")}},
+            RS2::ActionDrawCircle3P
+        },
+        // draw circle with centre point and radius - GSS
+        {
+            {{"circlepr", QObject::tr("circlecr", "circle point radius")}},
+            {{"ccr", QObject::tr("ccr", "circle point radius")},
+             {"cc", QObject::tr("cc", "circle point radius")}},
+            RS2::ActionDrawCircleCR
+        },
+
+        // draw circle Tangential to 2 Circles, 1 Point - GSS
+        {     
+            {{"circle2tan1p", QObject::tr("circle2tan1p", "circle 2 tangent point")}},
+            {{"c2tp", QObject::tr("c2tp", "circle 2 tangent point")}},
+            RS2::ActionDrawCircleTan2_1P
+        },
+        // draw circle Tangential, 2 Points - GSS
+        {
+            {{"circle1tan2p", QObject::tr("circle1tan2p", "circle tangent 2 points")}},
+            {{"ct2p", QObject::tr("ctan2p", "circle tangent 2 points")}},
+            RS2::ActionDrawCircleTan1_2P
+        },
+        //draw circle Tangential to 2 Circles, radius - GSS
+        {     
+            {{"circle2tanr", QObject::tr("circle2tan1p", "circle 2 tangent radius")}},
+            {{"c2tr", QObject::tr("c2tp", "circle 2 tangent radius")}},
+            RS2::ActionDrawCircleTan2
+        },
+
+        // draw circle tangent to 3 objects
+        {
+            {{"circletan3", QObject::tr("tan3", "circle tangent to 3")}},
+            {{"ct3", QObject::tr("ct3", "circle tangent to 3")},
+             {"tan3", QObject::tr("tan3", "circle tangent to 3")}},
+            RS2::ActionDrawCircleTan3
+        },
+
+        /* CURVE (ARC) COMMANDS */
+        // draw arc by centre point and radius - GSS
+        {
+            {{"arcpr", QObject::tr("arcpr", "arc point radius")}},
+			{{"apr", QObject::tr("apr", "arc point radius")}},
+            RS2::ActionDrawArc
+        },
+        // draw arc (3 points)
+        {
+            {{"arc", QObject::tr("arc", "draw arc")}},
+			{//{"ar", QObject::tr("ar", "draw arc")},
+            {"a", QObject::tr("a", "draw arc")}},
+            RS2::ActionDrawArc3P
+        },
+        // draw arc tangential - GSS
+        {
+            {{"arctan", QObject::tr("arctan", "arc tangent")}},
+			{{"at", QObject::tr("at", "arc tangent")}},
+            RS2::ActionDrawArcTangential
+        },
+        // draw spline
         {
             {{"spline", QObject::tr("spline", "draw spline")}},
             {{"spl", QObject::tr("spl", "draw spline")}},
@@ -120,108 +299,114 @@ RS_Commands::RS_Commands() {
             {{"stp", QObject::tr("stp", "spline through points")}},
             RS2::ActionDrawSplinePoints
         },
-        //draw parallel line
+        // draw ellipse arc by axis - GSS
         {
-            {{"offset", QObject::tr("offset", "create offset")},
-            {"parallel", QObject::tr("parallel", "create offset")}},
-            {{"o", QObject::tr("o", "create offset")},
-            {"pa", QObject::tr("pa", "create offset")}},
-            RS2::ActionDrawLineParallel
+            {{"arcell", QObject::tr("arcell", "arc ellipse")}},
+			{{"ae", QObject::tr("ae", "arc ellipse")}},
+            RS2::ActionDrawEllipseArcAxis
         },
-        //draw parallel line through point
+        //draw freehand line
         {
-            {{"ptp", QObject::tr("ptp", "parallel through point")}},
-            {{"pp", QObject::tr("pp", "parallel through point")}},
-            RS2::ActionDrawLineParallelThrough
+            {{"free", QObject::tr("free", "draw freehand line")}},
+            {{"fhl", QObject::tr("fhl", "draw freehand line")}},
+            RS2::ActionDrawLineFree
         },
-        //draw angle bisector
+
+        /* ELLIPSE COMMANDS */
+        // draw ellipse by axis - GSS
         {
-            {{"bisect", QObject::tr("bisect", "angle bisector")}},
-            {{"bi", QObject::tr("bi", "angle bisector")}},
-            RS2::ActionDrawLineBisector
+            {{"ellipseaxis", QObject::tr("ellipseaxis", "ellipse axis")}},
+            {{"elax", QObject::tr("elax", "ellipse axis")},
+            {"ea", QObject::tr("ea", "ellipse axis")}},
+            RS2::ActionDrawEllipseAxis
         },
-        //draw line tangent to circle from point
+        // draw ellipse by foci point - GSS
         {
-            {{"tangentpc", QObject::tr("tangentpc", "tangent point and circle")}},
-            {{"tanpc", QObject::tr("tanpc", "tangent point and circle")}},
-            RS2::ActionDrawLineTangent1
+            {{"ellipsefoci", QObject::tr("ellipsefoci", "ellipse foci")}},
+            {{"elf", QObject::tr("elf", "ellipse foci")},
+            {"ef", QObject::tr("ef", "ellipse foci")}},
+            RS2::ActionDrawEllipseFociPoint
         },
-        //draw perpendicular line
+        // draw ellipse by 4 points - GSS
         {
-            {{"perp", QObject::tr("perp", "perpendicular line")}},
-            {{"ortho", QObject::tr("ortho", "perpendicular line")}},
-            RS2::ActionDrawLineOrthogonal
+            {{"ellipse4p", QObject::tr("ellipse4p", "ellipse 4 point")}},
+            {{"el4p", QObject::tr("el4p", "ellipse 4 point")},
+            {"e4", QObject::tr("e4", "ellipse 4 point")}},
+            RS2::ActionDrawEllipse4Points
         },
-        //draw vertical line
+        // draw ellipse by center and 3 points - GSS
         {
-            {{"vertical", QObject::tr("vertical", "vertical line")}},
-            {{"ver", QObject::tr("ver", "vertical line")}},
-            RS2::ActionDrawLineVertical
+            {{"ellipsec3p", QObject::tr("ellipsec3p", "ellipse center 3 point")}},
+            {{"elc3p", QObject::tr("elc3p", "ellipse center 3 point")},
+             {"ec3p", QObject::tr("ec3p", "ellipse center 3 point")},
+             {"c3po", QObject::tr("c3po", "ellipse center 3 point")}},  // For the Star War nerds
+            RS2::ActionDrawEllipseCenter3Points
         },
-        //draw horizontal line
-        {
-            {{"horizontal", QObject::tr("horizontal", "horizontal line")}},
-            {{"hor", QObject::tr("hor", "horizontal line")}},
-            RS2::ActionDrawLineHorizontal
-        },
-        //draw rectangle
-        {
-            {{"rectangle", QObject::tr("rectangle", "draw rectangle")}},
-            {{"rectang", QObject::tr("rectang", "draw rectangle")},
-             {"rect", QObject::tr("rect", "draw rectangle")},
-            {"rec", QObject::tr("rec", "draw rectangle")}},
-            RS2::ActionDrawLineRectangle
-        },
-        //draw polygon by 2 vertices
-        {
-            {{"polygon2v", QObject::tr("polygon2v", "polygon by 2 vertices")}},
-            {{"poly2", QObject::tr("poly2", "polygon by 2 vertices")}},
-            RS2::ActionDrawLinePolygonCorCor
-        },
-        //draw arc
-        {
-            {{"arc", QObject::tr("arc", "draw arc")}},
-			{//{"ar", QObject::tr("ar", "draw arc")},
-            {"a", QObject::tr("a", "draw arc")}},
-            RS2::ActionDrawArc3P
-        },
-        //draw circle
-        {
-            {{"circle", QObject::tr("circle", "draw circle")}},
-            {{"ci", QObject::tr("ci", "draw circle")}},
-            RS2::ActionDrawCircle
-        },        
-        //draw 2 point circle
-        {
-            {{"circle2", QObject::tr("circle2", "circle 2 points")}},
-            {{"c2", QObject::tr("c2", "circle 2 points")}},
-            RS2::ActionDrawCircle2P
-        },
-        //draw 3 point circle
-        {
-            {{"circle3", QObject::tr("circle3", "circle 3 points")}},
-            {{"c3", QObject::tr("c3", "circle 3 points")}},
-            RS2::ActionDrawCircle3P
-        },
-	//draw circle with point and radius
-	{
-		{{"circlecr", QObject::tr("circlecr", "circle with center and radius")}},
-		{{"cc", QObject::tr("cc", "circle with center and radius")}},
-		RS2::ActionDrawCircleCR
-	},
-        //draw circle tangent to 3 objects
-        {
-            {{"tan3", QObject::tr("tan3", "circle tangent to 3")}},
-            {{"ct3", QObject::tr("ct3", "circle tangent to 3")}},
-            RS2::ActionDrawCircleTan3
-        },
-        //draw inscribed ellipse
+        // draw inscribed ellipse
         {
             {{"ellipseinscribed", QObject::tr("ellipseinscribed", "inscribed ellipse")}},
             {{"ei", QObject::tr("ei", "inscribed ellipse")},
             {"ie", QObject::tr("ie", "inscribed ellipse")}},
             RS2::ActionDrawEllipseInscribe
         },
+
+        /* POLYLINE COMMANDS */
+        // draw polyline
+        {
+            {{"polyline", QObject::tr("polyline", "draw polyline")}},
+            {{"pl", QObject::tr("pl", "draw polyline")}},
+            RS2::ActionDrawPolyline
+        },
+        // polyline add node
+        {
+            {{"pladdnode", QObject::tr("pladdnode", "pl add node")}},
+            {{"pladd", QObject::tr("pladd", "pl add node")}},
+            RS2::ActionPolylineAdd
+        },
+        // polyline append node
+        {
+            {{"plappnode", QObject::tr("plappnode", "pl append node")}},
+            {{"plapp", QObject::tr("plapp", "pl append node")}},
+            RS2::ActionPolylineAppend
+        },
+        // polyline delete node
+        {
+            {{"pldelnode", QObject::tr("pldelnode", "pl delete node")}},
+            {{"pldeln", QObject::tr("pldeln", "pl delete node")}},
+            RS2::ActionPolylineDel
+        },
+        // polyline delete between two nodes
+        {
+            {{"pldelbtwn", QObject::tr("pldelbtwn", "pl del between nodes")}},
+            {{"pldelseg", QObject::tr("pldelseg", "pl del between nodes")}},
+            RS2::ActionPolylineDelBetween
+        },
+        // polyline trim segments
+        {
+            {{"pltrimseg", QObject::tr("pltrimseg", "pl trim segments")}},
+            {{"pltr", QObject::tr("pltr", "pl trim segments")}},
+            RS2::ActionPolylineTrim
+        },
+        // equidistant polyline
+        {
+            {{"plparallel", QObject::tr("plparallel", "pl equidistant")}},
+            {{"plpa", QObject::tr("plpa", "pl equidistant")},
+             {"plo", QObject::tr("plo", "pl equidistant")}},
+            RS2::ActionPolylineEquidistant
+         },
+        // polyline from existing segments
+        {
+            {{"pljoin", QObject::tr("fullcmd", "pl join")}},
+            {{"join", QObject::tr("join", "pl join")}},
+            RS2::ActionPolylineSegment
+         },
+
+/*  -- START DEBUG
+*/ //-- END DEBUG
+
+/* SELECT COMMANDS */
+
+
         //draw hatch
         {
             {{"hatch", QObject::tr("hatch", "draw hatch")}},
@@ -315,25 +500,25 @@ RS_Commands::RS_Commands() {
              {"dr", QObject::tr("dr", "dimension - linear")}},
             RS2::ActionDimLinear
         },
-	//dimension angular
-	{
-		{{"dimangular", QObject::tr("dimangular", "dimension - angular")}},
-		{{"dan", QObject::tr("dan", "dimension - angular")}},
-		RS2::ActionDimAngular
-	},
-	//dimension radius
-	{
-		{{"dimradial", QObject::tr("dimradial", "dimension - radial")}},
-		{{"dimradius", QObject::tr("dimradius", "dimension - radius")}},
-		RS2::ActionDimRadial
-	},
-	//dimension diameter
-	{
-		{{"dimdiametric", QObject::tr("dimdiametric", "dimension - diametric")}},
-		{{"dimdiameter", QObject::tr("dimdiameter", "dimension - diametric")},
-		 {"dd", QObject::tr("dd", "dimension - diametric")}},
-		RS2::ActionDimDiametric
-	},
+        //dimension angular
+        {
+            {{"dimangular", QObject::tr("dimangular", "dimension - angular")}},
+            {{"dan", QObject::tr("dan", "dimension - angular")}},
+            RS2::ActionDimAngular
+        },
+        //dimension radius
+        {
+            {{"dimradial", QObject::tr("dimradial", "dimension - radial")}},
+            {{"dimradius", QObject::tr("dimradius", "dimension - radius")}},
+            RS2::ActionDimRadial
+        },
+        //dimension diameter
+        {
+            {{"dimdiametric", QObject::tr("dimdiametric", "dimension - diametric")}},
+            {{"dimdiameter", QObject::tr("dimdiameter", "dimension - diametric")},
+            {"dd", QObject::tr("dd", "dimension - diametric")}},
+            RS2::ActionDimDiametric
+        },
         //dimension leader
         {
             {{"dimleader", QObject::tr("dimleader", "dimension - leader")}},
@@ -458,6 +643,13 @@ RS_Commands::RS_Commands() {
             {{"explode", QObject::tr("explode", "explode block/polyline into entities")}},
             {{"xp", QObject::tr("xp", "explode block/polyline into entities")}},
             RS2::ActionBlocksExplode
+        },
+        //snap exclusive
+        {
+            {{"snapexcl", QObject::tr("snapexcl", "snap - excl")}},
+            {{"sx", QObject::tr("sx", "snap - excl")},
+            {"ex", QObject::tr("ex", "snap - excl")}},
+            RS2::ActionSnapExcl
         },
         //snap free
         {

--- a/librecad/src/cmd/rs_commands.cpp
+++ b/librecad/src/cmd/rs_commands.cpp
@@ -221,13 +221,13 @@ RS_Commands::RS_Commands() {
         // draw 3 point circle
         {
             {{"circle3", QObject::tr("circle3", "circle 3 points")}},
-            {{"c3p", QObject::tr("c3", "circle 3 points")},
+            {{"c3p", QObject::tr("c3p", "circle 3 points")},
              {"c3", QObject::tr("c3", "circle 3 points")}},
             RS2::ActionDrawCircle3P
         },
         // draw circle with centre point and radius - GSS
         {
-            {{"circlepr", QObject::tr("circlecr", "circle point radius")}},
+            {{"circlecr", QObject::tr("circlecr", "circle point radius")}},
             {{"ccr", QObject::tr("ccr", "circle point radius")},
              {"cc", QObject::tr("cc", "circle point radius")}},
             RS2::ActionDrawCircleCR
@@ -242,19 +242,19 @@ RS_Commands::RS_Commands() {
         // draw circle Tangential, 2 Points - GSS
         {
             {{"circle1tan2p", QObject::tr("circle1tan2p", "circle tangent 2 points")}},
-            {{"ct2p", QObject::tr("ctan2p", "circle tangent 2 points")}},
+            {{"ct2p", QObject::tr("ct2p", "circle tangent 2 points")}},
             RS2::ActionDrawCircleTan1_2P
         },
         //draw circle Tangential to 2 Circles, radius - GSS
         {     
-            {{"circle2tanr", QObject::tr("circle2tan1p", "circle 2 tangent radius")}},
-            {{"c2tr", QObject::tr("c2tp", "circle 2 tangent radius")}},
+            {{"circle2tanr", QObject::tr("circle2tanr", "circle 2 tangent radius")}},
+            {{"c2tr", QObject::tr("c2tr", "circle 2 tangent radius")}},
             RS2::ActionDrawCircleTan2
         },
 
         // draw circle tangent to 3 objects
         {
-            {{"circletan3", QObject::tr("tan3", "circle tangent to 3")}},
+            {{"circletan3", QObject::tr("circletan3", "circle tangent to 3")}},
             {{"ct3", QObject::tr("ct3", "circle tangent to 3")},
              {"tan3", QObject::tr("tan3", "circle tangent to 3")}},
             RS2::ActionDrawCircleTan3
@@ -389,7 +389,7 @@ RS_Commands::RS_Commands() {
          },
         // polyline from existing segments
         {
-            {{"pljoin", QObject::tr("fullcmd", "pl join")}},
+            {{"pljoin", QObject::tr("pljoin", "pl join")}},
             {{"join", QObject::tr("join", "pl join")}},
             RS2::ActionPolylineSegment
          },
@@ -444,8 +444,8 @@ RS_Commands::RS_Commands() {
         // dimension radius
         {
             {{"dimradial", QObject::tr("dimradial", "dimension - radial")}},
-            {{"dimradius", QObject::tr("dimradius", "dimension - radius")},
-             {"dr", QObject::tr("dr", "dimension - linear")}},
+            {{"dimradius", QObject::tr("dimradius", "dimension - radial")},
+             {"dr", QObject::tr("dr", "dimension - radial")}},
             RS2::ActionDimRadial
         },
         // dimension diameter
@@ -540,8 +540,8 @@ RS_Commands::RS_Commands() {
         },
         // offset
         {
-            {{"modoffset", QObject::tr("lengthen", "modify - offset")}},
-            {{"moff", QObject::tr("le", "modify - offset")}},
+            {{"modoffset", QObject::tr("modoffset", "modify - offset")}},
+            {{"moff", QObject::tr("moff", "modify - offset")}},
             RS2::ActionModifyOffset
         },
         // bevel
@@ -616,8 +616,7 @@ RS_Commands::RS_Commands() {
         // Distance Entity to Point
         {
             {{"distep", QObject::tr("distep", "distance entity to point")}},
-            {{"dep", QObject::tr("dist", "distance entity to point")},
-            {"", QObject::tr("dpp", "distance entity to point")}},
+            {{"dep", QObject::tr("dep", "distance entity to point")}},
             RS2::ActionInfoDist2
 		},
         // Measure angle
@@ -659,16 +658,14 @@ RS_Commands::RS_Commands() {
             RS2::ActionDrawPoint
         },
 
-/*  -- START DEBUG
-*/ //-- END DEBUG
         /* SNAP COMMANDS */
-        // snap exclusive
+        /* snap exclusive - GSS
         {
             {{"snapexcl", QObject::tr("snapexcl", "snap - excl")}},
             {{"sx", QObject::tr("sx", "snap - excl")},
             {"ex", QObject::tr("ex", "snap - excl")}},
-            RS2::ActionSnapExcl
-        },
+            RS2::ActionSnapExcl  // Not present
+        }, */
         //snap free
         {
             {{"snapfree", QObject::tr("snapfree", "snap - free")}},

--- a/librecad/src/cmd/rs_commands.cpp
+++ b/librecad/src/cmd/rs_commands.cpp
@@ -350,44 +350,44 @@ RS_Commands::RS_Commands() {
             {{"pl", QObject::tr("pl", "draw polyline")}},
             RS2::ActionDrawPolyline
         },
-        // polyline add node
+        // polyline add node - GSS
         {
             {{"pladdnode", QObject::tr("pladdnode", "pl add node")}},
             {{"pladd", QObject::tr("pladd", "pl add node")}},
             RS2::ActionPolylineAdd
         },
-        // polyline append node
+        // polyline append node - GSS
         {
             {{"plappnode", QObject::tr("plappnode", "pl append node")}},
             {{"plapp", QObject::tr("plapp", "pl append node")}},
             RS2::ActionPolylineAppend
         },
-        // polyline delete node
+        // polyline delete node - GSS
         {
             {{"pldelnode", QObject::tr("pldelnode", "pl delete node")}},
             {{"pldeln", QObject::tr("pldeln", "pl delete node")}},
             RS2::ActionPolylineDel
         },
-        // polyline delete between two nodes
+        // polyline delete between two nodes - GSS
         {
             {{"pldelbtwn", QObject::tr("pldelbtwn", "pl del between nodes")}},
             {{"pldelseg", QObject::tr("pldelseg", "pl del between nodes")}},
             RS2::ActionPolylineDelBetween
         },
-        // polyline trim segments
+        // polyline trim segments - GSS
         {
             {{"pltrimseg", QObject::tr("pltrimseg", "pl trim segments")}},
             {{"pltr", QObject::tr("pltr", "pl trim segments")}},
             RS2::ActionPolylineTrim
         },
-        // equidistant polyline
+        // equidistant polyline - GSS
         {
             {{"plparallel", QObject::tr("plparallel", "pl equidistant")}},
             {{"plpa", QObject::tr("plpa", "pl equidistant")},
              {"plo", QObject::tr("plo", "pl equidistant")}},
             RS2::ActionPolylineEquidistant
          },
-        // polyline from existing segments
+        // polyline from existing segments - GSS
         {
             {{"pljoin", QObject::tr("pljoin", "pl join")}},
             {{"join", QObject::tr("join", "pl join")}},

--- a/librecad/src/cmd/rs_commands.cpp
+++ b/librecad/src/cmd/rs_commands.cpp
@@ -421,44 +421,41 @@ RS_Commands::RS_Commands() {
              {"si", QObject::tr("si", "invert select")}},
             RS2::ActionSelectInvert
         },
-        /* Remaining select tools are mouse-specific. */
-
-/*  -- START DEBUG
-*/ //-- END DEBUG
+        /* Remaining select tools require the mouse - no point in adding commands. */
 
         /* DIMENSION COMMANDS */
-        //dimension aligned
+        // dimension aligned
         {
             {{"dimaligned", QObject::tr("dimaligned", "dimension - aligned")}},
             {{"da", QObject::tr("da", "dimension - aligned")}},
             RS2::ActionDimAligned
         },
-        //dimension linear
+        // dimension linear
         {
             {{"dimlinear", QObject::tr("dimlinear", "dimension - linear")}},
 			{{"dl", QObject::tr("dl", "dimension - linear")}},
             RS2::ActionDimLinear
         },
-        //dimension horizontal
+        // dimension horizontal
         {
             {{"dimhorizontal", QObject::tr("dimhorizontal", "dimension - horizontal")}},
             {{"dh", QObject::tr("dh", "dimension - horizontal")}},
             RS2::ActionDimLinearHor
         },
-        //dimension vertical
+        // dimension vertical
         {
             {{"dimvertical", QObject::tr("dimvertical", "dimension - vertical")}},
             {{"dv", QObject::tr("dv", "dimension - vertical")}},
             RS2::ActionDimLinearVer
         },
-        //dimension radius
+        // dimension radius
         {
             {{"dimradial", QObject::tr("dimradial", "dimension - radial")}},
             {{"dimradius", QObject::tr("dimradius", "dimension - radius")},
              {"dr", QObject::tr("dr", "dimension - linear")},
             RS2::ActionDimRadial
         },
-        //dimension diameter
+        // dimension diameter
         {
             {{"dimdiametric", QObject::tr("dimdiametric", "dimension - diametric")}},
             {{"dimdiameter", QObject::tr("dimdiameter", "dimension - diametric")},
@@ -471,13 +468,13 @@ RS_Commands::RS_Commands() {
             {{"dan", QObject::tr("dan", "dimension - angular")}},
             RS2::ActionDimAngular
         },
-        //dimension leader
+        // dimension leader
         {
             {{"dimleader", QObject::tr("dimleader", "dimension - leader")}},
             {{"ld", QObject::tr("ld", "dimension - leader")}},
             RS2::ActionDimLeader
         },
-        //dimension regenerate
+        // dimension regenerate
         {
             {{"dimregen", QObject::tr("dimregen", "dimension - regenerate")}},
             {},
@@ -485,26 +482,89 @@ RS_Commands::RS_Commands() {
         },
 
         /* MODIFY COMMANDS */
-        //move
+        // move
         {
             {{"move", QObject::tr("move", "modify - move (copy)")}},
             {{"mv", QObject::tr("mv", "modify - move (copy)")}},
             RS2::ActionModifyMove
         },
-        //bevel
+        // rotate
+        {
+            {{"rotate", QObject::tr("rotate", "modify - rotate")}},
+            {{"ro", QObject::tr("ro", "modify - rotate")}},
+            RS2::ActionModifyRotate
+        },
+        // scale
+        {
+            {{"scale", QObject::tr("scale", "modify - scale")}},
+            {{"sz", QObject::tr("sz", "modify - scale")}},
+            RS2::ActionModifyScale
+        },
+        // mirror
+        {
+            {{"mirror", QObject::tr("mirror", "modify -  mirror")}},
+            {{"mi", QObject::tr("mi", "modify -  mirror")}},
+            RS2::ActionModifyMirror
+        },
+        // move and rotate - GSS
+        {
+            {{"moverotate", QObject::tr("moverotate", "modify - move rotate")}},
+            {{"mvro", QObject::tr("mvro", "modify - move rotate")}
+             {"mr", QObject::tr("mr", "modify - move rotate"},
+            RS2::ActionModifyMoveRotate
+        },
+        // rotate two - GSS
+        {
+            {{"rotatetwo", QObject::tr("rotatetwo", "modify - rotate2")}},
+            {{"ro2", QObject::tr("ro2", "modify - rotate2")},
+             {"r2", QObject::tr("r2", "modify - rotate2")},
+            RS2::ActionModifyRotate2
+        },
+        // revert
+        {
+            {{"revert", QObject::tr("revert", "modify -  revert direction")}},
+            {{"rev", QObject::tr("rev", "modify -  revert direction")}},
+            RS2::ActionModifyRevertDirection
+        },
+        // trim
+        {
+            {{"trim", QObject::tr("trim", "modify - trim (extend)")}},
+            {{"tm", QObject::tr("tm", "modify - trim (extend)")}},
+            RS2::ActionModifyTrim
+        },
+        // trim2
+        {
+            {{"trim2", QObject::tr("trim2", "modify - multi trim (extend)")}},
+            {{"tm2", QObject::tr("tm2", "modify - multi trim (extend)")},
+             {"t2", QObject::tr("t2", "modify - multi trim (extend)")}},
+            RS2::ActionModifyTrim2
+        },
+        // lengthen
+        {
+            {{"lengthen", QObject::tr("lengthen", "modify - lengthen")}},
+            {{"le", QObject::tr("le", "modify - lengthen")}},
+            RS2::ActionModifyTrimAmount
+        },
+        // offset
+        {
+            {{"modoffset", QObject::tr("lengthen", "modify - offset")}},
+            {{"moff", QObject::tr("le", "modify - offset")}},
+            RS2::ActionModifyOffset
+        },
+        // bevel
         {
             {{"bevel", QObject::tr("bevel", "modify - bevel")}},
             {{"bev", QObject::tr("bev", "modify - bevel")},
             {"ch", QObject::tr("ch", "modify - bevel")}},
             RS2::ActionModifyBevel
         },
-        //fillet
+        // fillet
         {
             {{"fillet", QObject::tr("fillet", "modify - fillet")}},
             {{"fi", QObject::tr("fi", "modify - fillet")}},
             RS2::ActionModifyRound
         },
-        //divide
+        // divide
         {
             {{"divide", QObject::tr("divide", "modify - divide (cut)")},
              {"cut", QObject::tr("cut", "modify - divide (cut)")}},
@@ -512,82 +572,48 @@ RS_Commands::RS_Commands() {
             {"di", QObject::tr("di", "modify - divide (cut)")}},
             RS2::ActionModifyCut
         },
-        //mirror
-        {
-            {{"mirror", QObject::tr("mirror", "modify -  mirror")}},
-            {{"mi", QObject::tr("mi", "modify -  mirror")}},
-            RS2::ActionModifyMirror
-        },
-        //revert
-        {
-            {{"revert", QObject::tr("revert", "modify -  revert direction")}},
-            {{"rev", QObject::tr("rev", "modify -  revert direction")}},
-            RS2::ActionModifyRevertDirection
-        },
-        //rotate
-        {
-            {{"rotate", QObject::tr("rotate", "modify - rotate")}},
-            {{"ro", QObject::tr("ro", "modify - rotate")}},
-            RS2::ActionModifyRotate
-        },
-        //scale
-        {
-            {{"scale", QObject::tr("scale", "modify - scale")}},
-            {{"sz", QObject::tr("sz", "modify - scale")}},
-            RS2::ActionModifyScale
-        },
-        //trim
-        {
-            {{"trim", QObject::tr("trim", "modify - trim (extend)")}},
-            {{"tm", QObject::tr("tm", "modify - trim (extend)")}},
-            RS2::ActionModifyTrim
-        },
-        //trim2
-        {
-            {{"trim2", QObject::tr("trim2", "modify - multi trim (extend)")}},
-            {{"tm2", QObject::tr("tm2", "modify - multi trim (extend)")},
-             {"t2", QObject::tr("t2", "modify - multi trim (extend)")}},
-            RS2::ActionModifyTrim2
-        },
-        //lengthen
-        {
-            {{"lengthen", QObject::tr("lengthen", "modify - lengthen")}},
-            {{"le", QObject::tr("le", "modify - lengthen")}},
-            RS2::ActionModifyTrimAmount
-        },
-        //stretch
+        // stretch
         {
             {{"stretch", QObject::tr("stretch", "modify - stretch")}},
             {{"ss", QObject::tr("ss", "modify - stretch")}},
             RS2::ActionModifyStretch
         },
-        //delete
-        {
-            {{"delete", QObject::tr("delete", "modify - delete (erase)")}},
-            {{"er", QObject::tr("er", "modify - delete (erase)")},
-             {"del", QObject::tr("del", "modify - delete (erase)")}},
-            RS2::ActionModifyDelete
-		},
-        //explode
-        {
-            {{"explode", QObject::tr("explode", "explode block/polyline into entities")}},
-            {{"xp", QObject::tr("xp", "explode block/polyline into entities")}},
-            RS2::ActionBlocksExplode
-        },
-        //Modify Attributes
-        {
-            {{"modifyattr", QObject::tr("modifyattr", "modify attribute")}},            
-            {{"attr", QObject::tr("attr", "modify attribute")},
-            {"ma", QObject::tr("ma", "modify attribute")}},
-            RS2::ActionModifyAttributes
-        },
-        //Modify Properties
+        // Modify Properties
         {
             {{"properties", QObject::tr("properties", "modify properties")}},
             {{"prop", QObject::tr("prop", "modify properties")},
              {"mp", QObject::tr("mp", "modify properties")}},
             RS2::ActionModifyEntity
         },
+        // Modify Attributes
+        {
+            {{"modifyattr", QObject::tr("modifyattr", "modify attribute")}},            
+            {{"attr", QObject::tr("attr", "modify attribute")},
+            {"ma", QObject::tr("ma", "modify attribute")}},
+            RS2::ActionModifyAttributes
+        },
+        // explode text - GSS
+        {
+            {{"explodetext", QObject::tr("explodetext", "explode text strings")}},
+            {{"xpt", QObject::tr("xpt", "explode text strings")}},
+            RS2::ActionModifyExplodeText
+        },
+        // explode
+        {
+            {{"explode", QObject::tr("explode", "explode block/polyline into entities")}},
+            {{"xp", QObject::tr("xp", "explode block/polyline into entities")}},
+            RS2::ActionBlocksExplode
+        },
+        // delete
+        {
+            {{"delete", QObject::tr("delete", "modify - delete (erase)")}},
+            {{"er", QObject::tr("er", "modify - delete (erase)")},
+             {"del", QObject::tr("del", "modify - delete (erase)")}},
+            RS2::ActionModifyDelete
+		},
+
+/*  -- START DEBUG
+*/ //-- END DEBUG
 
         /* INFO COMMANDS */
         //Distance Point to Point

--- a/librecad/src/cmd/rs_commands.cpp
+++ b/librecad/src/cmd/rs_commands.cpp
@@ -92,13 +92,6 @@ RS_Commands::RS_Commands() {
         },
 */
 
-        //draw point
-        {
-            {{"point", QObject::tr("point", "draw point")}},
-            {{"po", QObject::tr("po", "draw point")}},
-            RS2::ActionDrawPoint
-        },
-
         /* LINE COMMANDS */
         // draw line
         {
@@ -612,24 +605,28 @@ RS_Commands::RS_Commands() {
             RS2::ActionModifyDelete
 		},
 
-/*  -- START DEBUG
-*/ //-- END DEBUG
-
         /* INFO COMMANDS */
-        //Distance Point to Point
+        // Distance Point to Point
         {
             {{"distance", QObject::tr("distance", "distance point to point")}},
             {{"dist", QObject::tr("dist", "distance point to point")},
             {"dpp", QObject::tr("dpp", "distance point to point")}},
             RS2::ActionInfoDist
 		},
-        //Measure angle
+        // Distance Entity to Point
+        {
+            {{"distep", QObject::tr("distep", "distance entity to point")}},
+            {{"dep", QObject::tr("dist", "distance entity to point")},
+            {"", QObject::tr("dpp", "distance entity to point")}},
+            RS2::ActionInfoDist2
+		},
+        // Measure angle
         {
             {{"angle", QObject::tr("angle", "measure angle")}},
             {{"ang", QObject::tr("ang", "measure angle")}},
             RS2::ActionInfoAngle
         },
-        //Measure area
+        // Measure area
         {
             {{"area", QObject::tr("area", "measure area")}},
             {{"ar", QObject::tr("ar", "measure area")}},
@@ -637,27 +634,35 @@ RS_Commands::RS_Commands() {
         },
 
         /* OTHER COMMANDS */
-        //draw hatch
-        {
-            {{"hatch", QObject::tr("hatch", "draw hatch")}},
-            {{"ha", QObject::tr("ha", "draw hatch")}},
-            RS2::ActionDrawHatchNoSelect
-        },
-        //draw mtext
+        // draw mtext
         {
             {{"mtext", QObject::tr("mtext", "draw mtext")}},
             {{"mtxt", QObject::tr("mtxt", "draw mtext")}},
             RS2::ActionDrawMText
         },
-        //draw text
+        // draw text
         {
             {{"text", QObject::tr("text", "draw text")}},
             {{"txt", QObject::tr("txt", "draw text")}},
             RS2::ActionDrawText
         },
+        // draw hatch
+        {
+            {{"hatch", QObject::tr("hatch", "draw hatch")}},
+            {{"ha", QObject::tr("ha", "draw hatch")}},
+            RS2::ActionDrawHatchNoSelect
+        },
+        //draw point
+        {
+            {{"point", QObject::tr("point", "draw point")}},
+            {{"po", QObject::tr("po", "draw point")}},
+            RS2::ActionDrawPoint
+        },
 
+/*  -- START DEBUG
+*/ //-- END DEBUG
         /* SNAP COMMANDS */
-        //snap exclusive
+        // snap exclusive
         {
             {{"snapexcl", QObject::tr("snapexcl", "snap - excl")}},
             {{"sx", QObject::tr("sx", "snap - excl")},
@@ -745,6 +750,7 @@ RS_Commands::RS_Commands() {
             RS2::ActionRestrictVertical
         },
 
+        /* MENU COMMANDS */
         /* EDIT COMMANDS */
         //kill actions
         {
@@ -763,6 +769,14 @@ RS_Commands::RS_Commands() {
             {{"redo", QObject::tr("redo", "redo cycle")}},
             {{"r", QObject::tr("r", "redo cycle")}},
             RS2::ActionEditRedo
+        },
+
+        /* OPTIONS COMMANDS */
+        // Drawing Prefs - GSS
+        {
+            {{"drawpref", QObject::tr("drawpref", "drawing preferences")}},
+            {{"dp", QObject::tr("dp", "drawing preferences")}},
+            RS2::ActionOptionsDrawing
         },
 
         /* VIEW COMMANDS */

--- a/librecad/src/lib/engine/rs.h
+++ b/librecad/src/lib/engine/rs.h
@@ -164,6 +164,7 @@ public:
 
         ActionDefault,
 
+        /*  MENU ACTIONS */
         ActionFileNew,
         ActionFileNewTemplate,
         ActionFileOpen,
@@ -177,6 +178,9 @@ public:
         ActionFileExportMakerCam,
         ActionFileQuit,
 
+        ActionOptionsGeneral,
+        ActionOptionsDrawing,
+
         ActionEditKillAllActions,
         ActionEditUndo,
         ActionEditRedo,
@@ -185,11 +189,6 @@ public:
         ActionEditCopy,
         ActionEditCopyNoSelect,
         ActionEditPaste,
-        ActionOrderNoSelect,
-        ActionOrderBottom,
-        ActionOrderLower,
-        ActionOrderRaise,
-        ActionOrderTop,
 
         ActionViewStatusBar,
         ActionViewLayerList,
@@ -215,6 +214,7 @@ public:
         ActionZoomRedraw,
         ActionZoomPrevious,
 
+        /* SELECT ACTIONS */
         ActionSelect,
         ActionSelectSingle,
         ActionSelectContour,
@@ -229,10 +229,25 @@ public:
         ActionSelectDouble,
         ActionGetSelect,
 
-        ActionDrawArc,
-        ActionDrawArc3P,
-        ActionDrawArcParallel,
-        ActionDrawArcTangential,
+        /* DRAWING TOOL ACTIONS */
+        ActionDrawLine,
+        ActionDrawLineAngle,
+        ActionDrawLineHorizontal,
+        ActionDrawLineVertical,
+        ActionDrawLineRectangle,
+        ActionDrawLineParallelThrough,
+        ActionDrawLineParallel,
+        ActionDrawLineBisector,
+        ActionDrawLineHorVert,
+        ActionDrawLineOrthogonal,
+        ActionDrawLineOrthTan,
+        ActionDrawLinePolygonCenCor,
+        ActionDrawLinePolygonCenTan,   //add by txmy
+        ActionDrawLinePolygonCorCor,
+        ActionDrawLineRelAngle,
+        ActionDrawLineTangent1,
+        ActionDrawLineTangent2,
+
         ActionDrawCircle,
         ActionDrawCircle2P,
         ActionDrawCircle2PR,
@@ -245,6 +260,14 @@ public:
         ActionDrawCircleTan2,
         ActionDrawCircleTan3,
 
+        ActionDrawArc,
+        ActionDrawArc3P,
+        ActionDrawArcParallel,
+        ActionDrawArcTangential,
+        ActionDrawSpline,
+        ActionDrawSplinePoints,   //interpolation spline
+        ActionDrawLineFree,
+
         ActionDrawEllipseArcAxis,
         ActionDrawEllipseAxis,
         ActionDrawEllipseFociPoint,
@@ -252,35 +275,7 @@ public:
         ActionDrawEllipseCenter3Points,
         ActionDrawEllipseInscribe,
 
-        ActionDrawHatch,
-        ActionDrawHatchNoSelect,
-        ActionDrawImage,
-
-        ActionDrawLine,
-        ActionDrawLineAngle,
-        ActionDrawLineBisector,
-        ActionDrawLineFree,
-        ActionDrawLineHorVert,
-        ActionDrawLineHorizontal,
-        ActionDrawLineOrthogonal,
-        ActionDrawLineOrthTan,
-        ActionDrawLineParallel,
-        ActionDrawLineParallelThrough,
-        ActionDrawLinePolygonCenCor,
-        ActionDrawLinePolygonCenTan,   //add by txmy
-        ActionDrawLinePolygonCorCor,
-        ActionDrawLineRectangle,
-        ActionDrawLineRelAngle,
-        ActionDrawLineTangent1,
-        ActionDrawLineTangent2,
-        ActionDrawLineVertical,
-        ActionDrawMText,
-        ActionDrawPoint,
-        ActionDrawSpline,
-        ActionDrawSplinePoints,   //interpolation spline
         ActionDrawPolyline,
-        ActionDrawText,
-
         ActionPolylineAdd,
         ActionPolylineAppend,
         ActionPolylineDel,
@@ -297,6 +292,7 @@ public:
         ActionDimDiametric,
         ActionDimAngular,
         ActionDimLeader,
+        ActionToolRegenerateDimensions,
 
         ActionModifyAttributes,
         ActionModifyAttributesNoSelect,
@@ -328,6 +324,28 @@ public:
         ActionModifyRound,
         ActionModifyOffset,
         ActionModifyOffsetNoSelect,
+        ActionModifyExplodeText,
+        ActionModifyExplodeTextNoSelect,
+
+        ActionInfoInside,
+        ActionInfoDist,
+        ActionInfoDist2,
+        ActionInfoAngle,
+        ActionInfoTotalLength,
+        ActionInfoTotalLengthNoSelect,
+        ActionInfoArea,
+        ActionDrawText,
+        ActionDrawMText,
+        ActionDrawHatch,
+        ActionDrawPoint,
+        ActionDrawHatchNoSelect,
+        ActionDrawImage,
+
+        ActionOrderNoSelect,
+        ActionOrderBottom,
+        ActionOrderLower,
+        ActionOrderRaise,
+        ActionOrderTop,
 
         ActionSnapExcl,
         ActionSnapFree,
@@ -348,14 +366,6 @@ public:
         ActionSetRelativeZero,
         ActionLockRelativeZero,
         ActionUnlockRelativeZero,
-
-        ActionInfoInside,
-        ActionInfoDist,
-        ActionInfoDist2,
-        ActionInfoAngle,
-        ActionInfoTotalLength,
-        ActionInfoTotalLengthNoSelect,
-        ActionInfoArea,
 
         ActionLayersDefreezeAll,
         ActionLayersFreezeAll,
@@ -384,15 +394,7 @@ public:
         ActionBlocksExplodeNoSelect,
         ActionBlocksImport,
 
-        ActionModifyExplodeText,
-        ActionModifyExplodeTextNoSelect,
-
         ActionLibraryInsert,
-
-        ActionOptionsGeneral,
-        ActionOptionsDrawing,
-
-        ActionToolRegenerateDimensions,
 
         ActionScriptOpenIDE,
         ActionScriptRun,

--- a/librecad/src/lib/engine/rs.h
+++ b/librecad/src/lib/engine/rs.h
@@ -255,6 +255,7 @@ public:
         ActionDrawHatch,
         ActionDrawHatchNoSelect,
         ActionDrawImage,
+
         ActionDrawLine,
         ActionDrawLineAngle,
         ActionDrawLineBisector,
@@ -266,7 +267,7 @@ public:
         ActionDrawLineParallel,
         ActionDrawLineParallelThrough,
         ActionDrawLinePolygonCenCor,
-        ActionDrawLinePolygonCenTan,//add by txmy
+        ActionDrawLinePolygonCenTan,   //add by txmy
         ActionDrawLinePolygonCorCor,
         ActionDrawLineRectangle,
         ActionDrawLineRelAngle,
@@ -276,7 +277,7 @@ public:
         ActionDrawMText,
         ActionDrawPoint,
         ActionDrawSpline,
-        ActionDrawSplinePoints, //interpolation spline
+        ActionDrawSplinePoints,   //interpolation spline
         ActionDrawPolyline,
         ActionDrawText,
 
@@ -328,6 +329,7 @@ public:
         ActionModifyOffset,
         ActionModifyOffsetNoSelect,
 
+        ActionSnapExcl,
         ActionSnapFree,
         ActionSnapGrid,
         ActionSnapEndpoint,
@@ -625,6 +627,7 @@ public:
      * Snapping modes
      */
     enum SnapMode {
+        SnapExcl,         /**< Exclusive snap mode */
         SnapFree,         /**< Free positioning */
         SnapGrid,         /**< Snap to grid points */
         SnapEndpoint,     /**< Snap to endpoints */

--- a/librecad/src/lib/engine/rs.h
+++ b/librecad/src/lib/engine/rs.h
@@ -347,7 +347,7 @@ public:
         ActionOrderRaise,
         ActionOrderTop,
 
-        ActionSnapExcl,
+        // ActionSnapExcl,
         ActionSnapFree,
         ActionSnapGrid,
         ActionSnapEndpoint,


### PR DESCRIPTION
Added missing commands (Ref #1225) for:
Category | Tool
-- | --
Line | Angle
Line | Tangent (C,C)
Line | Tangent Orthogonal
Line | Relative Angle
Line | Polygon (Cen,Cor)
Line | Polygon (Cen,Tan)
Circle | 2 Points, Radius
Circle | Centre, Radius
Circle | Tangential, 2 Circles, 1 Point
Circle | Tangential, 2 Points
Circle | Tangential, 2 Circles, Radius
Curve | Center, Point, Angles
Curve | Arc Tangential
Curve | Ellipse Arc (Axis)
Ellipse | Ellipse (Axis)
Ellipse | Ellipse Foci Point
Ellipse | Ellipse 4 Point
Ellipse | Ellipse Center and 3 Points
Polyline | Add node
Polyline | Append node
Polyline | Delete node
Polyline | Delete between two nodes
Polyline | Trim segments
Polyline | Create Equidistant Polylines
Polyline | Create Polyline from Existing Segments
Select | Invert Selection
Menu | Options -> DrawPref

Tested to ensure:
- no duplicates in long or short form(s) of the commands
- commands are correct within each {}
- translation strings are correct for each action
- command operation is equal to icon operation
(refer to attached file: commands.xlsx)
[commands.xlsx](https://github.com/LibreCAD/LibreCAD/files/4742985/commands.xlsx)

Notes: 
- Does not change existing commands, only adds the missing commands
- I wanted to add a command for "Snap Exclusive", but (so far) I've unable to find the function/code. Any hints?





