### PR TITLE
Fix #1388 - Allow entering radius in command box

### DIFF
--- a/librecad/src/actions/rs_actionmodifyround.cpp
+++ b/librecad/src/actions/rs_actionmodifyround.cpp
@@ -323,10 +323,10 @@ void RS_ActionModifyRound::updateMouseButtonHints() {
 		RS_DIALOGFACTORY->updateMouseWidget(tr("Specify second entity"),
 											tr("Back"));
 		break;
-	    case SetRadius:
-            RS_DIALOGFACTORY->updateMouseWidget(tr("Enter radius:"),
-                                                tr("Cancel"));
-            break;
+    case SetRadius:
+        RS_DIALOGFACTORY->updateMouseWidget(tr("Enter radius:"),
+                                            tr("Cancel"));
+        break;
 		/*case SetTrim:
 				RS_DIALOGFACTORY->updateMouseWidget(tr("Trim on? (yes/no):"),
 													"");


### PR DESCRIPTION
I've added an `else` block on the back of the command handler to detect a radius, like the `offset` command.

https://github.com/LibreCAD/LibreCAD/blob/415f8fcbe4e8b256884c17da344b0fadc901a023/librecad/src/actions/rs_actiondrawlineparallel.cpp#L172-L177

It does duplicate the code required for the `radius` subcommand, but I didn't want to remove that.

Also updated the tooltip to say you can enter the radius, and what the current radius is (also like the offset command).

I think this affects translations, but I don't know how to fix that.