### PR TITLE
Fixed layer toggle view bug

### DIFF
--- a/librecad/src/actions/rs_actionlayerstoggleview.cpp
+++ b/librecad/src/actions/rs_actionlayerstoggleview.cpp
@@ -54,11 +54,13 @@ void RS_ActionLayersToggleView::trigger() {
             if (!layer->isVisibleInLayerList()) continue;
             if (!layer->isSelectedInLayerList()) continue;
             graphic->toggleLayer(layer);
+            layer->visibleInLayerList(!layer->isVisibleInLayerList());
             cnt++;
         }
         // if there wasn't selected layers, toggle active layer
         if (!cnt) {
             graphic->toggleLayer(a_layer);
+            a_layer->visibleInLayerList(!a_layer->isVisibleInLayerList());
         }
         graphic->updateInserts();
         container->calculateBorders();

--- a/librecad/src/actions/rs_actionlayerstoggleview.cpp
+++ b/librecad/src/actions/rs_actionlayerstoggleview.cpp
@@ -51,16 +51,13 @@ void RS_ActionLayersToggleView::trigger() {
         // toggle selected layers
         for (auto layer: *ll) {
             if (!layer) continue;
-            if (!layer->isVisibleInLayerList()) continue;
             if (!layer->isSelectedInLayerList()) continue;
             graphic->toggleLayer(layer);
-            layer->visibleInLayerList(!layer->isVisibleInLayerList());
             cnt++;
         }
         // if there wasn't selected layers, toggle active layer
         if (!cnt) {
             graphic->toggleLayer(a_layer);
-            a_layer->visibleInLayerList(!a_layer->isVisibleInLayerList());
         }
         graphic->updateInserts();
         container->calculateBorders();

--- a/librecad/src/lib/engine/rs_layer.cpp
+++ b/librecad/src/lib/engine/rs_layer.cpp
@@ -103,6 +103,7 @@ void RS_Layer::setConverted(bool c) {
 void RS_Layer::toggle() {
 	//toggleFlag(RS2::FlagFrozen);
 	data.frozen = !data.frozen;
+   data.visibleInLayerList = !data.frozen;
 }
 
 /**
@@ -112,6 +113,7 @@ void RS_Layer::toggle() {
  */
 void RS_Layer::freeze(bool freeze) {
 	data.frozen = freeze;
+   data.visibleInLayerList = !freeze;
 }
 
 /**

--- a/librecad/src/lib/engine/rs_layerlist.cpp
+++ b/librecad/src/lib/engine/rs_layerlist.cpp
@@ -409,11 +409,8 @@ void RS_LayerList::toggleConstruction(RS_Layer* layer) {
  */
 void RS_LayerList::freezeAll(bool freeze) {
 
-    for (unsigned l=0; l<count(); l++) {
-        if (at(l)->isVisibleInLayerList()) {
-             at(l)->freeze(freeze);
-         }
-    }
+    for (unsigned l=0; l<count(); l++) at(l)->freeze(freeze);
+
     setModified(true);
 
     for (int i=0; i<layerListListeners.size(); ++i) {


### PR DESCRIPTION
Without this fix, the programmer gets incorrect layer view status upon reading the layer's visibility via the `isVisibleInLayerList()` method.