### PR TITLE
List entities plugin: Add text insertion point and text content to its output

### DIFF
--- a/plugins/list/list.cpp
+++ b/plugins/list/list.cpp
@@ -177,6 +177,10 @@ QString LC_List::getStrData(Plug_Entity *ent) {
         break;
     case DPI::TEXT:
         strData.prepend( strEntity.arg(tr("TEXT")));
+	strData.append( strSpecificXY.arg(tr("in point")).
+                        arg(d->realToStr(data.value(DPI::STARTX).toDouble())).
+                        arg(d->realToStr(data.value(DPI::STARTY).toDouble())));
+	strData.append(strSpecific.arg(tr("TEXTCONTENT")).arg(data.value(DPI::TEXTCONTENT).toString()));
         break;
     case DPI::INSERT:
         strData.prepend( strEntity.arg(tr("INSERT")));


### PR DESCRIPTION
Currently the Height value of a point imported via the asciifile plugin only could be stored as a text near the point.
This commit would allow the List Entities plugin to retrieve the point of insertion of any text plus the text contents.
That would make possible to, via an apropiate script, correlate a point with its text height value.
HTH
Pere