### PR TITLE
Removed the 'All files' and 'Any files' options from the 'Import Image' and 'Export PDF' dialogs respectively

### DIFF
--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -2325,8 +2325,7 @@ void QC_ApplicationWindow::slotFilePrint(bool printPDF) {
         QString     defFilter("PDF files (*.pdf)");
         QStringList filters;
 
-        filters << defFilter
-                << "Any files (*)";
+        filters << defFilter;
 
         fileDlg.setNameFilters(filters);
         fileDlg.setFileMode(QFileDialog::AnyFile);

--- a/librecad/src/ui/qg_dialogfactory.cpp
+++ b/librecad/src/ui/qg_dialogfactory.cpp
@@ -657,7 +657,6 @@ QString QG_DialogFactory::requestImageOpenDialog()
     }
     QString strAllImageFiles = QObject::tr("All Image Files (%1)").arg(all);
     filters.append(strAllImageFiles);
-    filters.append(QObject::tr("All Files (*.*)"));
 
 	QFileDialog fileDlg(nullptr, "");
     fileDlg.setModal(true);


### PR DESCRIPTION
In the **Import Image** and **Export PDF** dialogs, the '_All files_' type amongst other options, makes no sense.

The **Export SVG** and **Export Image** dialogs do not have them :

![Screenshot from 2021-11-19 13-53-02](https://user-images.githubusercontent.com/66683108/142592462-15266e5e-ccfe-4eca-8537-f254ccad1b91.png)

![Screenshot from 2021-11-19 14-08-56](https://user-images.githubusercontent.com/66683108/142592476-7978bd55-6c62-48e3-830d-10547f5964f7.png)

<hr>

Then, why do the **Import Image** and **Export PDF** dialogs have them?

![Screenshot from 2021-11-19 14-09-58](https://user-images.githubusercontent.com/66683108/142592488-bed1cd81-8e98-4d62-aeaf-e12246b91f3d.png)

![Screenshot from 2021-11-19 14-10-16](https://user-images.githubusercontent.com/66683108/142592506-3519ee9b-b81a-4094-b1c3-26542f424f98.png)

<hr>

How would the 'Any files' option benefit the export of a specific type of file (e.g. PDF)?

Wouldn't the import of 'All files' whilst importing specific image file types lead to bugs and/or unpredictable behaviour?


