### PR TITLE
Fix b sizes

### DIFF
--- a/librecad/src/lib/engine/rs.h
+++ b/librecad/src/lib/engine/rs.h
@@ -885,12 +885,20 @@ public:
         A3,   /* 297 x 420 mm	11.7 x 16.5 in */
         A4,   /* 210 x 297 mm	8.3 x 11.7 in  */
 
-        /* Removed ISO "B" and "C" Series, C5E, Comm10E, DLE, (envelope sizes) */
+        /* ISO "B" Series */
+        B0,   /* 1000 x 1414 mm	39.4 x 55.7 in */
+        B1,   /* 707 x 1000 mm	27.8 x 39.4 in */
+        B2,   /* 500 x 707 mm	19.7 x 27.8 in */
+        B3,   /* 353 x 500 mm	13.9 x 19.7 in */
+        B4,   /* 250 x 353 mm	9.8 x 13.9 in */
 
-        /* Combined letter and tabloid (ledger) with respective ANSI sizes, dropped legal */
-        /* Ledger - technically, "Ledger" is 17 x 11 (according to the 
-           standards and in the qt library.  Using "ledger" will result in the
-           wrong page orientation when printing or exporting to PDF.) */
+        /* Removed "C" Series, C5E, Comm10E, DLE, (envelope sizes) */
+
+
+        /* US "Office" */
+        Letter,   /* 216 x 279 mm	8.5 x 11.0 in */
+        Legal,    /* 216 x 356 mm	8.5 x 14.0 in */
+        Ledger,   /* 279 x 432 mm	11.0 x 17.0 in (Also "Tabloid".  Although, technically, "Ledger" is 17 x 11.) */
 
         /* ANSI */
         Ansi_A,   /* 216 x 279 mm	8.5 x 11.0 in */

--- a/librecad/src/lib/engine/rs.h
+++ b/librecad/src/lib/engine/rs.h
@@ -888,9 +888,12 @@ public:
         /* Removed ISO "B" and "C" series, C5E, Comm10E, DLE, (envelope sizes) */
 
         /* US "Office" */
-        Letter,   /* 216 x 279 mm	8.5 x 11.0 in */
-        Legal,    /* 216 x 356 mm	8.5 x 14.0 in */
-        Ledger,   /* 279 x 432 mm	11.0 x 17.0 in (Also "Tabloid".  Although, technically, "Ledger" is 17 x 11.) */
+        Letter,   /* 216 x 279 mm   8.5 x 11.0 in */
+        Legal,    /* 216 x 356 mm   8.5 x 14.0 in */
+        Tabloid,  /* 279 x 432 mm   11.0 x 17.0 in */
+        /* Ledger - technically, "Ledger" is 17 x 11 (according to the 
+           standards and in the qt library.  Using "ledger" will result in the
+           wrong page orientation when printing or exporting to PDF.) */
 
         /* ANSI */
         Ansi_A,   /* 216 x 279 mm	8.5 x 11.0 in */

--- a/librecad/src/lib/engine/rs.h
+++ b/librecad/src/lib/engine/rs.h
@@ -885,20 +885,12 @@ public:
         A3,   /* 297 x 420 mm	11.7 x 16.5 in */
         A4,   /* 210 x 297 mm	8.3 x 11.7 in  */
 
-        /* ISO "B" Series */
-        B0,   /* 1000 x 1414 mm	39.4 x 55.7 in */
-        B1,   /* 707 x 1000 mm	27.8 x 39.4 in */
-        B2,   /* 500 x 707 mm	19.7 x 27.8 in */
-        B3,   /* 353 x 500 mm	13.9 x 19.7 in */
-        B4,   /* 250 x 353 mm	9.8 x 13.9 in */
+        /* Removed ISO "B" and "C" Series, C5E, Comm10E, DLE, (envelope sizes) */
 
