### PR TITLE
show current block and layer in status bar, fixes #1333

### DIFF
--- a/librecad/src/main/qc_applicationwindow.h
+++ b/librecad/src/main/qc_applicationwindow.h
@@ -80,6 +80,12 @@ class QC_ApplicationWindow: public MainWindowX
     Q_OBJECT
 
 public:
+
+    enum
+    {
+        DEFAULT_STATUS_BAR_MESSAGE_TIMEOUT = 2000
+    };
+
     QC_ApplicationWindow();
     ~QC_ApplicationWindow();
 

--- a/librecad/src/ui/qg_blockwidget.cpp
+++ b/librecad/src/ui/qg_blockwidget.cpp
@@ -33,6 +33,7 @@
 #include <QBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
+#include <QStatusBar>
 #include <QContextMenuEvent>
 
 #include <algorithm>
@@ -41,6 +42,7 @@
 #include "rs_blocklist.h"
 #include "qg_actionhandler.h"
 #include "rs_debug.h"
+#include "qc_applicationwindow.h"
 
 QG_BlockModel::QG_BlockModel(QObject * parent) : QAbstractTableModel(parent) {
     blockVisible = QIcon(":/icons/visible.svg");
@@ -305,8 +307,19 @@ void QG_BlockWidget::restoreSelections() {
  * Activates the given block and makes it the active
  * block in the blocklist.
  */
-void QG_BlockWidget::activateBlock(RS_Block* block) {
+void QG_BlockWidget::activateBlock(RS_Block* block)
+{
     RS_DEBUG->print("QG_BlockWidget::activateBlock()");
+
+    if (block != nullptr)
+    {
+        if (block->isSelectedInBlockList())
+        {
+            QC_ApplicationWindow::getAppWindow()->statusBar()
+                                                ->showMessage( QString("Block '%1' selected").arg(block->getName()), 
+                                                               QC_ApplicationWindow::DEFAULT_STATUS_BAR_MESSAGE_TIMEOUT);
+        }
+    }
 
     if (block==NULL || blockList==NULL) {
         return;

--- a/librecad/src/ui/qg_blockwidget.cpp
+++ b/librecad/src/ui/qg_blockwidget.cpp
@@ -311,18 +311,17 @@ void QG_BlockWidget::activateBlock(RS_Block* block)
 {
     RS_DEBUG->print("QG_BlockWidget::activateBlock()");
 
-    if (block != nullptr)
+    if ((block == nullptr) || (blockList == nullptr))
     {
-        if (block->isSelectedInBlockList())
-        {
-            QC_ApplicationWindow::getAppWindow()->statusBar()
-                                                ->showMessage( QString("Block '%1' selected").arg(block->getName()), 
-                                                               QC_ApplicationWindow::DEFAULT_STATUS_BAR_MESSAGE_TIMEOUT);
-        }
+        RS_DEBUG->print(RS_Debug::D_ERROR, "QG_BlockWidget::activateBlock: nullptr block or blockList");
+        return;
     }
 
-    if (block==NULL || blockList==NULL) {
-        return;
+    if (block->isSelectedInBlockList())
+    {
+        QC_ApplicationWindow::getAppWindow()->statusBar()
+                                            ->showMessage( QString("Block '%1' selected").arg(block->getName()), 
+                                                           QC_ApplicationWindow::DEFAULT_STATUS_BAR_MESSAGE_TIMEOUT);
     }
 
     lastBlock = blockList->getActive();

--- a/librecad/src/ui/qg_layerwidget.cpp
+++ b/librecad/src/ui/qg_layerwidget.cpp
@@ -405,19 +405,17 @@ void QG_LayerWidget::activateLayer(RS_Layer* layer, bool updateScroll)
 {
     RS_DEBUG->print("QG_LayerWidget::activateLayer() begin");
 
-    if (layer != nullptr)
+    if ((layer == nullptr) || (layerList == nullptr))
     {
-       if (layer->isSelectedInLayerList())
-       {
-           QC_ApplicationWindow::getAppWindow()->statusBar()
-                                               ->showMessage( QString("Layer '%1' selected").arg(layer->getName()), 
-                                                              QC_ApplicationWindow::DEFAULT_STATUS_BAR_MESSAGE_TIMEOUT);
-       }
-    }
-
-    if (!layer || !layerList) {
         RS_DEBUG->print(RS_Debug::D_ERROR, "QG_LayerWidget::activateLayer: nullptr layer or layerList");
         return;
+    }
+
+    if (layer->isSelectedInLayerList())
+    {
+        QC_ApplicationWindow::getAppWindow()->statusBar()
+                                            ->showMessage( QString("Layer '%1' selected").arg(layer->getName()), 
+                                                           QC_ApplicationWindow::DEFAULT_STATUS_BAR_MESSAGE_TIMEOUT);
     }
 
     layerList->activate(layer);

--- a/librecad/src/ui/qg_layerwidget.cpp
+++ b/librecad/src/ui/qg_layerwidget.cpp
@@ -405,11 +405,14 @@ void QG_LayerWidget::activateLayer(RS_Layer* layer, bool updateScroll)
 {
     RS_DEBUG->print("QG_LayerWidget::activateLayer() begin");
 
-    if (layer->isSelectedInLayerList())
+    if (layer != nullptr)
     {
-        QC_ApplicationWindow::getAppWindow()->statusBar()
-                                            ->showMessage( QString("Layer '%1' selected").arg(layer->getName()), 
-                                                           QC_ApplicationWindow::DEFAULT_STATUS_BAR_MESSAGE_TIMEOUT);
+       if (layer->isSelectedInLayerList())
+       {
+           QC_ApplicationWindow::getAppWindow()->statusBar()
+                                               ->showMessage( QString("Layer '%1' selected").arg(layer->getName()), 
+                                                              QC_ApplicationWindow::DEFAULT_STATUS_BAR_MESSAGE_TIMEOUT);
+       }
     }
 
     if (!layer || !layerList) {

--- a/librecad/src/ui/qg_layerwidget.cpp
+++ b/librecad/src/ui/qg_layerwidget.cpp
@@ -40,6 +40,7 @@
 #include <QLineEdit>
 #include <QContextMenuEvent>
 #include <QKeyEvent>
+#include <QStatusBar>
 #include "rs_debug.h"
 
 QG_LayerModel::QG_LayerModel(QObject * parent) : QAbstractTableModel(parent) {
@@ -400,8 +401,16 @@ void QG_LayerWidget::restoreSelections() {
  * Activates the given layer and makes it the active
  * layer in the layerlist.
  */
-void QG_LayerWidget::activateLayer(RS_Layer* layer, bool updateScroll) {
+void QG_LayerWidget::activateLayer(RS_Layer* layer, bool updateScroll)
+{
     RS_DEBUG->print("QG_LayerWidget::activateLayer() begin");
+
+    if (layer->isSelectedInLayerList())
+    {
+        QC_ApplicationWindow::getAppWindow()->statusBar()
+                                            ->showMessage( QString("Layer '%1' selected").arg(layer->getName()), 
+                                                           QC_ApplicationWindow::DEFAULT_STATUS_BAR_MESSAGE_TIMEOUT);
+    }
 
     if (!layer || !layerList) {
         RS_DEBUG->print(RS_Debug::D_ERROR, "QG_LayerWidget::activateLayer: nullptr layer or layerList");


### PR DESCRIPTION
* Solved issue #1333

<hr>

1. Displays the name of the selected **block** in the status bar as `Block 'X' selected`
2. Displays the name of the selected **layer** in the status bar as `Layer 'X' selected`

where `X` is the block / layer name.