### PR TITLE
Solved the 'freezing status bar on focus out' issue

### DIFF
--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -2783,7 +2783,7 @@ void QC_ApplicationWindow::slotViewStatusBar(bool toggle) {
 
     - by Melwyn Francis Carlo
 */
-void QC_ApplicationWindow::status_bar_user_widgets_visibility(bool clear)
+void QC_ApplicationWindow::status_bar_widgets_visibility(bool clear)
 {
     QString statusBarMessage = statusBar()->currentMessage();
 

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -2793,7 +2793,7 @@ void QC_ApplicationWindow::status_bar_widgets_visibility(bool clear)
     {
         if (!statusBarChildWidget->objectName().isEmpty())
         {
-            statusBarChildWidget->setVisible(!clear);
+            statusBarChildWidget->setVisible(clear);
         }
     }
 

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -2783,7 +2783,7 @@ void QC_ApplicationWindow::slotViewStatusBar(bool toggle) {
 
     - by Melwyn Francis Carlo
 */
-void QC_ApplicationWindow::status_bar_widgets_visibility(bool clear)
+void QC_ApplicationWindow::status_bar_widgets_visibility(bool isVisible)
 {
     QString statusBarMessage = statusBar()->currentMessage();
 
@@ -2793,7 +2793,7 @@ void QC_ApplicationWindow::status_bar_widgets_visibility(bool clear)
     {
         if (!statusBarChildWidget->objectName().isEmpty())
         {
-            statusBarChildWidget->setVisible(clear);
+            statusBarChildWidget->setVisible(isVisible);
         }
     }
 

--- a/librecad/src/main/qc_applicationwindow.h
+++ b/librecad/src/main/qc_applicationwindow.h
@@ -227,6 +227,8 @@ public slots:
 
     void invokeLicenseWindow();
 
+    void status_bar_widgets_visibility(bool clear);
+
 
 signals:
     void gridChanged(bool on);

--- a/librecad/src/main/qc_applicationwindow.h
+++ b/librecad/src/main/qc_applicationwindow.h
@@ -227,7 +227,7 @@ public slots:
 
     void invokeLicenseWindow();
 
-    void status_bar_widgets_visibility(bool clear);
+    void status_bar_widgets_visibility(bool isVisible);
 
 
 signals:

--- a/librecad/src/ui/qg_graphicview.cpp
+++ b/librecad/src/ui/qg_graphicview.cpp
@@ -448,14 +448,14 @@ void QG_GraphicView::tabletEvent(QTabletEvent* e) {
 
 void QG_GraphicView::leaveEvent(QEvent* e) {
     eventHandler->mouseLeaveEvent();
-    emit status_bar_widgets_visibility_request(true);
+    emit status_bar_widgets_visibility_request(false);
     QWidget::leaveEvent(e);
 }
 
 
 void QG_GraphicView::enterEvent(QEvent* e) {
     eventHandler->mouseEnterEvent();
-    emit status_bar_widgets_visibility_request(false);
+    emit status_bar_widgets_visibility_request(true);
     QWidget::enterEvent(e);
 }
 

--- a/librecad/src/ui/qg_graphicview.cpp
+++ b/librecad/src/ui/qg_graphicview.cpp
@@ -448,12 +448,14 @@ void QG_GraphicView::tabletEvent(QTabletEvent* e) {
 
 void QG_GraphicView::leaveEvent(QEvent* e) {
     eventHandler->mouseLeaveEvent();
+    emit status_bar_widgets_visibility_request(true);
     QWidget::leaveEvent(e);
 }
 
 
 void QG_GraphicView::enterEvent(QEvent* e) {
     eventHandler->mouseEnterEvent();
+    emit status_bar_widgets_visibility_request(false);
     QWidget::enterEvent(e);
 }
 

--- a/librecad/src/ui/qg_graphicview.h
+++ b/librecad/src/ui/qg_graphicview.h
@@ -167,6 +167,7 @@ private:
 signals:
     void xbutton1_released();
     void gridStatusChanged(const QString&);
+    void status_bar_widgets_visibility_request(bool);
 };
 
 #endif


### PR DESCRIPTION
Prior to this code, the status bar information (especially the coordinates) **just freezes** when the mouse focuses outside of the graphics view, and also when a file is closed.

I have implemented a method to hide the widgets within the status bar when the mouse focuses out, 
and show the widgets when the mouse focuses inside one of the graphic views (i.e. one of the open files).

This method will not _(should not)_ come in the way of status bar messages.
The status bar messages will continue to show regardless.

<hr>

Also, regarding the status bar message timeout:
there were magic numbers of _2000_ scattered throughout the _qc_applicationwindow.cpp_ file.
2000 stands for 2000 milliseconds (or just 2 seconds), which is the time for which 
the status bar message will be displayed.

I've assigned them a common constant variable at the top of the file.
This would make future edits simpler.