-        /* Removed "C" Series, C5E, Comm10E, DLE, (envelope sizes) */
-
-
-        /* US "Office" */
-        Letter,   /* 216 x 279 mm	8.5 x 11.0 in */
-        Legal,    /* 216 x 356 mm	8.5 x 14.0 in */
-        Ledger,   /* 279 x 432 mm	11.0 x 17.0 in (Also "Tabloid".  Although, technically, "Ledger" is 17 x 11.) */
+        /* Combined letter and tabloid (ledger) with respective ANSI sizes, dropped legal */
+        /* Ledger - technically, "Ledger" is 17 x 11 (according to the 
+           standards and in the qt library.  Using "ledger" will result in the
+           wrong page orientation when printing or exporting to PDF.) */
 
         /* ANSI */
         Ansi_A,   /* 216 x 279 mm	8.5 x 11.0 in */

--- a/librecad/src/lib/engine/rs.h
+++ b/librecad/src/lib/engine/rs.h
@@ -896,8 +896,8 @@ public:
            wrong page orientation when printing or exporting to PDF.) */
 
         /* ANSI */
-        Ansi_A,   /* 216 x 279 mm	8.5 x 11.0 in */
-        Ansi_B,   /* 279 x 432 mm	11.0 x 17.0 in */
+        //Ansi_A,   /* 216 x 279 mm	8.5 x 11.0 in */
+        //Ansi_B,   /* 279 x 432 mm	11.0 x 17.0 in */
         Ansi_C,   /* 432 x 559 mm	17.0 x 22.0 in */
         Ansi_D,   /* 559 x 864 mm	22.0 x 34.0 in */
         Ansi_E,   /* 864 x 1118 mm	34.0 x 44.0 in */

--- a/librecad/src/lib/engine/rs.h
+++ b/librecad/src/lib/engine/rs.h
@@ -885,15 +885,7 @@ public:
         A3,   /* 297 x 420 mm	11.7 x 16.5 in */
         A4,   /* 210 x 297 mm	8.3 x 11.7 in  */
 
-        /* ISO "B" Series */
-        B0,   /* 1000 x 1414 mm	39.4 x 55.7 in */
-        B1,   /* 707 x 1000 mm	27.8 x 39.4 in */
-        B2,   /* 500 x 707 mm	19.7 x 27.8 in */
-        B3,   /* 353 x 500 mm	13.9 x 19.7 in */
-        B4,   /* 250 x 353 mm	9.8 x 13.9 in */
-
-        /* Removed "C" Series, C5E, Comm10E, DLE, (envelope sizes) */
-
+        /* Removed ISO "B" and "C" series, C5E, Comm10E, DLE, (envelope sizes) */
 
         /* US "Office" */
         Letter,   /* 216 x 279 mm	8.5 x 11.0 in */

--- a/librecad/src/lib/engine/rs.h
+++ b/librecad/src/lib/engine/rs.h
@@ -891,9 +891,11 @@ public:
         Letter,   /* 216 x 279 mm   8.5 x 11.0 in */
         Legal,    /* 216 x 356 mm   8.5 x 14.0 in */
         Tabloid,  /* 279 x 432 mm   11.0 x 17.0 in */
-        /* Ledger - technically, "Ledger" is 17 x 11 (according to the 
-           standards and in the qt library.  Using "ledger" will result in the
-           wrong page orientation when printing or exporting to PDF.) */
+        /* Tabloid = Ledger = ANSI B.  Although, technically, both ANSI B and  
+           Ledger are defined in the qt library as 431.8 mm x 279.4 mm / 17 
+           x 11", while Tabloid is 279 x 432 mm / 11.0 x 17.0 in .  Using either 
+           "Ledger" or "AnsiB" will result in the wrong page orientation when 
+           printing or exporting to PDF.) */
 
         /* ANSI */
         //Ansi_A,   /* 216 x 279 mm	8.5 x 11.0 in */

