### PR TITLE
snap on middle fails for last point on spline, fixes #1395

### DIFF
--- a/librecad/src/lib/engine/lc_splinepoints.cpp
+++ b/librecad/src/lib/engine/lc_splinepoints.cpp
@@ -999,7 +999,9 @@ RS_Vector LC_SplinePoints::GetSplinePointAtDist(double dDist, int iStartSeg,
 
 	if(dDist <= dQuadDist)
 	{
-		double dt = GetQuadPointAtDist(vStart, vControl, vEnd, 0.0, dDist);
+        double t0 = 0.0;
+        if (i == (iStartSeg + 1)) { t0 = dStartT; }
+		double dt = GetQuadPointAtDist(vStart, vControl, vEnd, t0, dDist);
 		vRes = GetQuadPoint(vStart, vControl, vEnd, dt);
 		*piSeg = i - 1;
 		*pdt = dt;
@@ -1070,7 +1072,7 @@ RS_Vector LC_SplinePoints::getNearestMiddle(const RS_Vector& coord,
     vRes = GetSplinePointAtDist(dDist, 1, 0.0, &iNext, &dt);
 	if(vRes.valid) dMinDist = (vRes - coord).magnitude();
     i = 2;
-	while(vRes.valid && i < middlePoints)
+	while(vRes.valid && i <= middlePoints)
 	{
 		vNext = GetSplinePointAtDist(dDist, iNext, dt, &iNext, &dt);
 		dCurDist = (vNext - coord).magnitude();


### PR DESCRIPTION
* Solved issue #1395

The code talks about _splines_, but bears the equation of a _quadratic Bézier curve_.
Also, there is an analytic equation (which is generic) to compute the n-th degree Bézier curve, 
but the author of the code uses a very different approach (which is not compatible with the 
aforementioned analytic equation).