### PR TITLE
Solved 5 issues/feature-requests

### DIFF
--- a/librecad/src/actions/rs_actionblocksremove.cpp
+++ b/librecad/src/actions/rs_actionblocksremove.cpp
@@ -78,8 +78,9 @@ void RS_ActionBlocksRemove::trigger() {
 					if (e->rtti()==RS2::EntityInsert) {
 						RS_Insert* ins = (RS_Insert*)e;
 						if (ins->getName()==block->getName() && !ins->isUndone()) {
-                            document->addUndoable(ins);
+                            document->removeUndoable(ins);
                             ins->setUndoState(true);
+                            ins->reparent(NULL);
 							done = false;
 							break;
 						}
@@ -97,9 +98,26 @@ void RS_ActionBlocksRemove::trigger() {
 		// close all windows that are editing this block:
 		RS_DIALOGFACTORY->closeEditBlockWindow(block);
 
-        // Now remove block from the block list, but do not delete:
-        block->setUndoState(true);
-        document->addUndoable(block);
+      // Now remove block from the block list, but do not delete:
+      const int maximumBlockNameSize = 10;
+      const int numberOfCharsAZ = 26;
+      const int lowerCaseAsciiA = 97;
+      bool randomBlockNameFound = false;
+      while (!randomBlockNameFound) {
+          QString randomBlockName("");
+
+          for (int i = 0; i < maximumBlockNameSize; i++) {
+              const int randomNumber = (rand() % numberOfCharsAZ) + lowerCaseAsciiA;
+              randomBlockName = randomBlockName.append(QChar(randomNumber));
+          }
+          randomBlockName = block->getName().append("_").append(randomBlockName);
+
+          if (bl->rename(block, randomBlockName)) {
+             randomBlockNameFound = true;
+          }
+      }
+      block->setUndoState(true);
+      document->removeUndoable(block);
     }
     document->endUndoCycle();
 

--- a/librecad/src/lib/engine/lc_splinepoints.cpp
+++ b/librecad/src/lib/engine/lc_splinepoints.cpp
@@ -999,7 +999,9 @@ RS_Vector LC_SplinePoints::GetSplinePointAtDist(double dDist, int iStartSeg,
 
 	if(dDist <= dQuadDist)
 	{
-		double dt = GetQuadPointAtDist(vStart, vControl, vEnd, 0.0, dDist);
+        double t0 = 0.0;
+        if (i == (iStartSeg + 1)) { t0 = dStartT; }
+		double dt = GetQuadPointAtDist(vStart, vControl, vEnd, t0, dDist);
 		vRes = GetQuadPoint(vStart, vControl, vEnd, dt);
 		*piSeg = i - 1;
 		*pdt = dt;
@@ -1070,7 +1072,7 @@ RS_Vector LC_SplinePoints::getNearestMiddle(const RS_Vector& coord,
     vRes = GetSplinePointAtDist(dDist, 1, 0.0, &iNext, &dt);
 	if(vRes.valid) dMinDist = (vRes - coord).magnitude();
     i = 2;
-	while(vRes.valid && i < middlePoints)
+	while(vRes.valid && i <= middlePoints)
 	{
 		vNext = GetSplinePointAtDist(dDist, iNext, dt, &iNext, &dt);
 		dCurDist = (vNext - coord).magnitude();

--- a/librecad/src/lib/engine/rs_dimangular.cpp
+++ b/librecad/src/lib/engine/rs_dimangular.cpp
@@ -131,6 +131,7 @@ RS_Entity* RS_DimAngular::clone() const
     d->setOwner( isOwner());
     d->initId();
     d->detach();
+    d->updateDim();
 
     return d;
 }
@@ -341,19 +342,23 @@ void RS_DimAngular::updateDim(bool autoText /*= false*/)
 
     RS_Vector distV;
     double textAngle {0.0};
-    double angle1 {textPos.angleTo( dimCenter) - M_PI_2};
 
-    // rotate text so it's readable from the bottom or right (ISO)
-    // quadrant 1 & 4
-    if (angle1 > M_PI_2 * 3.0 + 0.001
-        || angle1 < M_PI_2 + 0.001) {
-        distV.setPolar( av.gap(), angle1 + M_PI_2);
-        textAngle = angle1;
-    }
-    // quadrant 2 & 3
-    else {
-        distV.setPolar( av.gap(), angle1 - M_PI_2);
-        textAngle = angle1 + M_PI;
+    if (!this->getInsideHorizontalText())
+    {
+        double angle1 {textPos.angleTo( dimCenter) - M_PI_2};
+
+        // rotate text so it's readable from the bottom or right (ISO)
+        // quadrant 1 & 4
+        if (angle1 > M_PI_2 * 3.0 + 0.001
+            || angle1 < M_PI_2 + 0.001) {
+            distV.setPolar( av.gap(), angle1 + M_PI_2);
+            textAngle = angle1;
+        }
+        // quadrant 2 & 3
+        else {
+            distV.setPolar( av.gap(), angle1 - M_PI_2);
+            textAngle = angle1 + M_PI;
+        }
     }
 
     // move text away from dimension line:

--- a/librecad/src/lib/engine/rs_dimdiametric.cpp
+++ b/librecad/src/lib/engine/rs_dimdiametric.cpp
@@ -76,6 +76,7 @@ RS_Entity* RS_DimDiametric::clone() const {
 	d->setOwner(isOwner());
 	d->initId();
 	d->detach();
+   d->updateDim();
 	return d;
 }
 

--- a/librecad/src/lib/engine/rs_dimlinear.cpp
+++ b/librecad/src/lib/engine/rs_dimlinear.cpp
@@ -83,6 +83,7 @@ RS_Entity* RS_DimLinear::clone() const {
 	d->setOwner(isOwner());
 	d->initId();
 	d->detach();
+   d->updateDim();
 	return d;
 }
 

--- a/librecad/src/lib/engine/rs_dimradial.cpp
+++ b/librecad/src/lib/engine/rs_dimradial.cpp
@@ -74,6 +74,7 @@ RS_Entity* RS_DimRadial::clone() const {
 	d->setOwner(isOwner());
 	d->initId();
 	d->detach();
+    d->updateDim();
 	return d;
 }
 
@@ -223,6 +224,11 @@ void RS_DimRadial::updateDim(bool autoText) {
         textAngle = angle+M_PI;
     }
 
+    if (!this->getInsideHorizontalText())
+    {
+        text->rotate({0., 0.}, textAngle);
+    }
+
     // move text label:
     RS_Vector textPos;
 
@@ -239,12 +245,10 @@ void RS_DimRadial::updateDim(bool autoText) {
         textPos += distV;
         data.middleOfText = textPos;
     }
-
-	text->rotate({0., 0.}, textAngle);
     text->move(textPos);
 
     text->setPen(RS_Pen(getTextColor(), RS2::WidthByBlock, RS2::SolidLine));
-	text->setLayer(nullptr);
+    text->setLayer(nullptr);
     addEntity(text);
 
     calculateBorders();

--- a/librecad/src/main/qc_applicationwindow.h
+++ b/librecad/src/main/qc_applicationwindow.h
@@ -311,6 +311,8 @@ protected:
 
 private:
 
+    bool windowIsInBlockMode = false;
+
     QMenu* createPopupMenu() override;
 
     QString format_filename_caption(const QString &qstring_in);

--- a/librecad/src/ui/forms/qg_mousewidget.cpp
+++ b/librecad/src/ui/forms/qg_mousewidget.cpp
@@ -40,7 +40,7 @@ QG_MouseWidget::QG_MouseWidget(QWidget* parent, const char* name, Qt::WindowFlag
 
     lLeftButton->setText("");
     lRightButton->setText("");
-    lMousePixmap->setPixmap( QPixmap(":/icons/mouse.svg"));
+    lMousePixmap->setPixmap( QPixmap(":/ui/mousebuttons24.png"));
 }
 
 /*


### PR DESCRIPTION
**My contributions:**

1. Solved issue #1400 
2. Solved issue #1395 
3. Added the ability to safely discard a block upon deletion
4. Solved issue #1396
5. Solved issue #1368

Regarding point number 3, earlier upon deleting a given block, you could not create a new block bearing the same name; well, now you can.

Regarding point number 2, the code talks about _splines_, but bears the equation of a _quadratic Bézier curve_.
Also, there is an analytic equation (which is generic) to compute the n-th degree Bézier curve, but the author of the code uses a very different approach (which is not compatible with the aforementioned analytic equation). 

Regarding point number 4, BOTH the bugs mentioned in the issue have been solved.

Regarding point number 5, the icon's size is implemented as is. The big mouse icon (located at `librecad/res/icons`) size was 80x80 pixels. The small mouse icon (located at `librecad/res/ui`) size is 24x24 pixels. I think _this_ icon was used before. To implement the right icon, just ensure that the icon size is about 25x25 pixels.