### PR TITLE
fix: now it is possible to cancel the close process.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ LibreCAD.pbproj/
 LibreCAD.dmg
 Info.plist
 
+#CLion internal directory
+.idea/
+
 # globs, anywhere
 *.o
 *.lo

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -2193,7 +2193,7 @@ bool QC_ApplicationWindow::slotFileExport(const QString& name,
  * If modified, show the Save/Close/Cancel dialog, then do the request.
  * If a save is needed but the user cancels, the window is not closed.
  */
-void QC_ApplicationWindow::slotFileClosing(QC_MDIWindow* win)
+bool QC_ApplicationWindow::slotFileClosing(QC_MDIWindow* win)
 {
     RS_DEBUG->print("QC_ApplicationWindow::slotFileClosing()");
 	bool cancel = false;
@@ -2208,11 +2208,11 @@ void QC_ApplicationWindow::slotFileClosing(QC_MDIWindow* win)
 			break;
 		}
 	}
-	if (!cancel)
-	{
+	if (!cancel) {
 		doClose(win);
 		doArrangeWindows(RS2::CurrentMode);
 	}
+	return !cancel;
 }
 
 /**

--- a/librecad/src/main/qc_applicationwindow.h
+++ b/librecad/src/main/qc_applicationwindow.h
@@ -163,8 +163,8 @@ public slots:
                         QSize borders,
                         bool black,
                         bool bw=true);
-    /** closing the current file */
-    void slotFileClosing(QC_MDIWindow*);
+    /** closing the current file; return false == operation cancelled */
+    bool slotFileClosing(QC_MDIWindow*);
 	/** close all files; return false == operation cancelled */
 	bool slotFileCloseAll();
     /** prints the current file */

--- a/librecad/src/main/qc_mdiwindow.cpp
+++ b/librecad/src/main/qc_mdiwindow.cpp
@@ -227,8 +227,13 @@ QC_MDIWindow* QC_MDIWindow::getPrintPreview() {
 void QC_MDIWindow::closeEvent(QCloseEvent* ce) {
     RS_DEBUG->print("QC_MDIWindow::closeEvent begin");
 
-    emit(signalClosing(this));
-    ce->accept(); // handling delegated to QApplication
+    auto accepted =  emit signalClosing(this) ;
+    if (accepted) {
+        ce->accept();
+    }
+    else {
+        ce->ignore();
+    }
 
     RS_DEBUG->print("QC_MDIWindow::closeEvent end");
 }

--- a/librecad/src/main/qc_mdiwindow.h
+++ b/librecad/src/main/qc_mdiwindow.h
@@ -115,7 +115,7 @@ public:
     bool has_children();
 
 signals:
-    void signalClosing(QC_MDIWindow*);
+    bool signalClosing(QC_MDIWindow*);
 
 protected:
     void closeEvent(QCloseEvent*);


### PR DESCRIPTION
Hi,

I found a bug about closing an MDI window. The File Close dialog always closed the current window even if the user clicked the cancel button. If the user opened a drawing a few times, added something, closed the drawing without saving and canceled the closing, the whole application crashed.

I think my changes fix the bug.