### PR TITLE
Try to ensure that entities get a reasonable (i.e. non-zero) Z scale.

### DIFF
--- a/librecad/src/actions/rs_actionblocksinsert.cpp
+++ b/librecad/src/actions/rs_actionblocksinsert.cpp
@@ -95,7 +95,7 @@ void RS_ActionBlocksInsert::init(int status) {
 void RS_ActionBlocksInsert::reset() {
 	data.reset(new RS_InsertData("",
                          RS_Vector(0.0,0.0),
-                         RS_Vector(1.0,1.0),
+                         RS_Vector(1.0,1.0,1.0),
                          0.0,
                          1, 1,
                          RS_Vector(1.0,1.0),

--- a/librecad/src/lib/engine/rs_mtext.cpp
+++ b/librecad/src/lib/engine/rs_mtext.cpp
@@ -427,7 +427,7 @@ void RS_MText::update()
 
             RS_InsertData d( letterText,
                              letterPos,
-                             RS_Vector( 1.0, 1.0),
+                             RS_Vector( 1.0, 1.0, 1.0 ),
                              0.0,
                              1,
                              1,

--- a/librecad/src/lib/engine/rs_text.cpp
+++ b/librecad/src/lib/engine/rs_text.cpp
@@ -298,7 +298,7 @@ void RS_Text::update() {
 
             RS_InsertData d(letterText,
                             letterPos,
-                            RS_Vector(1.0, 1.0),
+                            RS_Vector(1.0, 1.0, 1.0),
                             0.0,
                             1,1, RS_Vector(0.0,0.0),
                             font->getLetterList(), RS2::NoUpdate);

--- a/librecad/src/lib/filters/rs_filterdxf.cpp
+++ b/librecad/src/lib/filters/rs_filterdxf.cpp
@@ -455,7 +455,7 @@ void RS_FilterDXF::addInsert(const DL_InsertData& data) {
     }
 
     RS_Vector ip(data.ipx, data.ipy);
-    RS_Vector sc(data.sx, data.sy);
+    RS_Vector sc(data.sx, data.sy, data.sz);
     RS_Vector sp(data.colSp, data.rowSp);
 
     //cout << "Insert: " << name << " " << ip << " " << cols << "/" << rows << endl;

--- a/librecad/src/lib/filters/rs_filterdxfrw.cpp
+++ b/librecad/src/lib/filters/rs_filterdxfrw.cpp
@@ -668,7 +668,7 @@ void RS_FilterDXFRW::addInsert(const DRW_Insert& data) {
     RS_DEBUG->print("RS_FilterDXF::addInsert");
 
     RS_Vector ip(data.basePoint.x, data.basePoint.y);
-    RS_Vector sc(data.xscale, data.yscale);
+    RS_Vector sc(data.xscale, data.yscale, data.zscale);
     RS_Vector sp(data.colspace, data.rowspace);
 
     //cout << "Insert: " << name << " " << ip << " " << cols << "/" << rows << endl;

--- a/librecad/src/lib/filters/rs_filterjww.cpp
+++ b/librecad/src/lib/filters/rs_filterjww.cpp
@@ -447,7 +447,7 @@ void RS_FilterJWW::addInsert(const DL_InsertData& data) {
         }
 
         RS_Vector ip(data.ipx, data.ipy);
-        RS_Vector sc(data.sx, data.sy);
+        RS_Vector sc(data.sx, data.sy, data.sz);
         RS_Vector sp(data.colSp, data.rowSp);
 
         //cout << "Insert: " << name << " " << ip << " " << cols << "/" << rows << endl;

--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -456,7 +456,7 @@ void RS_Modification::paste(const RS_PasteData& data, RS_Graphic* source) {
     // adjust scaling factor for units conversion in case of clipboard paste
     double factor = (RS_TOLERANCE < fabs(data.factor)) ? data.factor : 1.0;
     // scale factor as vector
-    RS_Vector vfactor = RS_Vector(factor, factor);
+    RS_Vector vfactor = RS_Vector(factor, factor, factor);
     // select source for paste
 	if (!source) {
         RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::paste: add graphic source from clipboard");
@@ -465,7 +465,7 @@ void RS_Modification::paste(const RS_PasteData& data, RS_Graphic* source) {
         RS2::Unit sourceUnit = source->getUnit();
         RS2::Unit targetUnit = graphic->getUnit();
         factor = RS_Units::convert(1.0, sourceUnit, targetUnit);
-        vfactor = RS_Vector(factor, factor);
+	vfactor = RS_Vector(factor, factor, factor);
     } else {
         RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::paste: add graphic source from parts library");
     }
@@ -658,7 +658,7 @@ bool RS_Modification::pasteContainer(RS_Entity* entity, RS_EntityContainer* cont
     bc->reparent(graphic);
     graphic->addBlock(bc);
     // create insert for the new block
-    RS_InsertData di = RS_InsertData(name_new, insertionPoint, RS_Vector(1.0, 1.0), i->getAngle(), 1, 1, RS_Vector(0.0,0.0));
+    RS_InsertData di = RS_InsertData(name_new, insertionPoint, RS_Vector(1.0, 1.0, 1.0), i->getAngle(), 1, 1, RS_Vector(0.0,0.0));
     RS_Insert* ic = new RS_Insert(container, di);
     ic->reparent(container);
     container->addEntity(ic);

--- a/librecad/src/main/doc_plugin_interface.cpp
+++ b/librecad/src/main/doc_plugin_interface.cpp
@@ -316,6 +316,7 @@ void Plugin_Entity::getData(QHash<int, QVariant> *data){
         data->insert(DPI::STARTANGLE, d.angle );
         data->insert(DPI::XSCALE, d.scaleFactor.x );
         data->insert(DPI::YSCALE, d.scaleFactor.y );
+        data->insert(1.0, d.scaleFactor.z );
         break;}
     case RS2::EntityMText: {
         data->insert(DPI::ETYPE, DPI::MTEXT);
@@ -988,7 +989,7 @@ void Doc_plugin_interface::addImage(int handle, QPointF *start, QPointF *uvr, QP
 void Doc_plugin_interface::addInsert(QString name, QPointF ins, QPointF scale, qreal rot){
     if (doc) {
         RS_Vector ip(ins.x(), ins.y());
-        RS_Vector sp(scale.x(), scale.y());
+	RS_Vector sp(scale.x(), scale.y(), 1.0);
 
         RS_InsertData id(name, ip, sp, rot, 1, 1, RS_Vector(0.0, 0.0));
         RS_Insert* entity = new RS_Insert(doc, id);

--- a/librecad/src/main/qc_mdiwindow.cpp
+++ b/librecad/src/main/qc_mdiwindow.cpp
@@ -343,7 +343,7 @@ void QC_MDIWindow::drawChars() {
     sep = sep*3;
     for (int i=0; i<bl->count(); ++i) {
         RS_Block* ch = bl->at(i);
-        RS_InsertData data(ch->getName(), RS_Vector(i*sep,0), RS_Vector(1,1), 0, 1, 1, RS_Vector(0,0));
+        RS_InsertData data(ch->getName(), RS_Vector(i*sep,0), RS_Vector(1,1,1), 0, 1, 1, RS_Vector(0,0));
         RS_Insert* in = new RS_Insert(document, data);
         document->addEntity(in);
         QFileInfo info(document->getFilename() );

--- a/librecad/src/test/lc_simpletests.cpp
+++ b/librecad/src/test/lc_simpletests.cpp
@@ -549,7 +549,7 @@ void LC_SimpleTests::slotTestInsertBlock() {
 		RS_Insert* ins;
 		RS_InsertData insData("debugblock",
 							  RS_Vector(0.0,0.0),
-							  RS_Vector(1.0,1.0), 0.0,
+                                                          RS_Vector(1.0,1.0,1.0), 0.0,
 							  1, 1, RS_Vector(0.0, 0.0),
 							  NULL, RS2::NoUpdate);
 
@@ -565,7 +565,7 @@ void LC_SimpleTests::slotTestInsertBlock() {
 		// insert one green instance of the block (rotate):
 		insData = RS_InsertData("debugblock",
 								RS_Vector(-50.0,20.0),
-								RS_Vector(1.0,1.0), M_PI/6.,
+                                                                RS_Vector(1.0,1.0,1.0), M_PI/6.,
 								1, 1, RS_Vector(0.0, 0.0),
 								NULL, RS2::NoUpdate);
 		ins = new RS_Insert(graphic, insData);
@@ -579,7 +579,7 @@ void LC_SimpleTests::slotTestInsertBlock() {
 		// insert one cyan instance of the block (move):
 		insData = RS_InsertData("debugblock",
 								RS_Vector(10.0,20.0),
-								RS_Vector(1.0,1.0), 0.0,
+                                                                RS_Vector(1.0,1.0,1.0), 0.0,
 								1, 1, RS_Vector(0.0, 0.0),
 								NULL, RS2::NoUpdate);
 		ins = new RS_Insert(graphic, insData);
@@ -594,7 +594,7 @@ void LC_SimpleTests::slotTestInsertBlock() {
 		for (double a=0.0; a<360.0; a+=45.0) {
 			insData = RS_InsertData("debugblock",
 									RS_Vector(60.0,0.0),
-									RS_Vector(2.0/5,2.0/5), RS_Math::deg2rad(a),
+                                                                        RS_Vector(2.0/5,2.0/5,2.0/5), RS_Math::deg2rad(a),
 									1, 1, RS_Vector(0.0, 0.0),
 									NULL, RS2::NoUpdate);
 			ins = new RS_Insert(graphic, insData);
@@ -609,7 +609,7 @@ void LC_SimpleTests::slotTestInsertBlock() {
 		// insert an array of yellow instances of the block:
 		insData = RS_InsertData("debugblock",
 								RS_Vector(-100.0,-100.0),
-								RS_Vector(0.2,0.2), M_PI/6.0,
+                                                                RS_Vector(0.2,0.2,0.2), M_PI/6.0,
 								6, 4, RS_Vector(100.0, 100.0),
 								NULL, RS2::NoUpdate);
 		ins = new RS_Insert(graphic, insData);
@@ -1001,7 +1001,7 @@ void LC_SimpleTests::slotTestUnicode() {
 				if (graphic->findBlock(strCode)) {
 					RS_InsertData d(strCode,
 									RS_Vector(col/0x10*20.0,row*20.0),
-									RS_Vector(1.0,1.0), 0.0,
+                                                                        RS_Vector(1.0,1.0,1.0), 0.0,
 									1, 1, RS_Vector(0.0, 0.0),
 									NULL, RS2::NoUpdate);
 					ins = new RS_Insert(graphic, d);


### PR DESCRIPTION
While LibreCAD ignores Z scale on input, generating DXF with entities that has a Z scale of zero creates problems for others.
FreeCAD will for instance choke, see https://tracker.freecadweb.org/view.php?id=4791 
An alternative way of dealing with this would be omitting writing Z scales (record 43) to the DXF in the first place.

This is a proposed fix for #1428 