### PR TITLE
Widget spacer

### DIFF
--- a/librecad/src/cmd/rs_commands.cpp
+++ b/librecad/src/cmd/rs_commands.cpp
@@ -206,7 +206,7 @@ RS_Commands::RS_Commands() {
 	//draw circle with point and radius
 	{
 		{{"circlecr", QObject::tr("circlecr", "circle with center and radius")}},
-		{{"cc", QObject::tr("cc", "circle with center and radius")}},
+		{{"cr", QObject::tr("cr", "circle with center and radius")}},
 		RS2::ActionDrawCircleCR
 	},
         //draw circle tangent to 3 objects

--- a/librecad/src/ui/lc_widgetfactory.cpp
+++ b/librecad/src/ui/lc_widgetfactory.cpp
@@ -244,20 +244,22 @@ void LC_WidgetFactory::createLeftSidebar(int columns, int icon_size)
 
     // 'spacer' dock fills out dock area to prevent expansion of previous dock
     LC_DockWidget* dock_spacer = new LC_DockWidget(main_window);
-    dock_info->setObjectName("dock_spacer");
+    dock_spacer->setObjectName("dock_spacer");
+    dock_spacer->setFeatures(QDockWidget::NoDockWidgetFeatures);
 
     main_window->addDockWidget(Qt::LeftDockWidgetArea, dock_line);
     main_window->tabifyDockWidget(dock_line, dock_polyline);
-    dock_line->raise();
+    //dock_line->raise();
     main_window->addDockWidget(Qt::LeftDockWidgetArea, dock_circle);
     main_window->tabifyDockWidget(dock_circle, dock_curve);
     main_window->tabifyDockWidget(dock_curve, dock_ellipse);
-    dock_circle->raise();
+    //dock_circle->raise();
     main_window->addDockWidget(Qt::LeftDockWidgetArea, dock_dimension);
     main_window->tabifyDockWidget(dock_dimension, dock_info);
-    main_window->tabifyDockWidget(dock_info, dock_select);
-    dock_dimension->raise();
+    //dock_dimension->raise();
     main_window->addDockWidget(Qt::LeftDockWidgetArea, dock_modify);
+    main_window->tabifyDockWidget(dock_info, dock_select);
+    //dock_modify->raise();
     main_window->addDockWidget(Qt::LeftDockWidgetArea, dock_spacer);
     //dock_spacer->raise();
 
@@ -270,6 +272,7 @@ void LC_WidgetFactory::createLeftSidebar(int columns, int icon_size)
     dock_info->hide();
     dock_modify->hide();
     dock_select->hide();
+    dock_spacer->hide();
 }
 
 void LC_WidgetFactory::createRightSidebar(QG_ActionHandler* action_handler)

--- a/librecad/src/ui/lc_widgetfactory.cpp
+++ b/librecad/src/ui/lc_widgetfactory.cpp
@@ -242,6 +242,11 @@ void LC_WidgetFactory::createLeftSidebar(int columns, int icon_size)
     dock_info->setWindowTitle(QC_ApplicationWindow::tr("Info"));
     dock_info->add_actions(info_actions, columns, icon_size);
 
+    LC_DockWidget* dock_spacer = new LC_DockWidget(main_window);
+    dock_info->setObjectName("dock_spacer");
+    //dock_info->setWindowTitle(QC_ApplicationWindow::tr("Info"));
+    //dock_info->add_actions(info_actions, columns, icon_size);
+
     main_window->addDockWidget(Qt::LeftDockWidgetArea, dock_line);
     main_window->tabifyDockWidget(dock_line, dock_polyline);
     dock_line->raise();
@@ -254,6 +259,8 @@ void LC_WidgetFactory::createLeftSidebar(int columns, int icon_size)
     main_window->tabifyDockWidget(dock_info, dock_select);
     dock_dimension->raise();
     main_window->addDockWidget(Qt::LeftDockWidgetArea, dock_modify);
+    main_window->addDockWidget(Qt::LeftDockWidgetArea, dock_spacer);
+    dock_spacer->raise();
 
     dock_line->hide();
     dock_polyline->hide();

--- a/librecad/src/ui/lc_widgetfactory.cpp
+++ b/librecad/src/ui/lc_widgetfactory.cpp
@@ -136,7 +136,9 @@ LC_WidgetFactory::LC_WidgetFactory(QC_ApplicationWindow* main_win,
             << a_map["DimRadial"]
             << a_map["DimDiametric"]
             << a_map["DimAngular"]
-            << a_map["DimLeader"];
+            << a_map["DimLeader"]
+            << a_map["DrawMText"]
+            << a_map["DrawText"];
 
     modify_actions
             << a_map["ModifyMove"]
@@ -158,7 +160,8 @@ LC_WidgetFactory::LC_WidgetFactory(QC_ApplicationWindow* main_win,
             << a_map["ModifyAttributes"]
             << a_map["ModifyExplodeText"]
             << a_map["BlocksExplode"]
-            << a_map["ModifyDeleteQuick"];
+            << a_map["ModifyDeleteQuick"]
+            << a_map["DrawHatch"];
 
     info_actions
             << a_map["InfoDist"]

--- a/librecad/src/ui/lc_widgetfactory.cpp
+++ b/librecad/src/ui/lc_widgetfactory.cpp
@@ -259,7 +259,7 @@ void LC_WidgetFactory::createLeftSidebar(int columns, int icon_size)
     dock_dimension->raise();
     main_window->addDockWidget(Qt::LeftDockWidgetArea, dock_modify);
     main_window->addDockWidget(Qt::LeftDockWidgetArea, dock_spacer);
-    dock_spacer->raise();
+    //dock_spacer->raise();
 
     dock_line->hide();
     dock_polyline->hide();

--- a/librecad/src/ui/lc_widgetfactory.cpp
+++ b/librecad/src/ui/lc_widgetfactory.cpp
@@ -242,10 +242,9 @@ void LC_WidgetFactory::createLeftSidebar(int columns, int icon_size)
     dock_info->setWindowTitle(QC_ApplicationWindow::tr("Info"));
     dock_info->add_actions(info_actions, columns, icon_size);
 
+    // 'spacer' dock fills out dock area to prevent expansion of previous dock
     LC_DockWidget* dock_spacer = new LC_DockWidget(main_window);
     dock_info->setObjectName("dock_spacer");
-    //dock_info->setWindowTitle(QC_ApplicationWindow::tr("Info"));
-    //dock_info->add_actions(info_actions, columns, icon_size);
 
     main_window->addDockWidget(Qt::LeftDockWidgetArea, dock_line);
     main_window->tabifyDockWidget(dock_line, dock_polyline);


### PR DESCRIPTION
When using the dock areas (specifically the left area) for dock widgets, the widgets expand to fill the available area and results in the icons being spread out over the dock area.  Adding additional dock widgets will fill the area and reduce the amount of space between icons, but may require more dock widgets than are available (notably on HiDPI displays).

This PR adds an empty 'spacer' widget to the left dock area.  The added widget has no icons or any other decorations / features, but is simply to fill the empty space within the left dock area.  The spacer widget can be resized to prevent the other docks from expanding and spreading out the icons.