### PR TITLE
fix: increase maximum sizes of statusbar widgets to accommodate hidpi

### DIFF
--- a/librecad/src/ui/forms/qg_activelayername.ui
+++ b/librecad/src/ui/forms/qg_activelayername.ui
@@ -24,8 +24,8 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>240</width>
-    <height>50</height>
+    <width>600</width>
+    <height>160</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -57,7 +57,7 @@
      </property>
      <property name="maximumSize">
       <size>
-       <width>120</width>
+       <width>500</width>
        <height>16777215</height>
       </size>
      </property>
@@ -82,7 +82,7 @@
     <widget class="QLabel" name="lActiveLayerName">
      <property name="maximumSize">
       <size>
-       <width>120</width>
+       <width>500</width>
        <height>16777215</height>
       </size>
      </property>

--- a/librecad/src/ui/forms/qg_coordinatewidget.ui
+++ b/librecad/src/ui/forms/qg_coordinatewidget.ui
@@ -24,8 +24,8 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>500</width>
-    <height>50</height>
+    <width>1500</width>
+    <height>160</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/librecad/src/ui/forms/qg_mousewidget.ui
+++ b/librecad/src/ui/forms/qg_mousewidget.ui
@@ -25,7 +25,7 @@
   <property name="maximumSize">
    <size>
     <width>500</width>
-    <height>50</height>
+    <height>80</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -64,7 +64,7 @@
      <property name="maximumSize">
       <size>
        <width>32767</width>
-       <height>28</height>
+       <height>80</height>
       </size>
      </property>
      <property name="text">
@@ -95,7 +95,7 @@
      <property name="maximumSize">
       <size>
        <width>32767</width>
-       <height>28</height>
+       <height>80</height>
       </size>
      </property>
      <property name="frameShape">

--- a/librecad/src/ui/forms/qg_selectionwidget.ui
+++ b/librecad/src/ui/forms/qg_selectionwidget.ui
@@ -24,8 +24,8 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>240</width>
-    <height>50</height>
+    <width>800</width>
+    <height>160</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -60,7 +60,7 @@
      </property>
      <property name="maximumSize">
       <size>
-       <width>120</width>
+       <width>600</width>
        <height>16777215</height>
       </size>
      </property>
@@ -88,7 +88,7 @@
      </property>
      <property name="maximumSize">
       <size>
-       <width>120</width>
+       <width>600</width>
        <height>16777215</height>
       </size>
      </property>
@@ -110,7 +110,7 @@
     <widget class="QLabel" name="lEntities">
      <property name="maximumSize">
       <size>
-       <width>120</width>
+       <width>600</width>
        <height>16777215</height>
       </size>
      </property>
@@ -142,7 +142,7 @@ p, li { white-space: pre-wrap; }
     <widget class="QLabel" name="lTotalLength">
      <property name="maximumSize">
       <size>
-       <width>120</width>
+       <width>600</width>
        <height>16777215</height>
       </size>
      </property>


### PR DESCRIPTION
  Since all of these widgets shrink to fit their content anyway, there is
  really no downside to larger maximum sizes, and they prevent the text
  content of the widgets from being clipped on hidpi displays.