### PR TITLE
Set text height in textoptions

### DIFF
--- a/librecad/src/actions/rs_actiondrawmtext.cpp
+++ b/librecad/src/actions/rs_actiondrawmtext.cpp
@@ -294,5 +294,13 @@ double RS_ActionDrawMText::getAngle() {
 	return data->angle;
 }
 
+void RS_ActionDrawMText::setHeight(double h) {
+    data->height = h;
+    textChanged = true;
+}
+
+double RS_ActionDrawMText::getHeight() const {
+    return data->height;
+}
 
 // EOF

--- a/librecad/src/actions/rs_actiondrawmtext.h
+++ b/librecad/src/actions/rs_actiondrawmtext.h
@@ -79,6 +79,9 @@ public:
         void setAngle(double a);
         double getAngle();
 
+        void setHeight(double h);
+        double getHeight() const;
+
 private:
 	std::unique_ptr<RS_MTextData> data;
         //RS_Text* text;

--- a/librecad/src/actions/rs_actiondrawtext.cpp
+++ b/librecad/src/actions/rs_actiondrawtext.cpp
@@ -323,5 +323,13 @@ double RS_ActionDrawText::getAngle() const{
 	return data->angle;
 }
 
+void RS_ActionDrawText::setHeight(double h) {
+    data->height = h;
+    textChanged = true;
+}
+
+double RS_ActionDrawText::getHeight() const{
+    return data->height;
+}
 
 // EOF

--- a/librecad/src/actions/rs_actiondrawtext.h
+++ b/librecad/src/actions/rs_actiondrawtext.h
@@ -80,6 +80,9 @@ public:
 	void setAngle(double a);
 	double getAngle() const;
 
+	void setHeight(double h);
+	double getHeight() const;
+
 private:
 	struct Points;
 	std::unique_ptr<Points> pPoints;

