### PR TITLE
add boost tuple include to fix build

### DIFF
--- a/librecad/src/lib/engine/rs_ellipse.cpp
+++ b/librecad/src/lib/engine/rs_ellipse.cpp
@@ -48,6 +48,9 @@
 #include <boost/version.hpp>
 #include <boost/math/tools/roots.hpp>
 #include <boost/math/special_functions/ellint_2.hpp>
+#if BOOST_VERSION > 104500
+#include <boost/math/tools/tuple.hpp>
+#endif
 #endif
 
 namespace{


### PR DESCRIPTION
With boost 1.76, we see:
```
lib/engine/rs_ellipse.cpp:70:15: error: 'tuple' in namespace 'boost::math' does not name a template type
   70 |  boost::math::tuple<double, double, double> operator()(double const& z) const {
      |               ^~~~~
```
Fix this by including the proper boost header.