### PR TITLE
Resolved the 'open existing/deleted file' issues

### DIFF
--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -1889,9 +1889,13 @@ void QC_ApplicationWindow::slotFileOpen(const QString& fileName, RS2::FormatType
         commandWidget->appendHistory(message);
         statusBar()->showMessage(message, 2000);
 
-	} else {
-		QG_DIALOGFACTORY->commandMessage(tr("File '%1' does not exist. Opening aborted").arg(fileName));
+    }
+    else
+    {
+        QG_DIALOGFACTORY->commandMessage(tr("File '%1' does not exist. Opening aborted").arg(fileName));
         statusBar()->showMessage(tr("Opening aborted"), 2000);
+
+        recentFiles->remove(fileName);
     }
 
     QApplication::restoreOverrideCursor();

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -1751,23 +1751,28 @@ QString QC_ApplicationWindow::
  *	Returns:			void
  *	Notes:			Menu file -> open.
  *	*/
-void QC_ApplicationWindow::
-        slotFileOpen(const QString& fileName, RS2::FormatType type)
+void QC_ApplicationWindow::slotFileOpen(const QString& fileName, RS2::FormatType type)
 {
     RS_DEBUG->print("QC_ApplicationWindow::slotFileOpen(..)");
 
     QSettings settings;
 
-    QApplication::setOverrideCursor( QCursor(Qt::WaitCursor) );
+    QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
 
-    if ( QFileInfo(fileName).exists())
-         {
+    if (QFileInfo(fileName).exists())
+    {
         RS_DEBUG->print("QC_ApplicationWindow::slotFileOpen: creating new doc window");
-        if (openedFiles.indexOf(fileName) >=0) {
+
+        if (openedFiles.indexOf(fileName) != -1)
+        {
             QString message=tr("Warning: File already opened : ")+fileName;
             commandWidget->appendHistory(message);
             statusBar()->showMessage(message, 2000);
+
+            QApplication::setOverrideCursor(QCursor(Qt::ArrowCursor));
+            return;
         }
+
         // Create new document window:
 		QMdiSubWindow* old=activedMdiSubWindow;
         QRect geo;

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -1769,7 +1769,7 @@ void QC_ApplicationWindow::slotFileOpen(const QString& fileName, RS2::FormatType
             commandWidget->appendHistory(message);
             statusBar()->showMessage(message, 2000);
 
-            QApplication::setOverrideCursor(QCursor(Qt::ArrowCursor));
+            QApplication::restoreOverrideCursor();
             return;
         }
 

--- a/librecad/src/ui/qg_recentfiles.cpp
+++ b/librecad/src/ui/qg_recentfiles.cpp
@@ -80,6 +80,27 @@ void QG_RecentFiles::add(const QString& filename) {
 }
 
 
+/**
+ * Removes a file from the list of recently loaded files if
+ * it no longer exists on it's intended path.
+ */
+void QG_RecentFiles::remove(const QString& filename)
+{
+    RS_DEBUG->print("QG_RecentFiles::remove");
+
+    int index = files.indexOf(filename);
+
+    if (index != -1)
+    {
+        files.erase(files.begin() + index);
+
+        updateRecentFilesMenu();
+    }
+
+    RS_DEBUG->print("QG_RecentFiles::remove: OK");
+}
+
+
 QString QG_RecentFiles::get(int i) const{
 	if (i<files.size()) {
 		return files[i];

--- a/librecad/src/ui/qg_recentfiles.h
+++ b/librecad/src/ui/qg_recentfiles.h
@@ -47,6 +47,8 @@ public:
 
     void add(const QString& filename);
 
+    void remove(const QString& filename);
+
     /**
      * @return complete path and name of the file stored in the
      * list at index i


### PR DESCRIPTION
In both stable and development versions, 

if you open up an already open (existing) file, it is supposed to show a warning; which it does.

But then it also opens up another copy of the same file.

I've solved that issue. Now, it no longer opens up multiple copies of the same file; 
it shows the warning, as usual, and that's it; it safely returns back from the `slotFileOpen` function.

<hr>

Also, upon attempting to open a deleted file from the recently open menu, it shows the aborted error message;
but it does not remove the file listing from the recent menu. I've added a bit of code that removes that particular 
file name from the recent menu.

There is an `add` function in the `qg_recentfiles.cpp` file. 
I have included a simple `remove` function to it.