--- a/librecad/src/ui/forms/qg_mtextoptions.cpp
+++ b/librecad/src/ui/forms/qg_mtextoptions.cpp
@@ -61,12 +61,15 @@ void QG_MTextOptions::setAction(RS_ActionInterface* a, bool update) {
 
         QString st;
         QString sa;
+        QString ss;
         if (update) {
             st = action->getText();
             sa = QString("%1").arg(RS_Math::rad2deg(action->getAngle()));
+            ss = QString("%1").arg(action->getHeight());
         } else {
             st = "";
             sa = "0.0";
+            ss = "0.0";
         }
 
 /*#if defined(OOPL_VERSION) && defined(Q_WS_WIN)
@@ -81,6 +84,7 @@ void QG_MTextOptions::setAction(RS_ActionInterface* a, bool update) {
 		ui->teText->setText(st);
 //#endif
 		ui->leAngle->setText(sa);
+        ui->leHeight->setText(ss);
     } else {
         RS_DEBUG->print(RS_Debug::D_ERROR,
 			"QG_TextOptions::setAction: wrong action type");
@@ -107,5 +111,11 @@ void QG_MTextOptions::updateText() {
 void QG_MTextOptions::updateAngle() {
     if (action) {
 		action->setAngle(RS_Math::deg2rad(RS_Math::eval(ui->leAngle->text())));
+    }
+}
+
+void QG_MTextOptions::updateHeight() {
+    if (action) {
+        action->setHeight(RS_Math::eval(ui->leHeight->text()));
     }
 }

--- a/librecad/src/ui/forms/qg_mtextoptions.h
+++ b/librecad/src/ui/forms/qg_mtextoptions.h
@@ -47,6 +47,7 @@ public slots:
     virtual void setAction( RS_ActionInterface * a, bool update );
     virtual void updateText();
     virtual void updateAngle();
+    virtual void updateHeight();
 
 protected:
     RS_ActionDrawMText* action;

--- a/librecad/src/ui/forms/qg_mtextoptions.ui
+++ b/librecad/src/ui/forms/qg_mtextoptions.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>300</width>
+    <width>350</width>
     <height>24</height>
    </rect>
   </property>
@@ -18,13 +18,13 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>200</width>
+    <width>350</width>
     <height>22</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>300</width>
+    <width>350</width>
     <height>32767</height>
    </size>
   </property>
@@ -99,6 +99,23 @@
     <widget class="QLineEdit" name="leAngle"/>
    </item>
    <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Height:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="leHeight">
+     <property name="maximumSize">
+      <size>
+       <width>30</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="Line" name="sep1">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
@@ -140,6 +157,22 @@
    <signal>textChanged(QString)</signal>
    <receiver>Ui_MTextOptions</receiver>
    <slot>updateAngle()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>leHeight</sender>
+   <signal>textChanged(QString)</signal>
+   <receiver>Ui_MTextOptions</receiver>
+   <slot>updateHeight()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>

--- a/librecad/src/ui/forms/qg_textoptions.cpp
+++ b/librecad/src/ui/forms/qg_textoptions.cpp
@@ -61,12 +61,15 @@ void QG_TextOptions::setAction(RS_ActionInterface* a, bool update) {
 
         QString st;
         QString sa;
+        QString ss;
         if (update) {
             st = action->getText();
             sa = QString("%1").arg(RS_Math::rad2deg(action->getAngle()));
+            ss = QString("%1").arg(action->getHeight());
         } else {
             st = "";
             sa = "0.0";
+            ss = "0.0";
         }
 
 /*#if defined(OOPL_VERSION) && defined(Q_WS_WIN)
@@ -81,6 +84,7 @@ void QG_TextOptions::setAction(RS_ActionInterface* a, bool update) {
 		ui->teText->setText(st);
 //#endif
 		ui->leAngle->setText(sa);
+        ui->leHeight->setText(ss);
     } else {
         RS_DEBUG->print(RS_Debug::D_ERROR, 
 			"QG_TextOptions::setAction: wrong action type");
@@ -107,5 +111,11 @@ void QG_TextOptions::updateText() {
 void QG_TextOptions::updateAngle() {
     if (action) {
 		action->setAngle(RS_Math::deg2rad(RS_Math::eval(ui->leAngle->text())));
+    }
+}
+
+void QG_TextOptions::updateHeight() {
+    if (action) {
+        action->setHeight(RS_Math::eval(ui->leHeight->text()));
     }
 }

--- a/librecad/src/ui/forms/qg_textoptions.h
+++ b/librecad/src/ui/forms/qg_textoptions.h
@@ -47,6 +47,7 @@ public slots:
     virtual void setAction( RS_ActionInterface * a, bool update );
     virtual void updateText();
     virtual void updateAngle();
+    virtual void updateHeight();
 
 protected:
     RS_ActionDrawText* action;

--- a/librecad/src/ui/forms/qg_textoptions.ui
+++ b/librecad/src/ui/forms/qg_textoptions.ui
@@ -18,13 +18,13 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>200</width>
+    <width>250</width>
     <height>22</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>300</width>
+    <width>350</width>
     <height>32767</height>
    </size>
   </property>
@@ -99,6 +99,23 @@
     <widget class="QLineEdit" name="leAngle"/>
    </item>
    <item>
+    <widget class="QLabel" name="lSize">
+     <property name="text">
+      <string>Size:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="leHeight">
+     <property name="maximumSize">
+      <size>
+       <width>30</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="Line" name="sep1">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
@@ -140,6 +157,22 @@
    <signal>textChanged(QString)</signal>
    <receiver>Ui_TextOptions</receiver>
    <slot>updateAngle()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>leHeight</sender>
+   <signal>textChanged(QString)</signal>
+   <receiver>Ui_TextOptions</receiver>
+   <slot>updateHeight()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>

--- a/librecad/src/ui/forms/qg_textoptions.ui
+++ b/librecad/src/ui/forms/qg_textoptions.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>300</width>
+    <width>350</width>
     <height>24</height>
    </rect>
   </property>
@@ -18,7 +18,7 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>250</width>
+    <width>350</width>
     <height>22</height>
    </size>
   </property>
@@ -101,7 +101,7 @@
    <item>
     <widget class="QLabel" name="lSize">
      <property name="text">
-      <string>Size:</string>
+      <string>Height:</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Fixes #1375

This adds an input box to the top `qg_textoptions.ui` that allows editing the text height while keeping the text box active.

I've added it to `qg_mtextoptions.ui` too.

![image](https://user-images.githubusercontent.com/21159570/137625392-44e0e4a9-f5c3-48fe-85d0-86a23dea82e7.png)
