### PR TITLE
DXF2PNG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ core.*
 *.vcxproj
 *.vcxproj.filters
 *.sln
+
+#Files for testing
+*.dxf

--- a/README.md
+++ b/README.md
@@ -1,11 +1,59 @@
-# DXF Converter
+# LibreCAD [![Build Status](https://travis-ci.org/LibreCAD/LibreCAD.svg?branch=master)](https://travis-ci.org/LibreCAD/LibreCAD) 
 
-```
-sudo apt update
-sudo apt-get install build-essential
-sudo apt-get install qtcreator
-sudo apt-get install qt5-default
-sudo apt-get install g++ gcc make git-core qtbase5-dev libqt5svg5-dev qttools5-dev qtchooser qttools5-dev-tools libmuparser-dev librsvg2-bin libboost-dev libfreetype6-dev libicu-dev pkg-config
-qmake -r
-make
-```
+[→ Download ←](https://github.com/LibreCAD/LibreCAD/wiki/Download)
+
+[LibreCAD](https://www.librecad.org) is a 2D CAD drawing tool
+based on the community edition of [QCAD](https://www.qcad.org).
+LibreCAD uses the cross-platform framework [Qt](https://www.qt.io/download-open-source/),
+which means it works with most operating systems.  
+The user interface is translated in over 30 languages.  https://translate.librecad.org
+
+LibreCAD is free software; you can redistribute it and/or modify  
+it under the terms of the [GNU General Public License version 2](https://www.gnu.org/licenses/gpl-2.0.html) (GPLv2)  
+as published by the Free Software Foundation.  
+Please read the [LICENSE](LICENSE) file for additional information.
+
+The master branch represents the latest pre-release code,  
+and now requires Qt 5.2.1 or newer.  
+The 2.1 branch will be the last to support Qt4.  
+The 2.0 branch will be the last to support the QCAD toolbar. [![Build Status](https://travis-ci.org/LibreCAD/LibreCAD.svg?branch=2.0)](https://travis-ci.org/LibreCAD/LibreCAD) 
+
+- [Releases](https://github.com/LibreCAD/LibreCAD/releases)
+- [Milestones](https://github.com/LibreCAD/LibreCAD/milestones)
+
+[libdxfrw](https://sourceforge.net/projects/libdxfrw/) is an associated project that allows LibreCAD to read DWG files.
+
+**Requests and Bug reports**
+
+- [GitHub issues (preferred)](https://github.com/LibreCAD/LibreCAD/issues)
+- [SourceForge tickets (disabled)](https://sourceforge.net/p/librecad/_list/tickets?source=navbar)
+
+**Users Documentation**
+
+- [Users Manual](https://librecad.readthedocs.io/)
+- [Wiki Main Page](https://dokuwiki.librecad.org/)
+
+**Questions or Comments**
+
+- [LibreCAD's Forum](https://forum.librecad.org/)
+- IRC: [#librecad](https://webchat.freenode.net/?channels=librecad) at freenode.net
+
+**Building**
+
+Requirements:
+
+- [Qt](https://www.qt.io/download-open-source/) 5.2.1+ (MinGW version on Windows)
+- [Boost](https://www.boost.org/)
+
+More information: [Build from source](https://github.com/LibreCAD/LibreCAD/wiki/Build-from-source)
+
+**Contributing**
+
+[Git and GitHub](https://github.com/LibreCAD/LibreCAD/wiki/Git-and-GitHub)
+
+[Becoming a developer](https://github.com/LibreCAD/LibreCAD/wiki/Becoming-a-developer)
+
+There is a [resources repository](https://github.com/LibreCAD/Resources) for people that want to indirectly  
+contribute to the project by supplying icons, stylesheets, documentation, templates...
+
+Associated downloads: <https://sourceforge.net/projects/librecad/files/Resources/>

--- a/README.md
+++ b/README.md
@@ -1,59 +1,11 @@
-# LibreCAD [![Build Status](https://travis-ci.org/LibreCAD/LibreCAD.svg?branch=master)](https://travis-ci.org/LibreCAD/LibreCAD) 
+# DXF Converter
 
-[→ Download ←](https://github.com/LibreCAD/LibreCAD/wiki/Download)
-
-[LibreCAD](https://www.librecad.org) is a 2D CAD drawing tool
-based on the community edition of [QCAD](https://www.qcad.org).
-LibreCAD uses the cross-platform framework [Qt](https://www.qt.io/download-open-source/),
-which means it works with most operating systems.  
-The user interface is translated in over 30 languages.  https://translate.librecad.org
-
-LibreCAD is free software; you can redistribute it and/or modify  
-it under the terms of the [GNU General Public License version 2](https://www.gnu.org/licenses/gpl-2.0.html) (GPLv2)  
-as published by the Free Software Foundation.  
-Please read the [LICENSE](LICENSE) file for additional information.
-
-The master branch represents the latest pre-release code,  
-and now requires Qt 5.2.1 or newer.  
-The 2.1 branch will be the last to support Qt4.  
-The 2.0 branch will be the last to support the QCAD toolbar. [![Build Status](https://travis-ci.org/LibreCAD/LibreCAD.svg?branch=2.0)](https://travis-ci.org/LibreCAD/LibreCAD) 
-
-- [Releases](https://github.com/LibreCAD/LibreCAD/releases)
-- [Milestones](https://github.com/LibreCAD/LibreCAD/milestones)
-
-[libdxfrw](https://sourceforge.net/projects/libdxfrw/) is an associated project that allows LibreCAD to read DWG files.
-
-**Requests and Bug reports**
-
-- [GitHub issues (preferred)](https://github.com/LibreCAD/LibreCAD/issues)
-- [SourceForge tickets (disabled)](https://sourceforge.net/p/librecad/_list/tickets?source=navbar)
-
-**Users Documentation**
-
-- [Users Manual](https://librecad.readthedocs.io/)
-- [Wiki Main Page](https://dokuwiki.librecad.org/)
-
-**Questions or Comments**
-
-- [LibreCAD's Forum](https://forum.librecad.org/)
-- IRC: [#librecad](https://webchat.freenode.net/?channels=librecad) at freenode.net
-
-**Building**
-
-Requirements:
-
-- [Qt](https://www.qt.io/download-open-source/) 5.2.1+ (MinGW version on Windows)
-- [Boost](https://www.boost.org/)
-
-More information: [Build from source](https://github.com/LibreCAD/LibreCAD/wiki/Build-from-source)
-
-**Contributing**
-
-[Git and GitHub](https://github.com/LibreCAD/LibreCAD/wiki/Git-and-GitHub)
-
-[Becoming a developer](https://github.com/LibreCAD/LibreCAD/wiki/Becoming-a-developer)
-
-There is a [resources repository](https://github.com/LibreCAD/Resources) for people that want to indirectly  
-contribute to the project by supplying icons, stylesheets, documentation, templates...
-
-Associated downloads: <https://sourceforge.net/projects/librecad/files/Resources/>
+```
+sudo apt update
+sudo apt-get install build-essential
+sudo apt-get install qtcreator
+sudo apt-get install qt5-default
+sudo apt-get install g++ gcc make git-core qtbase5-dev libqt5svg5-dev qttools5-dev qtchooser qttools5-dev-tools libmuparser-dev librsvg2-bin libboost-dev libfreetype6-dev libicu-dev pkg-config
+qmake -r
+make
+```

--- a/librecad/src/main/console_dxf2pdf/console_dxf2pdf.h
+++ b/librecad/src/main/console_dxf2pdf/console_dxf2pdf.h
@@ -26,4 +26,4 @@
 
 int console_dxf2pdf(int argc, char** argv);
 
-#endif
+#endif // CONSOLE_DXF2PDF_H

--- a/librecad/src/main/console_dxf2png.cpp
+++ b/librecad/src/main/console_dxf2png.cpp
@@ -1,0 +1,8 @@
+#include "main.h"
+
+#include "console_dxf2pdf.h"
+
+int console_dxf2png(int argc, char* argv[])
+{
+    return 0;
+}

--- a/librecad/src/main/console_dxf2png.cpp
+++ b/librecad/src/main/console_dxf2png.cpp
@@ -200,7 +200,8 @@ int console_dxf2png(int argc, char* argv[])
     bool ret = slotFileExport(graphic, fn, format, size, borders,
                 black, bw);
 
-    return app.exec();
+    qDebug() << "Printing" << dxfFile << "to" << outFile << "DONE";
+    return 0;
 }
 
 static bool openDocAndSetGraphic(RS_Document** doc, RS_Graphic** graphic,

--- a/librecad/src/main/console_dxf2png.cpp
+++ b/librecad/src/main/console_dxf2png.cpp
@@ -65,11 +65,20 @@ int console_dxf2png(int argc, char* argv[])
     appDesc += "\n\n";
     appDesc += "Examples:\n\n";
     appDesc += "  " + librecad + " dxf2png *.dxf";
-    appDesc += "    -- print all dxf files to a png file with the same name.\n";
+    appDesc += "    -- print a dxf file to a png file with the same name.\n";
     parser.setApplicationDescription(appDesc);
 
     parser.addHelpOption();
     parser.addVersionOption();
+
+    parser.addPositionalArgument("<dxf_files>", "Input DXF file");
+
+    parser.process(app);
+
+    const QStringList args = parser.positionalArguments();
+
+    if (args.isEmpty() || (args.size() == 1 && args[0] == "dxf2png"))
+        parser.showHelp(EXIT_FAILURE);
 
     return app.exec();
 }

--- a/librecad/src/main/console_dxf2png.cpp
+++ b/librecad/src/main/console_dxf2png.cpp
@@ -110,9 +110,13 @@ int console_dxf2png(int argc, char* argv[])
     QString& dxfFile = dxfFiles[0];
 
     QFileInfo dxfFileInfo(dxfFile);
+    QString fn = dxfFileInfo.completeBaseName();
 
     QString outFile = dxfFileInfo.path()
-            + "/" + dxfFileInfo.completeBaseName() + ".png";
+            + "/" + fn + ".png";
+
+    if(fn==nullptr)
+        fn = "unnamed";
 
     RS_Document *doc;
     RS_Graphic *graphic;
@@ -122,15 +126,12 @@ int console_dxf2png(int argc, char* argv[])
     // Start of the actual conversion
 
     RS_DEBUG->print("QC_ApplicationWindow::slotFileExport()");
-    QString fn;
 
     // read default settings:
     RS_SETTINGS->beginGroup("/Export");
     QString defDir = dxfFileInfo.path();
 
     RS_SETTINGS->endGroup();
-
-    bool cancel = false;
 
     QStringList filters;
     QList<QByteArray> supportedImageFormats = QImageWriter::supportedImageFormats();
@@ -153,6 +154,13 @@ int console_dxf2png(int argc, char* argv[])
     // revise list of filters
     filters.removeDuplicates();
     filters.sort();
+
+    // find out extension:
+    QString filter = "Portable Network Graphic (png)(*.png)";
+    QString format = "";
+
+
+
 
     return app.exec();
 }

--- a/librecad/src/main/console_dxf2png.cpp
+++ b/librecad/src/main/console_dxf2png.cpp
@@ -65,11 +65,11 @@ int console_dxf2png(int argc, char* argv[])
     appDesc += "\n\n";
     appDesc += "Examples:\n\n";
     appDesc += "  " + librecad + " dxf2png *.dxf";
-    appDesc += "    -- print all dxf files to pdf files with the same names.\n";
-    appDesc += "\n";
-    appDesc += "  " + librecad + " dxf2pdf -o some.pdf *.dxf";
-    appDesc += "    -- print all dxf files to 'some.pdf' file.";
+    appDesc += "    -- print all dxf files to a png file with the same name.\n";
     parser.setApplicationDescription(appDesc);
+
+    parser.addHelpOption();
+    parser.addVersionOption();
 
     return app.exec();
 }

--- a/librecad/src/main/console_dxf2png.cpp
+++ b/librecad/src/main/console_dxf2png.cpp
@@ -80,5 +80,24 @@ int console_dxf2png(int argc, char* argv[])
     if (args.isEmpty() || (args.size() == 1 && args[0] == "dxf2png"))
         parser.showHelp(EXIT_FAILURE);
 
+    for (auto arg : args) {
+        QFileInfo dxfFileInfo(arg);
+        if (dxfFileInfo.suffix().toLower() != "dxf")
+            continue; // Skip files without .dxf extension
+        params.dxfFiles.append(arg);
+    }
+
+    if (params.dxfFiles.isEmpty())
+        parser.showHelp(EXIT_FAILURE);
+
+    if (!params.outDir.isEmpty()) {
+        // Create output directory
+        if (!QDir().mkpath(params.outDir)) {
+            qDebug() << "ERROR: Cannot create directory" << params.outDir;
+            return EXIT_FAILURE;
+        }
+    }
+
+
     return app.exec();
 }

--- a/librecad/src/main/console_dxf2png.cpp
+++ b/librecad/src/main/console_dxf2png.cpp
@@ -138,7 +138,7 @@ int console_dxf2png(int argc, char* argv[])
     RS_Graphic *graphic;
 
     if (!openDocAndSetGraphic(&doc, &graphic, dxfFile))
-        app.exec();
+        app.exit();
 
     qDebug() << "Printing" << dxfFile << "to" << outFile << ">>>>";
 
@@ -171,7 +171,6 @@ int console_dxf2png(int argc, char* argv[])
         if (st.length()>0)
             filters.push_back(st);
     }
-
     // revise list of filters
     filters.removeDuplicates();
     filters.sort();
@@ -200,7 +199,6 @@ int console_dxf2png(int argc, char* argv[])
 
     bool ret = slotFileExport(graphic, fn, format, size, borders,
                 black, bw);
-
 
     return app.exec();
 }

--- a/librecad/src/main/console_dxf2png.cpp
+++ b/librecad/src/main/console_dxf2png.cpp
@@ -1,8 +1,75 @@
+/******************************************************************************
+**
+** This file was created for the LibreCAD project, a 2D CAD program.
+**
+** Copyright (C) 2020 Nikita Letov <letovnn@gmail.com>
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU General Public License version 2 as published by the Free Software
+** Foundation and appearing in the file gpl-2.0.txt included in the
+** packaging of this file.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+**
+** This copyright notice MUST APPEAR in all copies of the script!
+**
+******************************************************************************/
+
+
+#include <QtCore>
+#include <QCoreApplication>
+#include <QApplication>
+
+#include "rs_debug.h"
+#include "rs_fontlist.h"
+#include "rs_patternlist.h"
+#include "rs_settings.h"
+#include "rs_system.h"
+
 #include "main.h"
 
 #include "console_dxf2pdf.h"
 
 int console_dxf2png(int argc, char* argv[])
 {
-    return 0;
+    RS_DEBUG->setLevel(RS_Debug::D_NOTHING);
+
+    QApplication app(argc, argv);
+    QCoreApplication::setOrganizationName("LibreCAD");
+    QCoreApplication::setApplicationName("LibreCAD");
+    QCoreApplication::setApplicationVersion(XSTR(LC_VERSION));
+
+    QFileInfo prgInfo(QFile::decodeName(argv[0]));
+    QString prgDir(prgInfo.absolutePath());
+    RS_SETTINGS->init(app.organizationName(), app.applicationName());
+    RS_SYSTEM->init(app.applicationName(), app.applicationVersion(),
+        XSTR(QC_APPDIR), prgDir);
+
+    QCommandLineParser parser;
+
+    QString appDesc;
+    QString librecad;
+    if (prgInfo.baseName() != "dxf2png") {
+        librecad = prgInfo.filePath();
+        appDesc = "\ndxf2png usage: " + prgInfo.filePath()
+            + " dxf2png [options] <dxf_files>\n";
+    }
+    appDesc += "\nPrint a DXF file to a PNG file.";
+    appDesc += "\n\n";
+    appDesc += "Examples:\n\n";
+    appDesc += "  " + librecad + " dxf2png *.dxf";
+    appDesc += "    -- print all dxf files to pdf files with the same names.\n";
+    appDesc += "\n";
+    appDesc += "  " + librecad + " dxf2pdf -o some.pdf *.dxf";
+    appDesc += "    -- print all dxf files to 'some.pdf' file.";
+    parser.setApplicationDescription(appDesc);
+
+    return app.exec();
 }

--- a/librecad/src/main/console_dxf2png.cpp
+++ b/librecad/src/main/console_dxf2png.cpp
@@ -135,7 +135,7 @@ int console_dxf2png(int argc, char* argv[])
     QString outFile = dxfFileInfo.path()
             + "/" + fn + ".png";
 
-    if(fn==nullptr)
+    if(fn == nullptr)
         fn = "unnamed";
 
     // Open the file and process the graphics
@@ -167,7 +167,7 @@ int console_dxf2png(int argc, char* argv[])
     for (QString format: supportedImageFormats) {
         format = format.toLower();
         QString st;
-        if (format=="jpeg" || format=="tiff") {
+        if (format == "jpeg" || format == "tiff") {
             // Don't add the aliases
         } else {
             st = QString("%1 (%2)(*.%2)")
@@ -196,10 +196,8 @@ int console_dxf2png(int argc, char* argv[])
         fn.push_back("." + format.toLower());
     }
 
-    QSize size = QSize(RS_Math::round(RS_Math::eval("2000")),
-                       RS_Math::round(RS_Math::eval("1000")));;
-    QSize borders = QSize(RS_Math::round(RS_Math::eval("5")),
-                          RS_Math::round(RS_Math::eval("5")));;
+    QSize size = QSize(2000, 1000);
+    QSize borders = QSize(5, 5);
     bool black = false;
     bool bw = false;
 
@@ -212,7 +210,7 @@ int console_dxf2png(int argc, char* argv[])
 
 
 static bool openDocAndSetGraphic(RS_Document** doc, RS_Graphic** graphic,
-    QString& dxfFile)
+                                 QString& dxfFile)
 {
     *doc = new RS_Graphic();
 

--- a/librecad/src/main/console_dxf2png.cpp
+++ b/librecad/src/main/console_dxf2png.cpp
@@ -27,6 +27,12 @@
 #include <QCoreApplication>
 #include <QApplication>
 
+#include "rs.h"
+#include "rs_graphic.h"
+#include "rs_painterqt.h"
+#include "lc_printing.h"
+#include "rs_staticgraphicview.h"
+
 #include "rs_debug.h"
 #include "rs_fontlist.h"
 #include "rs_patternlist.h"
@@ -91,6 +97,19 @@ int console_dxf2png(int argc, char* argv[])
 
     if (dxfFiles.isEmpty())
         parser.showHelp(EXIT_FAILURE);
+
+
+    // Start of the actual conversion
+
+    bool ret = false;
+    QString& dxfFile = dxfFiles[0];
+
+    QFileInfo dxfFileInfo(dxfFile);
+
+    QString outFile = dxfFileInfo.path()
+            + "/" + dxfFileInfo.completeBaseName() + ".png";
+
+    qDebug() << "Printing" << dxfFile << "to" << outFile << ">>>>";
 
     return app.exec();
 }

--- a/librecad/src/main/console_dxf2png.cpp
+++ b/librecad/src/main/console_dxf2png.cpp
@@ -63,7 +63,6 @@ bool slotFileExport(RS_Graphic* graphic,
                     bool black,
                     bool bw=true);
 
-
 int console_dxf2png(int argc, char* argv[])
 {
     RS_DEBUG->setLevel(RS_Debug::D_NOTHING);

--- a/librecad/src/main/console_dxf2png.cpp
+++ b/librecad/src/main/console_dxf2png.cpp
@@ -80,24 +80,17 @@ int console_dxf2png(int argc, char* argv[])
     if (args.isEmpty() || (args.size() == 1 && args[0] == "dxf2png"))
         parser.showHelp(EXIT_FAILURE);
 
+    QStringList dxfFiles;
+
     for (auto arg : args) {
         QFileInfo dxfFileInfo(arg);
         if (dxfFileInfo.suffix().toLower() != "dxf")
             continue; // Skip files without .dxf extension
-        params.dxfFiles.append(arg);
+        dxfFiles.append(arg);
     }
 
-    if (params.dxfFiles.isEmpty())
+    if (dxfFiles.isEmpty())
         parser.showHelp(EXIT_FAILURE);
-
-    if (!params.outDir.isEmpty()) {
-        // Create output directory
-        if (!QDir().mkpath(params.outDir)) {
-            qDebug() << "ERROR: Cannot create directory" << params.outDir;
-            return EXIT_FAILURE;
-        }
-    }
-
 
     return app.exec();
 }

--- a/librecad/src/main/console_dxf2png.cpp
+++ b/librecad/src/main/console_dxf2png.cpp
@@ -53,7 +53,14 @@
 
 #include "console_dxf2pdf.h"
 
+///////////////////////////////////////////////////////////////////////
+/// \brief openDocAndSetGraphic opens a DXF file and prepares all its graphics content
+/// for further manipulations
+/// \return
+//////////////////////////////////////////////////////////////////////
 static bool openDocAndSetGraphic(RS_Document**, RS_Graphic**, QString&);
+
+
 static void touchGraphic(RS_Graphic*);
 bool slotFileExport(RS_Graphic* graphic,
                     const QString& name,
@@ -137,7 +144,7 @@ int console_dxf2png(int argc, char* argv[])
     RS_Graphic *graphic;
 
     if (!openDocAndSetGraphic(&doc, &graphic, dxfFile))
-        app.exit();
+        return 1;
 
     qDebug() << "Printing" << dxfFile << "to" << outFile << ">>>>";
 
@@ -203,6 +210,7 @@ int console_dxf2png(int argc, char* argv[])
     return 0;
 }
 
+
 static bool openDocAndSetGraphic(RS_Document** doc, RS_Graphic** graphic,
     QString& dxfFile)
 {
@@ -210,6 +218,7 @@ static bool openDocAndSetGraphic(RS_Document** doc, RS_Graphic** graphic,
 
     if (!(*doc)->open(dxfFile, RS2::FormatUnknown)) {
         qDebug() << "ERROR: Failed to open document" << dxfFile;
+        qDebug() << "Check if file exists";
         delete *doc;
         return false;
     }

--- a/librecad/src/main/console_dxf2png.h
+++ b/librecad/src/main/console_dxf2png.h
@@ -24,30 +24,6 @@
 #ifndef CONSOLE_DXF2PNG_H
 #define CONSOLE_DXF2PNG_H
 
-struct PngPrintParams {
-        QStringList dxfFiles;
-        QString outDir;
-        QString outFile;
-        int resolution = 1200;
-        bool centerOnPage;
-        bool fitToPage;
-        bool monochrome;
-        bool grayscale;
-        double scale = 0.0;  // If scale <= 0.0, use value from dxf file.
-        RS_Vector pageSize;  // If zeros, use value from dxf file.
-        struct {
-            double left = -1.0;
-            double top = -1.0;
-            double right = -1.0;
-            double bottom = -1.0;
-        } margins;           // If margin < 0.0, use value from dxf file.
-        int pagesH = 0;      // If number of pages < 1,
-        int pagesV = 0;      // use value from dxf file.
-};
-
-
 int console_dxf2png(int argc, char** argv);
-
-
 
 #endif // CONSOLE_DXF2PNG_H

--- a/librecad/src/main/console_dxf2png.h
+++ b/librecad/src/main/console_dxf2png.h
@@ -48,4 +48,6 @@ struct PngPrintParams {
 
 int console_dxf2png(int argc, char** argv);
 
+
+
 #endif // CONSOLE_DXF2PNG_H

--- a/librecad/src/main/console_dxf2png.h
+++ b/librecad/src/main/console_dxf2png.h
@@ -24,6 +24,28 @@
 #ifndef CONSOLE_DXF2PNG_H
 #define CONSOLE_DXF2PNG_H
 
+struct PngPrintParams {
+        QStringList dxfFiles;
+        QString outDir;
+        QString outFile;
+        int resolution = 1200;
+        bool centerOnPage;
+        bool fitToPage;
+        bool monochrome;
+        bool grayscale;
+        double scale = 0.0;  // If scale <= 0.0, use value from dxf file.
+        RS_Vector pageSize;  // If zeros, use value from dxf file.
+        struct {
+            double left = -1.0;
+            double top = -1.0;
+            double right = -1.0;
+            double bottom = -1.0;
+        } margins;           // If margin < 0.0, use value from dxf file.
+        int pagesH = 0;      // If number of pages < 1,
+        int pagesV = 0;      // use value from dxf file.
+};
+
+
 int console_dxf2png(int argc, char** argv);
 
 #endif // CONSOLE_DXF2PNG_H

--- a/librecad/src/main/console_dxf2png.h
+++ b/librecad/src/main/console_dxf2png.h
@@ -1,0 +1,11 @@
+/******************************************************************************
+**
+** Copyright (C) 2018 Nikita Letov <letovnn@gmail.com>
+**
+******************************************************************************/
+#ifndef CONSOLE_DXF2PNG_H
+#define CONSOLE_DXF2PNG_H
+
+int console_dxf2png(int argc, char** argv);
+
+#endif // CONSOLE_DXF2PNG_H

--- a/librecad/src/main/console_dxf2png.h
+++ b/librecad/src/main/console_dxf2png.h
@@ -1,6 +1,24 @@
 /******************************************************************************
 **
-** Copyright (C) 2018 Nikita Letov <letovnn@gmail.com>
+** This file was created for the LibreCAD project, a 2D CAD program.
+**
+** Copyright (C) 2020 Nikita Letov <letovnn@gmail.com>
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU General Public License version 2 as published by the Free Software
+** Foundation and appearing in the file gpl-2.0.txt included in the
+** packaging of this file.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+**
+** This copyright notice MUST APPEAR in all copies of the script!
 **
 ******************************************************************************/
 #ifndef CONSOLE_DXF2PNG_H

--- a/librecad/src/main/main.cpp
+++ b/librecad/src/main/main.cpp
@@ -75,6 +75,9 @@ int main(int argc, char** argv)
         if (arg.compare("dxf2pdf") == 0) {
             return console_dxf2pdf(argc, argv);
         }
+        if (arg.compare("dxf2png") == 0) {
+            return console_dxf2png(argc, argv);
+        }
     }
 
     RS_DEBUG->setLevel(RS_Debug::D_WARNING);
@@ -112,6 +115,7 @@ int main(int argc, char** argv)
             qDebug()<<"Commands:";
             qDebug()<<"";
             qDebug()<<"  dxf2pdf\tRun librecad as console dxf2pdf tool. Use -h for help.";
+            qDebug()<<"  dxf2png\tRun librecad as console dxf2png tool. Use -h for help.";
             qDebug()<<"";
             qDebug()<<"Options:";
             qDebug()<<"";

--- a/librecad/src/main/main.cpp
+++ b/librecad/src/main/main.cpp
@@ -58,8 +58,8 @@ int main(int argc, char** argv)
     QT_REQUIRE_VERSION(argc, argv, "5.2.1");
 
     // Check first two arguments in order to decide if we want to run librecad
-    // as console dxf2pdf tool. On Linux we can create a link to librecad
-    // executable and  name it dxf2pdf. So, we can run either:
+    // as console dxf2pdf or dxf2png tools. On Linux we can create a link to
+    // librecad executable and  name it dxf2pdf. So, we can run either:
     //
     //     librecad dxf2pdf [options] ...
     //
@@ -75,7 +75,7 @@ int main(int argc, char** argv)
         if (arg.compare("dxf2pdf") == 0) {
             return console_dxf2pdf(argc, argv);
         }
-        if (arg.compare("dxf2png") == 0) {
+        else if (arg.compare("dxf2png") == 0) {
             return console_dxf2png(argc, argv);
         }
     }

--- a/librecad/src/main/main.cpp
+++ b/librecad/src/main/main.cpp
@@ -4,6 +4,7 @@
 **
 ** Copyright (C) 2018 A. Stebich (librecad@mail.lordofbikes.de)
 ** Copyright (C) 2018 Simon Wells <simonrwells@gmail.com>
+** Copyright (C) 2020 Nikita Letov <letovnn@gmail.com>
 ** Copyright (C) 2015-2016 ravas (github.com/r-a-v-a-s)
 ** Copyright (C) 2010 R. van Twisk (librecad@rvt.dds.nl)
 ** Copyright (C) 2001-2003 RibbonSoft. All rights reserved.
@@ -46,6 +47,7 @@
 #include "rs_debug.h"
 
 #include "console_dxf2pdf.h"
+#include "console_dxf2png.h"
 
 
 /**

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -2072,6 +2072,12 @@ void QC_ApplicationWindow::slotFileExport() {
             w->getGraphic()->calculateBorders();
             dlg.setGraphicSize(w->getGraphic()->getSize()*2.);
             if (dlg.exec()) {
+
+                QSize size = dlg.getSize();
+                QSize borders = dlg.getBorders();
+                bool black = dlg.isBackgroundBlack();
+                bool bw = dlg.isBlackWhite();
+
                 bool ret = slotFileExport(fn, format, dlg.getSize(), dlg.getBorders(),
                             dlg.isBackgroundBlack(), dlg.isBlackWhite());
                 if (ret) {

--- a/librecad/src/src.pro
+++ b/librecad/src/src.pro
@@ -210,6 +210,7 @@ HEADERS += \
     lib/math/rs_math.h \
     lib/math/lc_quadratic.h \
     actions/lc_actiondrawcircle2pr.h \
+    main/console_dxf2png.h \
     test/lc_simpletests.h \
     lib/generators/lc_makercamsvg.h \
     lib/generators/lc_xmlwriterinterface.h \
@@ -298,6 +299,7 @@ SOURCES += \
     lib/engine/rs_color.cpp \
     lib/engine/rs_pen.cpp \
     actions/lc_actiondrawcircle2pr.cpp \
+    main/console_dxf2png.cpp \
     test/lc_simpletests.cpp \
     lib/generators/lc_xmlwriterqxmlstreamwriter.cpp \
     lib/generators/lc_makercamsvg.cpp \


### PR DESCRIPTION
Added an option to run LibreCAD as console dxf2png tool which converts DXF files to PNG. Works similarly to the already existing dxf2pdf tool, though able to take only one DXF file as an input at a time (because there is no reason to make multipage PDF as the output is an image). 

Can be ran as `./librecad dxf2png file_name.dxf`. The output file is saved in the executable folder under the name of `file_name.png`. The default resolution is 2000x1000 but can be customized as `./librecad dxf2png file_name.dxf -r <WxH>`. The output filename would be `file_name.png` if not customized as follows: `./librecad dxf2png file_name.dxf -o <output.png>`. 

The GIF animation attached shows how it works.
![Screencast from 2020-12-02 12_24_38 PM](https://user-images.githubusercontent.com/22379984/100935646-5cc86680-34be-11eb-93c8-6d7e7a5b2ad3.gif)