--- a/librecad/src/lib/engine/rs_units.cpp
+++ b/librecad/src/lib/engine/rs_units.cpp
@@ -910,18 +910,12 @@ QString RS_Units::paperFormatToString(RS2::PaperFormat p) {
     case RS2::A3: return QObject::tr( "A3", "Paper format");
     case RS2::A4: return QObject::tr( "A4", "Paper format");
 
-    case RS2::B0: return QObject::tr( "B0", "Paper format");
-    case RS2::B1: return QObject::tr( "B1", "Paper format");
-    case RS2::B2: return QObject::tr( "B2", "Paper format");
-    case RS2::B3: return QObject::tr( "B3", "Paper format");
-    case RS2::B4: return QObject::tr( "B4", "Paper format");
+    /* Removed ISO "B" and "C" Series, C5E, Comm10E, DLE, (envelope sizes) */
 
-    case RS2::Letter: return QObject::tr( "Letter", "Paper format");
-    case RS2::Legal:  return QObject::tr( "Legal",  "Paper format");
-    case RS2::Ledger: return QObject::tr( "Ledger", "Paper format");
+    /* Combined letter and tabloid (ledger) with respective ANSI sizes, dropped legal */
 
-    case RS2::Ansi_A: return QObject::tr( "ANSI A", "Paper format");
-    case RS2::Ansi_B: return QObject::tr( "ANSI B", "Paper format");
+    case RS2::Ansi_A: return QObject::tr( "ANSI A / Letter", "Paper format");
+    case RS2::Ansi_B: return QObject::tr( "ANSI B / Tabloid", "Paper format");
     case RS2::Ansi_C: return QObject::tr( "ANSI C", "Paper format");
     case RS2::Ansi_D: return QObject::tr( "ANSI D", "Paper format");
     case RS2::Ansi_E: return QObject::tr( "ANSI E", "Paper format");
@@ -962,23 +956,9 @@ RS2::PaperFormat RS_Units::stringToPaperFormat(const QString& p) {
     if (ls == QStringLiteral("a4") || ls == QObject::tr("a4", "Paper format").toLower())
         return RS2::A4;
 
-    if (ls == QStringLiteral("b0") || ls == QObject::tr("b0", "Paper format").toLower())
-        return RS2::B0;
-    if (ls == QStringLiteral("b1") || ls == QObject::tr("b1", "Paper format").toLower())
-        return RS2::B1;
-    if (ls == QStringLiteral("b2") || ls == QObject::tr("b2", "Paper format").toLower())
-        return RS2::B2;
-    if (ls == QStringLiteral("b3") || ls == QObject::tr("b3", "Paper format").toLower())
-        return RS2::B3;
-    if (ls == QStringLiteral("b4") || ls == QObject::tr("b4", "Paper format").toLower())
-        return RS2::B4;
+    /* Removed ISO "B" and "C" Series, C5E, Comm10E, DLE, (envelope sizes) */
 
-    if (ls == QStringLiteral("letter") || ls == QObject::tr("letter", "Paper format").toLower())
-        return RS2::Letter;
-    if (ls == QStringLiteral("legal")  || ls == QObject::tr("legal",  "Paper format").toLower())
-        return RS2::Legal;
-    if (ls == QStringLiteral("ledger") || ls == QObject::tr("ledger", "Paper format").toLower())
-        return RS2::Ledger;
+    /* Combined letter and tabloid (ledger) with respective ANSI sizes, dropped legal */
 
     if (ls == QStringLiteral("ansi a") || ls == QObject::tr("ansi a", "Paper format").toLower())
         return RS2::Ansi_A;

--- a/librecad/src/lib/engine/rs_units.cpp
+++ b/librecad/src/lib/engine/rs_units.cpp
@@ -841,7 +841,7 @@ RS_Vector RS_Units::paperFormatToSize(RS2::PaperFormat p) {
 
     /* Removed ISO "B" and "C" series, C5E, Comm10E, DLE, (envelope sizes) */
 
-    case RS2::Letter:  /* 8.5 x 11.0 in.  Sizes used for 'hard' conversion to metric */
+    case RS2::Letter:  /* 8.5 x 11.0 in.  Sizes shown are used for 'hard' conversion to metric */
         return RS_Vector(215.9, 279.4);
     case RS2::Legal:  /* 8.5 x 14.0 in */
         return RS_Vector(215.9, 355.6);

--- a/librecad/src/lib/engine/rs_units.cpp
+++ b/librecad/src/lib/engine/rs_units.cpp
@@ -839,25 +839,9 @@ RS_Vector RS_Units::paperFormatToSize(RS2::PaperFormat p) {
     case RS2::A4:
         return RS_Vector(210.0, 297.0);
 
-    case RS2::B0:
-        return RS_Vector(1000.0, 1414.0);
-    case RS2::B1:
-        return RS_Vector(707.0, 1000.0);
-    case RS2::B2:
-        return RS_Vector(500.0, 707.0);
-    case RS2::B3:
-        return RS_Vector(353.0, 500.0);
-    case RS2::B4:
-        return RS_Vector(250.0, 353.0);
+    /* Removed ISO "B" and "C" Series, C5E, Comm10E, DLE, (envelope sizes) */
 
-    case RS2::Letter:  /* 8.5 x 11.0 in.  Sizes used for 'hard' conversion to metric */
-        return RS_Vector(215.9, 279.4);
-    case RS2::Legal:  /* 8.5 x 14.0 in */
-        return RS_Vector(215.9, 355.6);
-
-    case RS2::Ledger:  /* 11.0 x 17.0 */
-        return RS_Vector(279.4, 431.8);
-        break;
+    /* Combined letter and tabloid (ledger) with respective ANSI sizes, dropped legal */
 
     case RS2::Ansi_A:  /* 8.5 x 11.0 in */
         return RS_Vector(215.9, 279.4);

--- a/librecad/src/lib/engine/rs_units.cpp
+++ b/librecad/src/lib/engine/rs_units.cpp
@@ -839,9 +839,25 @@ RS_Vector RS_Units::paperFormatToSize(RS2::PaperFormat p) {
     case RS2::A4:
         return RS_Vector(210.0, 297.0);
 
-    /* Removed ISO "B" and "C" Series, C5E, Comm10E, DLE, (envelope sizes) */
+    case RS2::B0:
+        return RS_Vector(1000.0, 1414.0);
+    case RS2::B1:
+        return RS_Vector(707.0, 1000.0);
+    case RS2::B2:
+        return RS_Vector(500.0, 707.0);
+    case RS2::B3:
+        return RS_Vector(353.0, 500.0);
+    case RS2::B4:
+        return RS_Vector(250.0, 353.0);
 
-    /* Combined letter and tabloid (ledger) with respective ANSI sizes, dropped legal */
+    case RS2::Letter:  /* 8.5 x 11.0 in.  Sizes used for 'hard' conversion to metric */
+        return RS_Vector(215.9, 279.4);
+    case RS2::Legal:  /* 8.5 x 14.0 in */
+        return RS_Vector(215.9, 355.6);
+
+    case RS2::Ledger:  /* 11.0 x 17.0 */
+        return RS_Vector(279.4, 431.8);
+        break;
 
     case RS2::Ansi_A:  /* 8.5 x 11.0 in */
         return RS_Vector(215.9, 279.4);

--- a/librecad/src/lib/engine/rs_units.cpp
+++ b/librecad/src/lib/engine/rs_units.cpp
@@ -845,8 +845,7 @@ RS_Vector RS_Units::paperFormatToSize(RS2::PaperFormat p) {
         return RS_Vector(215.9, 279.4);
     case RS2::Legal:  /* 8.5 x 14.0 in */
         return RS_Vector(215.9, 355.6);
-
-    case RS2::Ledger:  /* 11.0 x 17.0 */
+    case RS2::Tabloid:  /* 11.0 x 17.0 */
         return RS_Vector(279.4, 431.8);
         break;
 
@@ -921,7 +920,7 @@ QString RS_Units::paperFormatToString(RS2::PaperFormat p) {
 
     case RS2::Letter: return QObject::tr( "Letter", "Paper format");
     case RS2::Legal:  return QObject::tr( "Legal",  "Paper format");
-    case RS2::Ledger: return QObject::tr( "Ledger", "Paper format");
+    case RS2::Tabloid: return QObject::tr( "Tabloid", "Paper format");
 
     case RS2::Ansi_A: return QObject::tr( "ANSI A", "Paper format");
     case RS2::Ansi_B: return QObject::tr( "ANSI B", "Paper format");
@@ -972,8 +971,8 @@ RS2::PaperFormat RS_Units::stringToPaperFormat(const QString& p) {
         return RS2::Letter;
     if (ls == QStringLiteral("legal")  || ls == QObject::tr("legal",  "Paper format").toLower())
         return RS2::Legal;
-    if (ls == QStringLiteral("ledger") || ls == QObject::tr("ledger", "Paper format").toLower())
-        return RS2::Ledger;
+    if (ls == QStringLiteral("tabloid") || ls == QObject::tr("tabloid", "Paper format").toLower())
+        return RS2::Tabloid;
 
     if (ls == QStringLiteral("ansi a") || ls == QObject::tr("ansi a", "Paper format").toLower())
         return RS2::Ansi_A;

--- a/librecad/src/lib/engine/rs_units.cpp
+++ b/librecad/src/lib/engine/rs_units.cpp
@@ -839,16 +839,7 @@ RS_Vector RS_Units::paperFormatToSize(RS2::PaperFormat p) {
     case RS2::A4:
         return RS_Vector(210.0, 297.0);
 
-    case RS2::B0:
-        return RS_Vector(1000.0, 1414.0);
-    case RS2::B1:
-        return RS_Vector(707.0, 1000.0);
-    case RS2::B2:
-        return RS_Vector(500.0, 707.0);
-    case RS2::B3:
-        return RS_Vector(353.0, 500.0);
-    case RS2::B4:
-        return RS_Vector(250.0, 353.0);
+    /* Removed ISO "B" and "C" series, C5E, Comm10E, DLE, (envelope sizes) */
 
     case RS2::Letter:  /* 8.5 x 11.0 in.  Sizes used for 'hard' conversion to metric */
         return RS_Vector(215.9, 279.4);
@@ -926,11 +917,7 @@ QString RS_Units::paperFormatToString(RS2::PaperFormat p) {
     case RS2::A3: return QObject::tr( "A3", "Paper format");
     case RS2::A4: return QObject::tr( "A4", "Paper format");
 
-    case RS2::B0: return QObject::tr( "B0", "Paper format");
-    case RS2::B1: return QObject::tr( "B1", "Paper format");
-    case RS2::B2: return QObject::tr( "B2", "Paper format");
-    case RS2::B3: return QObject::tr( "B3", "Paper format");
-    case RS2::B4: return QObject::tr( "B4", "Paper format");
+    /* Removed ISO "B" and "C" series, C5E, Comm10E, DLE, (envelope sizes) */
 
     case RS2::Letter: return QObject::tr( "Letter", "Paper format");
     case RS2::Legal:  return QObject::tr( "Legal",  "Paper format");
@@ -978,16 +965,8 @@ RS2::PaperFormat RS_Units::stringToPaperFormat(const QString& p) {
     if (ls == QStringLiteral("a4") || ls == QObject::tr("a4", "Paper format").toLower())
         return RS2::A4;
 
-    if (ls == QStringLiteral("b0") || ls == QObject::tr("b0", "Paper format").toLower())
-        return RS2::B0;
-    if (ls == QStringLiteral("b1") || ls == QObject::tr("b1", "Paper format").toLower())
-        return RS2::B1;
-    if (ls == QStringLiteral("b2") || ls == QObject::tr("b2", "Paper format").toLower())
-        return RS2::B2;
-    if (ls == QStringLiteral("b3") || ls == QObject::tr("b3", "Paper format").toLower())
-        return RS2::B3;
-    if (ls == QStringLiteral("b4") || ls == QObject::tr("b4", "Paper format").toLower())
-        return RS2::B4;
+    /* Removed ISO "B" and "C" series, C5E, Comm10E, DLE, (envelope sizes) */
+
 
     if (ls == QStringLiteral("letter") || ls == QObject::tr("letter", "Paper format").toLower())
         return RS2::Letter;

--- a/librecad/src/lib/engine/rs_units.cpp
+++ b/librecad/src/lib/engine/rs_units.cpp
@@ -847,12 +847,11 @@ RS_Vector RS_Units::paperFormatToSize(RS2::PaperFormat p) {
         return RS_Vector(215.9, 355.6);
     case RS2::Tabloid:  /* 11.0 x 17.0 */
         return RS_Vector(279.4, 431.8);
-        break;
 
-    case RS2::Ansi_A:  /* 8.5 x 11.0 in */
-        return RS_Vector(215.9, 279.4);
-    case RS2::Ansi_B:  /* 11.0 x 17.0 in */
-        return RS_Vector(279.4, 431.8);
+    //case RS2::Ansi_A:  /* 8.5 x 11.0 in */
+    //    return RS_Vector(215.9, 279.4);
+    //case RS2::Ansi_B:  /* 11.0 x 17.0 in */
+    //    return RS_Vector(279.4, 431.8);
     case RS2::Ansi_C:  /* 17.0 x 22.0 in */
         return RS_Vector(431.8, 558.8);
     case RS2::Ansi_D:  /* 22.0 x 34.0 in */
@@ -918,12 +917,12 @@ QString RS_Units::paperFormatToString(RS2::PaperFormat p) {
 
     /* Removed ISO "B" and "C" series, C5E, Comm10E, DLE, (envelope sizes) */
 
-    case RS2::Letter: return QObject::tr( "Letter", "Paper format");
+    case RS2::Letter: return QObject::tr( "Letter / ANSI A", "Paper format");
     case RS2::Legal:  return QObject::tr( "Legal",  "Paper format");
-    case RS2::Tabloid: return QObject::tr( "Tabloid", "Paper format");
+    case RS2::Tabloid: return QObject::tr( "Tabloid / ANSI B", "Paper format");
 
-    case RS2::Ansi_A: return QObject::tr( "ANSI A", "Paper format");
-    case RS2::Ansi_B: return QObject::tr( "ANSI B", "Paper format");
+    //case RS2::Ansi_A: return QObject::tr( "Letter / ANSI A", "Paper format");
+    //case RS2::Ansi_B: return QObject::tr( "Tabloid / ANSI B", "Paper format");
     case RS2::Ansi_C: return QObject::tr( "ANSI C", "Paper format");
     case RS2::Ansi_D: return QObject::tr( "ANSI D", "Paper format");
     case RS2::Ansi_E: return QObject::tr( "ANSI E", "Paper format");
@@ -966,7 +965,6 @@ RS2::PaperFormat RS_Units::stringToPaperFormat(const QString& p) {
 
     /* Removed ISO "B" and "C" series, C5E, Comm10E, DLE, (envelope sizes) */
 
-
     if (ls == QStringLiteral("letter") || ls == QObject::tr("letter", "Paper format").toLower())
         return RS2::Letter;
     if (ls == QStringLiteral("legal")  || ls == QObject::tr("legal",  "Paper format").toLower())
@@ -974,10 +972,10 @@ RS2::PaperFormat RS_Units::stringToPaperFormat(const QString& p) {
     if (ls == QStringLiteral("tabloid") || ls == QObject::tr("tabloid", "Paper format").toLower())
         return RS2::Tabloid;
 
-    if (ls == QStringLiteral("ansi a") || ls == QObject::tr("ansi a", "Paper format").toLower())
-        return RS2::Ansi_A;
-    if (ls == QStringLiteral("ansi b") || ls == QObject::tr("ansi b", "Paper format").toLower())
-        return RS2::Ansi_B;
+    //if (ls == QStringLiteral("ansi a") || ls == QObject::tr("ansi a", "Paper format").toLower())
+    //    return RS2::Ansi_A;
+    //if (ls == QStringLiteral("ansi b") || ls == QObject::tr("ansi b", "Paper format").toLower())
+    //    return RS2::Ansi_B;
     if (ls == QStringLiteral("ansi c") || ls == QObject::tr("ansi c", "Paper format").toLower())
         return RS2::Ansi_C;
     if (ls == QStringLiteral("ansi d") || ls == QObject::tr("ansi d", "Paper format").toLower())

--- a/librecad/src/lib/engine/rs_units.cpp
+++ b/librecad/src/lib/engine/rs_units.cpp
@@ -910,12 +910,18 @@ QString RS_Units::paperFormatToString(RS2::PaperFormat p) {
     case RS2::A3: return QObject::tr( "A3", "Paper format");
     case RS2::A4: return QObject::tr( "A4", "Paper format");
 
-    /* Removed ISO "B" and "C" Series, C5E, Comm10E, DLE, (envelope sizes) */
+    case RS2::B0: return QObject::tr( "B0", "Paper format");
+    case RS2::B1: return QObject::tr( "B1", "Paper format");
+    case RS2::B2: return QObject::tr( "B2", "Paper format");
+    case RS2::B3: return QObject::tr( "B3", "Paper format");
+    case RS2::B4: return QObject::tr( "B4", "Paper format");
 
-    /* Combined letter and tabloid (ledger) with respective ANSI sizes, dropped legal */
+    case RS2::Letter: return QObject::tr( "Letter", "Paper format");
+    case RS2::Legal:  return QObject::tr( "Legal",  "Paper format");
+    case RS2::Ledger: return QObject::tr( "Ledger", "Paper format");
 
-    case RS2::Ansi_A: return QObject::tr( "ANSI A / Letter", "Paper format");
-    case RS2::Ansi_B: return QObject::tr( "ANSI B / Tabloid", "Paper format");
+    case RS2::Ansi_A: return QObject::tr( "ANSI A", "Paper format");
+    case RS2::Ansi_B: return QObject::tr( "ANSI B", "Paper format");
     case RS2::Ansi_C: return QObject::tr( "ANSI C", "Paper format");
     case RS2::Ansi_D: return QObject::tr( "ANSI D", "Paper format");
     case RS2::Ansi_E: return QObject::tr( "ANSI E", "Paper format");
@@ -956,9 +962,23 @@ RS2::PaperFormat RS_Units::stringToPaperFormat(const QString& p) {
     if (ls == QStringLiteral("a4") || ls == QObject::tr("a4", "Paper format").toLower())
         return RS2::A4;
 
-    /* Removed ISO "B" and "C" Series, C5E, Comm10E, DLE, (envelope sizes) */
+    if (ls == QStringLiteral("b0") || ls == QObject::tr("b0", "Paper format").toLower())
+        return RS2::B0;
+    if (ls == QStringLiteral("b1") || ls == QObject::tr("b1", "Paper format").toLower())
+        return RS2::B1;
+    if (ls == QStringLiteral("b2") || ls == QObject::tr("b2", "Paper format").toLower())
+        return RS2::B2;
+    if (ls == QStringLiteral("b3") || ls == QObject::tr("b3", "Paper format").toLower())
+        return RS2::B3;
+    if (ls == QStringLiteral("b4") || ls == QObject::tr("b4", "Paper format").toLower())
+        return RS2::B4;
 
-    /* Combined letter and tabloid (ledger) with respective ANSI sizes, dropped legal */
+    if (ls == QStringLiteral("letter") || ls == QObject::tr("letter", "Paper format").toLower())
+        return RS2::Letter;
+    if (ls == QStringLiteral("legal")  || ls == QObject::tr("legal",  "Paper format").toLower())
+        return RS2::Legal;
+    if (ls == QStringLiteral("ledger") || ls == QObject::tr("ledger", "Paper format").toLower())
+        return RS2::Ledger;
 
     if (ls == QStringLiteral("ansi a") || ls == QObject::tr("ansi a", "Paper format").toLower())
         return RS2::Ansi_A;

--- a/librecad/src/lib/printing/lc_printing.cpp
+++ b/librecad/src/lib/printing/lc_printing.cpp
@@ -33,15 +33,9 @@ QPrinter::PageSize LC_Printing::rsToQtPaperFormat(RS2::PaperFormat f)
     case RS2::A3: return QPrinter::A3;
     case RS2::A4: return QPrinter::A4;
 
-    case RS2::B0: return QPrinter::B0;
-    case RS2::B1: return QPrinter::B1;
-    case RS2::B2: return QPrinter::B2;
-    case RS2::B3: return QPrinter::B3;
-    case RS2::B4: return QPrinter::B4;
+    /* Removed ISO "B" and "C" Series, C5E, Comm10E, DLE, (envelope sizes) */
 
-    case RS2::Letter: return QPrinter::Letter;
-    case RS2::Legal:  return QPrinter::Legal;
-    case RS2::Ledger: return QPrinter::Ledger;
+    /* Combined letter and tabloid (ledger) with respective ANSI sizes, dropped legal */
 
     case RS2::Ansi_A: return QPrinter::AnsiA;
     case RS2::Ansi_B: return QPrinter::AnsiB;

--- a/librecad/src/lib/printing/lc_printing.cpp
+++ b/librecad/src/lib/printing/lc_printing.cpp
@@ -39,8 +39,8 @@ QPrinter::PageSize LC_Printing::rsToQtPaperFormat(RS2::PaperFormat f)
     case RS2::Legal:  return QPrinter::Legal;
     case RS2::Tabloid: return QPrinter::Tabloid;
 
-    case RS2::Ansi_A: return QPrinter::AnsiA;
-    case RS2::Ansi_B: return QPrinter::AnsiB;
+    //case RS2::Ansi_A: return QPrinter::AnsiA;
+    //case RS2::Ansi_B: return QPrinter::AnsiB;
     case RS2::Ansi_C: return QPrinter::AnsiC;
     case RS2::Ansi_D: return QPrinter::AnsiD;
     case RS2::Ansi_E: return QPrinter::AnsiE;

--- a/librecad/src/lib/printing/lc_printing.cpp
+++ b/librecad/src/lib/printing/lc_printing.cpp
@@ -33,9 +33,15 @@ QPrinter::PageSize LC_Printing::rsToQtPaperFormat(RS2::PaperFormat f)
     case RS2::A3: return QPrinter::A3;
     case RS2::A4: return QPrinter::A4;
 
-    /* Removed ISO "B" and "C" Series, C5E, Comm10E, DLE, (envelope sizes) */
+    case RS2::B0: return QPrinter::B0;
+    case RS2::B1: return QPrinter::B1;
+    case RS2::B2: return QPrinter::B2;
+    case RS2::B3: return QPrinter::B3;
+    case RS2::B4: return QPrinter::B4;
 
-    /* Combined letter and tabloid (ledger) with respective ANSI sizes, dropped legal */
+    case RS2::Letter: return QPrinter::Letter;
+    case RS2::Legal:  return QPrinter::Legal;
+    case RS2::Ledger: return QPrinter::Ledger;
 
     case RS2::Ansi_A: return QPrinter::AnsiA;
     case RS2::Ansi_B: return QPrinter::AnsiB;

--- a/librecad/src/lib/printing/lc_printing.cpp
+++ b/librecad/src/lib/printing/lc_printing.cpp
@@ -33,11 +33,8 @@ QPrinter::PageSize LC_Printing::rsToQtPaperFormat(RS2::PaperFormat f)
     case RS2::A3: return QPrinter::A3;
     case RS2::A4: return QPrinter::A4;
 
-    case RS2::B0: return QPrinter::B0;
-    case RS2::B1: return QPrinter::B1;
-    case RS2::B2: return QPrinter::B2;
-    case RS2::B3: return QPrinter::B3;
-    case RS2::B4: return QPrinter::B4;
+    /* Removed ISO "B" and "C" series, C5E, Comm10E, DLE, (envelope sizes) */
+
 
     case RS2::Letter: return QPrinter::Letter;
     case RS2::Legal:  return QPrinter::Legal;

--- a/librecad/src/lib/printing/lc_printing.cpp
+++ b/librecad/src/lib/printing/lc_printing.cpp
@@ -35,10 +35,9 @@ QPrinter::PageSize LC_Printing::rsToQtPaperFormat(RS2::PaperFormat f)
 
     /* Removed ISO "B" and "C" series, C5E, Comm10E, DLE, (envelope sizes) */
 
-
     case RS2::Letter: return QPrinter::Letter;
     case RS2::Legal:  return QPrinter::Legal;
-    case RS2::Ledger: return QPrinter::Ledger;
+    case RS2::Tabloid: return QPrinter::Tabloid;
 
     case RS2::Ansi_A: return QPrinter::AnsiA;
     case RS2::Ansi_B: return QPrinter::AnsiB;


### PR DESCRIPTION
Removed ISO "B" sizes, fixed issue with ANSI B / Ledger / Tabloid (and ANSI A / Letter)
ANSI A Print preview (ANSI B similar):
![ANSI-A_PrnPrev](https://user-images.githubusercontent.com/44550894/84579740-ba8cb900-ad8d-11ea-97d5-0fa3710c4654.png)
ANSI A pdf export:
[ANSI-A_Export.pdf](https://github.com/LibreCAD/LibreCAD/files/4775545/ANSI-A_Export.pdf)
ANSI B pdf export:
[ANSI-B_Export.pdf](https://github.com/LibreCAD/LibreCAD/files/4775546/ANSI-B_Export.pdf)

Files changed:
rs.h
rs_units.cpp
lc_printing.cpp

Refer #724, #1247 
