### PR TITLE
Fix typos

### DIFF
--- a/librecad/src/actions/rs_actiondrawarc3p.cpp
+++ b/librecad/src/actions/rs_actiondrawarc3p.cpp
@@ -49,7 +49,7 @@ RS_Vector point1;
  */
 RS_Vector point2;
 /**
- * 3nd point.
+ * 3rd point.
  */
 RS_Vector point3;
 };

--- a/librecad/src/actions/rs_actiondrawcircle3p.cpp
+++ b/librecad/src/actions/rs_actiondrawcircle3p.cpp
@@ -46,7 +46,7 @@ struct RS_ActionDrawCircle3P::Points {
 	 */
 	RS_Vector point2;
 	/**
-	 * 3nd point.
+	 * 3rd point.
 	 */
 	RS_Vector point3;
 };

--- a/librecad/src/lib/actions/rs_previewactioninterface.cpp
+++ b/librecad/src/lib/actions/rs_previewactioninterface.cpp
@@ -104,7 +104,7 @@ void RS_PreviewActionInterface::trigger() {
  */
 void RS_PreviewActionInterface::deletePreview() {
 		if (hasPreview){
-                //avoid deletiong NULL or empty preview
+                //avoid deleting NULL or empty preview
             preview->clear();
             hasPreview=false;
         }

--- a/librecad/src/lib/engine/rs.h
+++ b/librecad/src/lib/engine/rs.h
@@ -811,12 +811,12 @@ public:
         SizeAllCursor,        /**< SizeAllCursor - all directions resize. */
         BlankCursor,          /**< BlankCursor - blank/invisible cursor. */
         SplitVCursor,         /**< SplitVCursor - vertical splitting. */
-        SplitHCursor,         /**< SplitHCursor - horziontal splitting. */
+        SplitHCursor,         /**< SplitHCursor - horizontal splitting. */
         PointingHandCursor,   /**< PointingHandCursor - a pointing hand. */
         ForbiddenCursor,      /**< ForbiddenCursor - a slashed circle. */
         WhatsThisCursor,      /**< WhatsThisCursor - an arrow with a ?. */
         OpenHandCursor,       /**< Qt OpenHandCursor */
-        ClosedHandCursor,       /**< Qt ClosedHandCursor */
+        ClosedHandCursor,     /**< Qt ClosedHandCursor */
         CadCursor,            /**< CadCursor - a bigger cross. */
         DelCursor,            /**< DelCursor - cursor for choosing entities */
         SelectCursor,         /**< SelectCursor - for selecting single entities */

--- a/librecad/src/lib/engine/rs_arc.cpp
+++ b/librecad/src/lib/engine/rs_arc.cpp
@@ -692,7 +692,7 @@ RS_Vector RS_Arc::prepareTrim(const RS_Vector& trimCoord,
             }
         }
         std::sort(ias.begin(),ias.end());
-		for(size_t ii=0; ii<trimSol.getNumber(); ++ii) { //find segment to enclude trimCoord
+		for(size_t ii=0; ii<trimSol.getNumber(); ++ii) { //find segment to include trimCoord
             if ( ! RS_Math::isSameDirection(ia,ias[ii],RS_TOLERANCE)) continue;
             if( RS_Math::isAngleBetween(am,ias[(ii+trimSol.getNumber()-1)% trimSol.getNumber()],ia,false))  {
                 ia2=ias[(ii+trimSol.getNumber()-1)% trimSol.getNumber()];
@@ -701,7 +701,7 @@ RS_Vector RS_Arc::prepareTrim(const RS_Vector& trimCoord,
             }
             break;
         }
-		for(const RS_Vector& vp: trimSol) { //find segment to enclude trimCoord
+		for(const RS_Vector& vp: trimSol) { //find segment to include trimCoord
 			if ( ! RS_Math::isSameDirection(ia2,getArcAngle(vp),RS_TOLERANCE)) continue;
 			is2=vp;
             break;

--- a/librecad/src/lib/engine/rs_blocklist.cpp
+++ b/librecad/src/lib/engine/rs_blocklist.cpp
@@ -388,7 +388,7 @@ void RS_BlockList::setModified(bool m) {
 		}
 	}
 
-	// Notify listeneres
+	// Notify listeners
 	for (auto l: blockListListeners) {
 		l->blockListModified(m);
 	}

--- a/librecad/src/lib/engine/rs_dimaligned.cpp
+++ b/librecad/src/lib/engine/rs_dimaligned.cpp
@@ -102,7 +102,7 @@ RS_VectorSolutions RS_DimAligned::getRefPoints() const
 }
 
 /**
- * @return Automatically creted label for the default
+ * @return Automatically created label for the default
  * measurement of this dimension.
  */
 QString RS_DimAligned::getMeasuredLabel() {

--- a/librecad/src/lib/engine/rs_ellipse.cpp
+++ b/librecad/src/lib/engine/rs_ellipse.cpp
@@ -395,7 +395,7 @@ RS_Vector RS_Ellipse::getNearestDist(double distance,
     }
 
 	if(e.getMajorRadius() < RS_TOLERANCE)
-		return {}; //elipse too small
+		return {}; //ellipse too small
 
     if(getRatio()<RS_TOLERANCE) {
         //treat the ellipse as a line
@@ -1232,7 +1232,7 @@ RS_Vector RS_Ellipse::prepareTrim(const RS_Vector& trimCoord,
         }
     }
     std::sort(ias.begin(),ias.end());
-	for(size_t ii=0; ii<trimSol.getNumber(); ++ii) { //find segment to enclude trimCoord
+	for(size_t ii=0; ii<trimSol.getNumber(); ++ii) { //find segment to include trimCoord
         if ( ! RS_Math::isSameDirection(ia,ias[ii],RS_TOLERANCE)) continue;
         if( RS_Math::isAngleBetween(am,ias[(ii+trimSol.getNumber()-1)% trimSol.getNumber()],ia,false))  {
             ia2=ias[(ii+trimSol.getNumber()-1)% trimSol.getNumber()];
@@ -1241,7 +1241,7 @@ RS_Vector RS_Ellipse::prepareTrim(const RS_Vector& trimCoord,
         }
         break;
     }
-	for(const RS_Vector& vp: trimSol) { //find segment to enclude trimCoord
+	for(const RS_Vector& vp: trimSol) { //find segment to include trimCoord
 		if ( ! RS_Math::isSameDirection(ia2,getEllipseAngle(vp),RS_TOLERANCE)) continue;
 		is2=vp;
         break;
@@ -1323,7 +1323,7 @@ const RS_EllipseData& RS_Ellipse::getData() const
 
 /* Dongxu Li's Version, 19 Aug 2011
  * scale an ellipse
- * Find the eigen vactors and eigen values by optimization
+ * Find the eigen vectors and eigen values by optimization
  * original ellipse equation,
  * x= a cos t
  * y= b sin t

--- a/librecad/src/lib/engine/rs_graphic.h
+++ b/librecad/src/lib/engine/rs_graphic.h
@@ -364,7 +364,7 @@ private:
         RS_LayerList layerList;
         RS_BlockList blockList;
         RS_VariableDict variableDict;
-        RS2::CrosshairType crosshairType; //corss hair type used by isometric grid
+        RS2::CrosshairType crosshairType; //crosshair type used by isometric grid
         //if set to true, will refuse to modify paper scale
         bool paperScaleFixed;
 

--- a/librecad/src/lib/engine/rs_mtext.cpp
+++ b/librecad/src/lib/engine/rs_mtext.cpp
@@ -247,7 +247,7 @@ void RS_MText::update()
     int lineCounter {0};
 
     // Every single text line gets stored in this entity container
-    // so we can move the whole line around easely:
+    // so we can move the whole line around easily:
     RS_EntityContainer* oneLine {new RS_EntityContainer(this)};
 
     // First every text line is created with

--- a/librecad/src/lib/engine/rs_system.cpp
+++ b/librecad/src/lib/engine/rs_system.cpp
@@ -658,7 +658,7 @@ QString RS_System::languageToSymbol(const QString& lang) {
 
 
 /**
- * Converst a locale code into a readable string
+ * Converts a locale code into a readable string
  * (e.g. 'de' to 'German Deutsch'
  * (e.g. 'en_au' to 'English (Australia)'
  */

--- a/librecad/src/lib/engine/rs_undo.cpp
+++ b/librecad/src/lib/engine/rs_undo.cpp
@@ -119,7 +119,7 @@ void RS_Undo::startUndoCycle()
         obsolete.sort();
         obsolete.unique();
 
-        // delete obsolte undoables which are not in keep list
+        // delete obsolete undoables which are not in keep list
         for (auto it = obsolete.begin(); it != obsolete.end(); ++it) {
             if (keep.end() == std::find( keep.begin(), keep.end(), *it)) {
                 removeUndoable( *it);

--- a/librecad/src/lib/engine/rs_undocycle.h
+++ b/librecad/src/lib/engine/rs_undocycle.h
@@ -41,7 +41,7 @@
  * the action. Undoables are entities in a container that can be
  * created and deleted.
  *
- * Undo Cycles are stored within classes derrived from RS_Undo.
+ * Undo Cycles are stored within classes derived from RS_Undo.
  *
  * @see RS_Undoable
  * @see RS_Undo

--- a/librecad/src/lib/engine/rs_units.cpp
+++ b/librecad/src/lib/engine/rs_units.cpp
@@ -963,7 +963,7 @@ QString RS_Units::paperFormatToString(RS2::PaperFormat p) {
 RS2::PaperFormat RS_Units::stringToPaperFormat(const QString& p) {
     QString ls {p.toLower()};
 
-    // use toLower() on localized paper format strings, dont't trust that translators keep lower case
+    // use toLower() on localized paper format strings, don't trust that translators keep lower case
     if (ls == QStringLiteral("custom") || ls == QObject::tr("custom", "Paper format").toLower())
         return RS2::Custom;
 

--- a/librecad/src/lib/filters/rs_filterdxf.cpp
+++ b/librecad/src/lib/filters/rs_filterdxf.cpp
@@ -2417,7 +2417,7 @@ void RS_FilterDXF::writeEntityContainer(DL_WriterA& dw, RS_EntityContainer* con,
 
 
 /**
- * Writes the atomic entities of the given cotnainer to the file.
+ * Writes the atomic entities of the given container to the file.
  */
 void RS_FilterDXF::writeAtomicEntities(DL_WriterA& dw, RS_EntityContainer* c,
                                        const DL_Attributes& attrib,
@@ -3276,7 +3276,7 @@ RS2::Unit RS_FilterDXF::numberToUnit(int num) {
 
 
 /**
- * Converst a unit enum into a DXF unit number e.g. for INSUNITS.
+ * Converts a unit enum into a DXF unit number e.g. for INSUNITS.
  */
 int RS_FilterDXF::unitToNumber(RS2::Unit unit) {
     switch (unit) {

--- a/librecad/src/lib/filters/rs_filterdxf1.cpp
+++ b/librecad/src/lib/filters/rs_filterdxf1.cpp
@@ -1791,7 +1791,7 @@ void RS_FilterDXF1::separateBuf(char _c1,
 //   comments get replaced by '\0'
 //
 void RS_FilterDXF1::removeComment(char _fc, char _lc) {
-    bool rem=false;   // Are we removing currrently?
+    bool rem=false;   // Are we removing currently?
     int bc;           // counter
 
     for(bc=0; bc<(int)fSize; ++bc) {

--- a/librecad/src/lib/filters/rs_filterdxfrw.cpp
+++ b/librecad/src/lib/filters/rs_filterdxfrw.cpp
@@ -2943,7 +2943,7 @@ void RS_FilterDXFRW::writeImage(RS_Image * i) {
 
 
 /**
- * Writes the atomic entities of the given cotnainer to the file.
+ * Writes the atomic entities of the given container to the file.
  */
 /*void RS_FilterDXFRW::writeAtomicEntities(DL_WriterA& dw, RS_EntityContainer* c,
                                        const DRW_Entity& attrib,
@@ -3839,7 +3839,7 @@ RS2::Unit RS_FilterDXFRW::numberToUnit(int num) {
 
 
 /**
- * Converst a unit enum into a DXF unit number e.g. for INSUNITS.
+ * Converts a unit enum into a DXF unit number e.g. for INSUNITS.
  */
 int RS_FilterDXFRW::unitToNumber(RS2::Unit unit) {
     switch (unit) {

--- a/librecad/src/lib/filters/rs_filterjww.cpp
+++ b/librecad/src/lib/filters/rs_filterjww.cpp
@@ -2423,7 +2423,7 @@ void RS_FilterJWW::writeEntityContainer(DL_WriterA& dw, RS_EntityContainer* con,
 
 
 /**
- * Writes the atomic entities of the given cotnainer to the file.
+ * Writes the atomic entities of the given container to the file.
  */
 void RS_FilterJWW::writeAtomicEntities(DL_WriterA& dw, RS_EntityContainer* c,
                                                                            const DL_Attributes& attrib,
@@ -3299,7 +3299,7 @@ RS2::Unit RS_FilterJWW::numberToUnit(int num) {
 
 
 /**
- * Converst a unit enum into a JWW unit number e.g. for INSUNITS.
+ * Converts a unit enum into a JWW unit number e.g. for INSUNITS.
  */
 int RS_FilterJWW::unitToNumber(RS2::Unit unit) {
         switch (unit) {

--- a/librecad/src/lib/gui/rs_dialogfactoryinterface.h
+++ b/librecad/src/lib/gui/rs_dialogfactoryinterface.h
@@ -407,7 +407,7 @@ public:
      * This virtual method must be overwritten if the graphic view has
      * a component that is interested in the current mouse button hints.
      * The implementation will be called typically by actions to inform
-     * the user about the current functionalty of the mouse buttons.
+     * the user about the current functionality of the mouse buttons.
      *
      * @param left Help text for the left mouse button.
      * @param right Help text for the right mouse button.

--- a/librecad/src/lib/gui/rs_graphicview.h
+++ b/librecad/src/lib/gui/rs_graphicview.h
@@ -318,7 +318,7 @@ public:
 	void lockRelativeZero(bool lock);
 
 	/**
-		 * @return true if the position of the realtive zero point is
+		 * @return true if the position of the relative zero point is
 		 * locked.
 		 */
 	bool isRelativeZeroLocked() const;

--- a/librecad/src/lib/information/rs_infoarea.cpp
+++ b/librecad/src/lib/information/rs_infoarea.cpp
@@ -41,7 +41,7 @@ RS_InfoArea::RS_InfoArea():
 /**
  * Adds a point to the internal list
  *
- * @param p co-ordinate of the point
+ * @param p coordinate of the point
  */
 void RS_InfoArea::push_back(const RS_Vector& p) {
     if (thePoints.empty()) {

--- a/librecad/src/lib/information/rs_information.cpp
+++ b/librecad/src/lib/information/rs_information.cpp
@@ -57,7 +57,7 @@ RS_Information::RS_Information(RS_EntityContainer& container):
 
 
 /**
- * @return true: if the entity is a dimensioning enity.
+ * @return true: if the entity is a dimensioning entity.
  *         false: otherwise
  */
 bool RS_Information::isDimension(RS2::EntityType type) {
@@ -589,7 +589,7 @@ RS_VectorSolutions RS_Information::getIntersectionEllipseEllipse(
     double b2=e02->getMinorRadius();
 
     if( e01->getMinorRadius() < RS_TOLERANCE || e01 -> getRatio()< RS_TOLERANCE) {
-        // treate e01 as a line
+        // treat e01 as a line
         RS_Line line{e1->getParent(), {{-a1,0.}, {a1,0.}}};
         ret= getIntersectionEllipseLine(&line, e02);
         ret.rotate(-shifta1);
@@ -597,7 +597,7 @@ RS_VectorSolutions RS_Information::getIntersectionEllipseEllipse(
         return ret;
     }
     if( e02->getMinorRadius() < RS_TOLERANCE || e02 -> getRatio()< RS_TOLERANCE) {
-        // treate e02 as a line
+        // treat e02 as a line
         RS_Line line{e1->getParent(), {{-a2,0.}, {a2,0.}}};
         line.rotate({0.,0.}, e02->getAngle());
         line.move(e02->getCenter());

--- a/librecad/src/main/console_dxf2pdf/pdf_print_loop.cpp
+++ b/librecad/src/main/console_dxf2pdf/pdf_print_loop.cpp
@@ -57,7 +57,7 @@ void PdfPrintLoop::printOneDxfToOnePdf(QString& dxfFile) {
 
     // Main code logic and flow for this method is originally stolen from
     // QC_ApplicationWindow::slotFilePrint(bool printPDF) method.
-    // But finally it was splitted in smaller parts.
+    // But finally it was split in to smaller parts.
 
     QFileInfo dxfFileInfo(dxfFile);
     params.outFile =

--- a/librecad/src/plugins/document_interface.h
+++ b/librecad/src/plugins/document_interface.h
@@ -268,10 +268,10 @@ public:
     virtual QString intColor2str(int color) = 0;
 };
 
-//! Interface for comunicate plugins.
+//! Interface for communicate plugins.
  /*!
- * Class for comunicate plugins with document (drawing).
- * entities whitout add*() function:
+ * Class for communicate plugins with document (drawing).
+ * entities without add*() function:
  * atomic = CONSTRUCTIONLINE, OVERLAYBOX, SOLID,
  * container = INSERT, POLYLINE, SPLINE, HATCH, DIMLEADER,
  * DIMALIGNED, DIMLINEAR, DIMRADIAL, DIMDIAMETRIC, DIMANGULAR,
@@ -469,7 +469,7 @@ public:
     //! Gets all entities in document.
     /*! You can delete all, the Plug_Entity and the returned QList wen no more needed.
     * \param sel a QList of pointers to Plug_Entity handled the selected entities.
-    * \param visible default fo false, do not select entities in hidden layers.
+    * \param visible default for false, do not select entities in hidden layers.
     * \return true if success.
     * \return false if fail, i.e. user cancel.
     */

--- a/librecad/src/test/lc_simpletests.cpp
+++ b/librecad/src/test/lc_simpletests.cpp
@@ -980,7 +980,7 @@ void LC_SimpleTests::slotTestUnicode() {
 		int col;
 		int row;
 		QChar uCode;       // e.g. 65 (or 'A')
-		QString strCode;   // unicde as string e.g. '[0041] A'
+		QString strCode;   // unicode as string e.g. '[0041] A'
 
 		graphic->setAutoUpdateBorders(false);
 

--- a/librecad/src/ui/forms/qg_dlgoptionsdrawing.ui
+++ b/librecad/src/ui/forms/qg_dlgoptionsdrawing.ui
@@ -1595,7 +1595,7 @@
        <item row="11" column="2">
         <widget class="QDoubleSpinBox" name="cbDimFxL">
          <property name="toolTip">
-          <string>fixed extension line legth</string>
+          <string>fixed extension line length</string>
          </property>
          <property name="decimals">
           <number>4</number>

--- a/librecad/src/ui/lg_dimzerosbox.h
+++ b/librecad/src/ui/lg_dimzerosbox.h
@@ -8,7 +8,7 @@
 
 /*
  * DimZin value is mixed integer and bit flag value
- * inches and feets are integer values, removal of left and right zeros are flags
+ * inches and feet are integer values, removal of left and right zeros are flags
  * 0: removes 0' & 0"
  * 1: draw 0' & 0"
  * 2: removes 0"

--- a/librecad/src/ui/qg_filedialog.cpp
+++ b/librecad/src/ui/qg_filedialog.cpp
@@ -325,7 +325,7 @@ QString QG_FileDialog::getSaveFileName(QWidget* parent, RS2::FormatType* type) {
             cancel = false;
 
             // append default extension:
-            // TODO, since we are starting to suppor tmore extensions, we need to find a better way to add the default
+            // TODO, since we are starting to support more extensions, we need to find a better way to add the default
             if (QFileInfo(fn).fileName().indexOf('.')==-1) {
 
                 if (fileDlg->selectedNameFilter()=="LFF Font (*.lff)") {

--- a/librecad/ts/README.md
+++ b/librecad/ts/README.md
@@ -5,7 +5,7 @@ LibreCAD supports more than 40 languages, nearly half of them have active contri
 Many languages have more than one contributor and most of them are not a developer. They are not familiar with source code and git.
 
 For that and a couple of other reasons we have a translation server at http://translate.librecad.org/.
-To reduce the workload for managing the server, the syncing process is automated by scripts. These scrips can be broken by manual commits to the *ts* folders because of merge conflicts which cannot be handled automatically.
+To reduce the workload for managing the server, the syncing process is automated by scripts. These scripts can be broken by manual commits to the *ts* folders because of merge conflicts which cannot be handled automatically.
 
 So here is our urgent request: Even if you are an experienced developer, please register an account at http://translate.librecad.org/ and get some information from below, how to contribute in translating LibreCAD.
 

--- a/plugins/divide/divide.cpp
+++ b/plugins/divide/divide.cpp
@@ -2,7 +2,7 @@
 *  divide.cpp - divide lines, circles and arcs                              *
 *                                                                           *
 *  Copyright (C) 2018 mad-hatter                                            *
-*  somme code borrowed from                                                 *
+*  some code borrowed from                                                  *
 *  list.cpp - Copyrighted by Rallaz, rallazz@gmail.com                      *
 *                                                                           *
 *  This library is free software, licensed under the terms of the GNU       *
@@ -557,7 +557,7 @@ QString divide::getStrData( Plug_Entity *ent )
     return strData;
 }
 
-//return center of active windoow
+//return center of active window
 QPoint divide::findWindowCentre()
 {
     QPoint centXY;

--- a/plugins/ts/README.md
+++ b/plugins/ts/README.md
@@ -5,7 +5,7 @@ LibreCAD supports more than 40 languages, nearly half of them have active contri
 Many languages have more than one contributor and most of them are not a developer. They are not familiar with source code and git.
 
 For that and a couple of other reasons we have a translation server at http://translate.librecad.org/.
-To reduce the workload for managing the server, the syncing process is automated by scripts. These scrips can be broken by manual commits to the *ts* folders because of merge conflicts which cannot be handled automatically.
+To reduce the workload for managing the server, the syncing process is automated by scripts. These scripts can be broken by manual commits to the *ts* folders because of merge conflicts which cannot be handled automatically.
 
 So here is our urgent request: Even if you are an experienced developer, please register an account at http://translate.librecad.org/ and get some information from below, how to contribute in translating LibreCAD.
 

--- a/tools/ttf2lff/ttf2lff.1
+++ b/tools/ttf2lff/ttf2lff.1
@@ -2,7 +2,7 @@
 .SH NAME
 ttf2lff \- ttf to lff converter.
 .SH DESCRIPTION
-ttf2lff is a font converter. It convert fonts in ttf format to lff format usseful
+ttf2lff is a font converter. It convert fonts in ttf format to lff format useful
 to use with LibreCAD or another app that uses this format.
 
 ttf2lff invocation parameters are printed to the console if ttf2lff is called without parameters.


### PR DESCRIPTION
Found via `codespell -q 3 -S *.ts,./libraries,*.dxf,*.lff -L ans,atleast,ba,lightyear`