### PR TITLE
save single layer as DXF, fixes #1327

### DIFF
--- a/librecad/src/actions/lc_actionlayersexport.cpp
+++ b/librecad/src/actions/lc_actionlayersexport.cpp
@@ -1,0 +1,271 @@
+/****************************************************************************
+**
+** This file is part of the LibreCAD project, a 2D CAD program
+**
+** Copyright (C) 2021 Melwyn Francis Carlo
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU General Public License version 2 as published by the Free Software
+** Foundation and appearing in the file gpl-2.0.txt included in the
+** packaging of this file.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+**
+** This copyright notice MUST APPEAR in all copies of the script!
+**
+**********************************************************************/
+
+
+#include <QDir>
+#include <QStatusBar>
+#include <QFileDialog>
+#include <QApplication>
+
+#include "rs_debug.h"
+#include "rs_layer.h"
+#include "rs_graphic.h"
+#include "rs_layerlist.h"
+#include "qc_applicationwindow.h"
+#include "lc_filedialogservice.h"
+
+#include "lc_actionlayersexport.h"
+
+
+/*
+    This action class exports the current selected layers as a drawing file, 
+    either as individual files, or combined within a single file.
+*/
+
+
+LC_ActionLayersExport::LC_ActionLayersExport( RS_EntityContainer& document, 
+                                              RS_GraphicView& graphicView, 
+                                              RS_LayerList* inputLayersList, 
+                                              Mode inputExportMode) 
+                                              :
+                                              RS_ActionInterface("Export selected layer(s)", document, graphicView), 
+                                              layersList(inputLayersList), 
+                                              exportMode(inputExportMode)
+{
+}
+
+
+void LC_ActionLayersExport::init(int status)
+{
+    RS_DEBUG->print("LC_ActionLayersExport::init");
+
+    RS_ActionInterface::init(status);
+
+    trigger();
+}
+
+
+void LC_ActionLayersExport::trigger()
+{
+    RS_DEBUG->print("LC_ActionLayersExport::trigger");
+
+    QString exportModeString = "visible";
+    if (exportMode == LC_ActionLayersExport::SelectedMode) exportModeString = "selected";
+
+
+    RS_LayerList *originalLayersList = document->getLayerList();
+
+    const int totalNumberOfLayers = originalLayersList->count();
+
+    QStringList layersToExport;
+
+    for (int i = 0; i < totalNumberOfLayers; i++)
+    {
+        if ((   originalLayersList->at(i)->isSelectedInLayerList() && (exportMode == LC_ActionLayersExport::SelectedMode)) 
+        ||  ( ! originalLayersList->at(i)->isFrozen()              && (exportMode == LC_ActionLayersExport::VisibleMode)))
+        {
+            layersToExport.append(originalLayersList->at(i)->getName());
+        }
+    }
+
+    /* No export layer found. */
+    if (layersToExport.isEmpty())
+    {
+        QC_ApplicationWindow::getAppWindow()->statusBar()->showMessage( QObject::tr("No %1 layers found").arg(exportModeString), 
+                                                                        QC_ApplicationWindow::DEFAULT_STATUS_BAR_MESSAGE_TIMEOUT);
+        RS_DEBUG->print(RS_Debug::D_NOTICE, "LC_ActionLayersExport::trigger: No %1 layers found", exportModeString);
+        finish();
+        return;
+    }
+
+
+    LC_FileDialogService::FileDialogResult result;
+
+    if (exportMode == LC_ActionLayersExport::SelectedMode)
+    {
+        result = LC_FileDialogService::getFileDetails (LC_FileDialogService::ExportLayersSelected);
+    }
+    else
+    {
+        result = LC_FileDialogService::getFileDetails (LC_FileDialogService::ExportLayersVisible);
+    }
+
+    if (result.filePath.isEmpty())
+    {
+        RS_DEBUG->print(RS_Debug::D_NOTICE, "LC_ActionLayersExport::trigger: User cancelled");
+        finish();
+        return;
+    }
+
+
+    QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
+
+
+    int currentExportLayerIndex = 0;
+
+    while (currentExportLayerIndex < layersToExport.size())
+    {
+        RS_Graphic *documentDeepCopy = new RS_Graphic();
+
+        documentDeepCopy->newDoc();
+
+        RS_LayerList *duplicateLayersList = documentDeepCopy->getLayerList();
+
+        documentDeepCopy->setVariableDictObject(document->getGraphic()->getVariableDictObject());
+
+        QString modifiedFilePath;
+
+        bool exportLayer0 = false;
+
+
+
+        /* Combine all layers. */
+        if (result.checkState == Qt::Checked)
+        {
+            /* This is just to break early out of the loop. */
+            currentExportLayerIndex = layersToExport.size();
+
+            modifiedFilePath = result.filePath;
+
+            for (int i = 0; i < layersToExport.size(); i++)
+            {
+                if (layersToExport.at (i).compare("0") == 0) exportLayer0 = true;
+
+                /* It does a 'new' internally. */
+                RS_Layer *duplicateLayer = originalLayersList->find (layersToExport.at (i))->clone();
+
+                duplicateLayersList->add(duplicateLayer);
+            }
+        }
+        /* Individualize all layers. */
+        else
+        {
+            if (layersToExport.at (currentExportLayerIndex).compare("0") == 0) exportLayer0 = true;
+
+            RS_Layer *duplicateLayer = originalLayersList->find (layersToExport.at (currentExportLayerIndex))->clone();
+
+            duplicateLayersList->add(duplicateLayer);
+
+            /* Note that the QString::append() function causes a bug; hence the '+' overload operator. */
+            modifiedFilePath = QDir::toNativeSeparators (
+
+                                    result.dirPath + "/" 
+                                                   + result.fileName 
+                                                   + paddedIndex(currentExportLayerIndex + 1, layersToExport.size()) 
+                                                   + result.fileExtension 
+                               );
+        }
+
+
+
+        const int totalNumberOfLayers = duplicateLayersList->count();
+
+        int i = 0;
+
+        while (1)
+        {
+            RS_Entity *entity = document->entityAt (i++);
+
+            if (entity == nullptr) break;
+
+            QString entityLayerName = entity->getLayer()->getName();
+
+            for (int j = 0; j < totalNumberOfLayers; j++)
+            {
+                if (entityLayerName.compare(duplicateLayersList->at(j)->getName()) == 0)
+                {
+                    if ((duplicateLayersList->at(j)->getName().compare("0") == 0) && !exportLayer0) continue;
+
+                    /* It does a 'new' internally. */
+                    RS_Entity *duplicateEntity = entity->clone();
+
+                    documentDeepCopy->addEntity(duplicateEntity);
+
+                    duplicateEntity->setLayer(duplicateLayersList->find (entityLayerName));
+                }
+            }
+        }
+
+
+
+        /* Saving. */
+        documentDeepCopy->setGraphicView(graphicView);
+
+        const bool saveWasSuccessful = documentDeepCopy->saveAs(modifiedFilePath, result.fileType, true);
+
+
+
+        /* Cleaning up. */
+        for (int j = 0; j < totalNumberOfLayers; j++)
+        {
+            delete duplicateLayersList->at(j);
+        }
+
+        documentDeepCopy->setGraphicView(nullptr);
+        documentDeepCopy->setParent(nullptr);
+        documentDeepCopy->newDoc();
+
+        delete documentDeepCopy;
+
+
+
+        currentExportLayerIndex++;
+
+
+
+        if (!saveWasSuccessful)
+        {
+            RS_DEBUG->print(RS_Debug::D_ERROR, "LC_ActionLayersExport::trigger: Error encountered while exporting layers");
+
+            QApplication::restoreOverrideCursor();
+
+            finish();
+
+            return;
+        }
+    }
+
+
+
+    QApplication::restoreOverrideCursor();
+
+    finish();
+
+    RS_DEBUG->print("LC_ActionLayersExport::trigger: OK");
+}
+
+
+QString LC_ActionLayersExport::paddedIndex(int const& index, int const& totalNumber)
+{
+    if (totalNumber == 1) return "";
+
+    const int minimumPaddingDigits  = 2;
+    const int numberOfindexDigits   = QString::number(index).length();
+          int numberOfPaddingDigits = QString::number(totalNumber).length();
+
+    if (numberOfPaddingDigits < minimumPaddingDigits) numberOfPaddingDigits = minimumPaddingDigits;
+
+    return QString("0").repeated(numberOfPaddingDigits - numberOfindexDigits).append(QString::number(index));
+}
+

--- a/librecad/src/actions/lc_actionlayersexport.h
+++ b/librecad/src/actions/lc_actionlayersexport.h
@@ -1,0 +1,70 @@
+/****************************************************************************
+**
+** This file is part of the LibreCAD project, a 2D CAD program
+**
+** Copyright (C) 2021 Melwyn Francis Carlo
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU General Public License version 2 as published by the Free Software
+** Foundation and appearing in the file gpl-2.0.txt included in the
+** packaging of this file.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+**
+** This copyright notice MUST APPEAR in all copies of the script!
+**
+**********************************************************************/
+
+
+#pragma once
+
+
+#include "rs_actioninterface.h"
+
+
+class RS_LayerList;
+
+
+/*
+    This action class exports the current selected layers as a drawing file, 
+    either as individual files, or combined within a single file.
+*/
+
+
+class LC_ActionLayersExport : public RS_ActionInterface
+{
+    Q_OBJECT
+
+    public:
+
+        enum Mode
+        {
+            SelectedMode, 
+            VisibleMode 
+        };
+
+        LC_ActionLayersExport( RS_EntityContainer& document, 
+                               RS_GraphicView& graphicView, 
+                               RS_LayerList* inputLayersList, 
+                               Mode inputExportMode);
+
+        void init(int status=0) override;
+
+        void trigger() override;
+
+    private:
+
+        RS_LayerList* layersList;
+
+        Mode exportMode;
+
+        QString paddedIndex(int const& index, int const& totalNumber);
+};
+

--- a/librecad/src/lib/engine/rs.h
+++ b/librecad/src/lib/engine/rs.h
@@ -366,6 +366,8 @@ public:
         ActionLayersToggleLock,
         ActionLayersTogglePrint,
         ActionLayersToggleConstruction,
+        ActionLayersExportSelected,
+        ActionLayersExportVisible,
 
         ActionBlocksDefreezeAll,
         ActionBlocksFreezeAll,

--- a/librecad/src/lib/engine/rs_graphic.h
+++ b/librecad/src/lib/engine/rs_graphic.h
@@ -225,6 +225,16 @@ public:
         return variableDict.getVariableDict();
     }
 
+    RS_VariableDict getVariableDictObject()
+    {
+        return variableDict;
+    }
+
+    void setVariableDictObject(RS_VariableDict inputVariableDict)
+    {
+        variableDict = inputVariableDict;
+    }
+
     RS2::LinearFormat getLinearFormat();
     RS2::LinearFormat getLinearFormat(int f);
     int getLinearPrecision();

--- a/librecad/src/src.pro
+++ b/librecad/src/src.pro
@@ -399,6 +399,7 @@ HEADERS += actions/rs_actionblocksadd.h \
     actions/rs_actionlayerstoggleview.h \
     actions/rs_actionlayerstoggleprint.h \
     actions/lc_actionlayerstoggleconstruction.h \
+    actions/lc_actionlayersexport.h \
     actions/rs_actionlibraryinsert.h \
     actions/rs_actionlockrelativezero.h \
     actions/rs_actionmodifyattributes.h \
@@ -534,6 +535,7 @@ SOURCES += actions/rs_actionblocksadd.cpp \
     actions/rs_actionlayerstoggleview.cpp \
     actions/rs_actionlayerstoggleprint.cpp \
     actions/lc_actionlayerstoggleconstruction.cpp \
+    actions/lc_actionlayersexport.cpp \
     actions/rs_actionlibraryinsert.cpp \
     actions/rs_actionlockrelativezero.cpp \
     actions/rs_actionmodifyattributes.cpp \
@@ -696,7 +698,8 @@ HEADERS += ui/lc_actionfactory.h \
     ui/generic/colorcombobox.h \
     ui/generic/colorwizard.h \
     ui/lc_penwizard.h \
-    ui/generic/textfileviewer.h
+    ui/generic/textfileviewer.h \
+    ui/lc_filedialogservice.h
 
 SOURCES += ui/lc_actionfactory.cpp \
     ui/qg_actionhandler.cpp \
@@ -799,7 +802,8 @@ SOURCES += ui/lc_actionfactory.cpp \
     ui/generic/colorcombobox.cpp \
     ui/generic/colorwizard.cpp \
     ui/lc_penwizard.cpp \
-    ui/generic/textfileviewer.cpp
+    ui/generic/textfileviewer.cpp \
+    ui/lc_filedialogservice.cpp
 
 FORMS = ui/forms/qg_commandwidget.ui \
     ui/forms/qg_arcoptions.ui \

--- a/librecad/src/ui/lc_actionfactory.cpp
+++ b/librecad/src/ui/lc_actionfactory.cpp
@@ -448,6 +448,15 @@ void LC_ActionFactory::fillActionContainer(QMap<QString, QAction*>& a_map, LC_Ac
     action->setObjectName("PolylineDel");
     a_map["PolylineDel"] = action;
 
+    action = new QAction(tr("&Delete a polyline node promptly"), agm->polyline);
+    action->setShortcuts(QList<QKeySequence>() << QKeySequence(Qt::CTRL + Qt::Key_Delete) 
+                                               << QKeySequence(Qt::CTRL + Qt::Key_Backspace));
+    action->setIcon(QIcon(":/icons/delete_node.svg"));
+    connect(action, SIGNAL(triggered()),
+    action_handler, SLOT(slotDeletePolylineNodePromptly()));
+    action->setObjectName("DeletePolylineNodePromptly");
+    a_map["DeletePolylineNodePromptly"] = action;
+
     action = new QAction(tr("Delete &between two nodes"), agm->polyline);
     action->setShortcut(QKeySequence());
     action->setIcon(QIcon(":/icons/delete_between_nodes.svg"));
@@ -893,6 +902,16 @@ void LC_ActionFactory::fillActionContainer(QMap<QString, QAction*>& a_map, LC_Ac
             action_handler, SLOT(slotLayersToggleConstruction()));
     action->setObjectName("LayersToggleConstruction");
     a_map["LayersToggleConstruction"] = action;
+
+    action = new QAction(tr("&Export Selected Layer(s)"), agm->layer);
+    connect(action, &QAction::triggered, action_handler, &QG_ActionHandler::slotLayersExportSelected);
+    action->setObjectName("LayersExportSelected");
+    a_map["LayersExportSelected"] = action;
+
+    action = new QAction(tr("Export &Visible Layer(s)"), agm->layer);
+    connect(action, &QAction::triggered, action_handler, &QG_ActionHandler::slotLayersExportVisible);
+    action->setObjectName("LayersExportVisible");
+    a_map["LayersExportVisible"] = action;
 
     // <[~ Block ~]>
 

--- a/librecad/src/ui/lc_filedialogservice.cpp
+++ b/librecad/src/ui/lc_filedialogservice.cpp
@@ -1,0 +1,296 @@
+/****************************************************************************
+**
+** This file is part of the LibreCAD project, a 2D CAD program
+**
+** Copyright (C) 2021 Melwyn Francis Carlo
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU General Public License version 2 as published by the Free Software
+** Foundation and appearing in the file gpl-2.0.txt included in the
+** packaging of this file.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+**
+** This copyright notice MUST APPEAR in all copies of the script!
+**
+**********************************************************************/
+#include<iostream>
+
+#include <QDir>
+#include <QLayout>
+#include <QCheckBox>
+#include <QFileDialog>
+#include <QMessageBox>
+
+#include "rs.h"
+#include "rs_debug.h"
+#include "rs_settings.h"
+
+#include "lc_filedialogservice.h"
+
+
+/*
+    This service class centralizes the file I/O user interface.
+*/
+
+
+LC_FileDialogService::FileDialogResult LC_FileDialogService::getFileDetails (FileDialogMode const& fileDialogMode)
+{
+    RS_DEBUG->print("LC_FileDialogService::getFileName");
+
+    FileDialogResult result;
+
+
+
+    /* Constant variables initialization - START */
+        QStringList filters_stringList[] = 
+        {
+            /* Drawing filters */
+            {
+                "Drawing Exchange DXF 2007 (*.dxf)", 
+                "Drawing Exchange DXF 2004 (*.dxf)", 
+                "Drawing Exchange DXF 2000 (*.dxf)", 
+                "Drawing Exchange DXF R14 (*.dxf)", 
+                "Drawing Exchange DXF R12 (*.dxf)", 
+
+                #ifdef DWGSUPPORT
+                    "DWG Drawing (*.dwg)", 
+                #endif
+
+                "LFF Font (*.lff)", 
+                "QCAD Font (*.cxf)", 
+                "JWW Drawing (*.jww)" 
+            } 
+        };
+
+        QList<RS2::FormatType> filters_typeList[] = 
+        {
+            /* Drawing filters */
+            {
+                RS2::FormatDXFRW, 
+                RS2::FormatDXFRW2004, 
+                RS2::FormatDXFRW2000, 
+                RS2::FormatDXFRW14, 
+                RS2::FormatDXFRW12, 
+
+                #ifdef DWGSUPPORT
+                    RS2::FormatDWG, 
+                #endif
+
+                RS2::FormatLFF, 
+                RS2::FormatCXF, 
+                RS2::FormatJWW 
+            } 
+        };
+
+        /*
+            Number of values pertaining to the open file dialog mode, 
+            as defined in one of the relevant lists below.
+        */
+        const int numberOf_openFileModes = 0;
+
+        /* File save mode. */
+        if ((int) fileDialogMode >= (int) numberOf_openFileModes)
+        {
+            #ifndef JWW_WRITE_SUPPORT
+                filters_stringList[0].QList::removeLast();
+                filters_typeList[0].QList::removeLast();
+            #endif
+        }
+
+        const QStringList filterSettingsPaths = 
+        {
+            /* List of open modes. */
+
+
+            /* List of save modes. */
+            "/SaveDrawingFilter",               /* SaveDrawing mode           */
+            "/SaveDrawingFilter",               /* ExportLayersSelected mode  */
+            "/SaveDrawingFilter"                /* ExportLayersVisible mode   */
+        };
+
+        const QStringList fileIOSettingsPaths = 
+        {
+            /* List of open modes. */
+
+
+            /* List of save modes. */
+            "/Save",                            /* SaveDrawing mode           */
+            "/Save",                            /* ExportLayersSelected mode  */
+            "/Save"                             /* ExportLayersVisible mode   */
+        };
+
+        const int defaultFilters_indices[] = 
+        {
+            /* List of open modes. */
+
+
+            /* List of save modes. */
+            0,                                  /* SaveDrawing mode           */
+            0,                                  /* ExportLayersSelected mode  */
+            0                                   /* ExportLayersVisible mode   */
+        };
+
+        const QStringList fileDialogTitles = 
+        {
+            /* List of open modes. */
+
+
+            /* List of save modes. */
+            "Save Drawing as",                  /* SaveDrawing mode           */
+            "Export selected layer(s)",         /* ExportLayersSelected mode  */
+            "Export visible layer(s)"           /* ExportLayersVisible mode   */
+        };
+    /* Constant variables initialization - END */
+
+
+
+    /* Reading from path settings - START */
+        RS_SETTINGS->beginGroup("/Paths");
+        QString defaultDir    = RS_SETTINGS->readEntry( fileIOSettingsPaths.at (fileDialogMode), 
+                                                        QDir::toNativeSeparators (QDir::homePath()));
+
+        QString defaultFilter = RS_SETTINGS->readEntry( filterSettingsPaths.at (fileDialogMode), 
+                                                        filters_stringList [defaultFilters_indices [fileDialogMode]].at(0));
+        RS_SETTINGS->endGroup();
+    /* Reading from path settings - END */
+
+
+
+    /* Setting up the QFileDialog widget - START */
+        QFileDialog* saveFileDialog = new QFileDialog( nullptr, 
+                                                       fileDialogTitles.at (fileDialogMode), 
+                                                       defaultDir, 
+                                                       filters_stringList [defaultFilters_indices [fileDialogMode]].join(";;"));
+
+        saveFileDialog->QFileDialog::selectNameFilter (defaultFilter);
+
+        /* File open mode. */
+        if ((int) fileDialogMode < (int) numberOf_openFileModes)
+        {
+            saveFileDialog->QFileDialog::setAcceptMode (QFileDialog::AcceptOpen);
+        }
+        /* File save mode. */
+        else
+        {
+            saveFileDialog->QFileDialog::setAcceptMode (QFileDialog::AcceptSave);
+        }
+
+        saveFileDialog->setOption (QFileDialog::HideNameFilterDetails, false);
+    /* Setting up the QFileDialog widget - END */
+
+
+
+    /* Reading from default settings - START */
+        RS_SETTINGS->beginGroup("/Defaults");
+
+        if (RS_SETTINGS->readEntry("/UseQtFileOpenDialog", 0) == 0)
+        {
+            saveFileDialog->setOption (QFileDialog::DontUseNativeDialog, false);
+        }
+        else
+        {
+            saveFileDialog->setOption (QFileDialog::DontUseNativeDialog, true);
+        }
+
+        RS_SETTINGS->endGroup();
+    /* Reading from default settings - END */
+
+
+
+    /* Styling the QFileDialog widget - START LC_FileDialogService*/
+        QCheckBox *checkBox_combinedSave = nullptr;
+
+        if ((fileDialogMode == ExportLayersSelected) || (fileDialogMode == ExportLayersVisible))
+        {
+            checkBox_combinedSave = new QCheckBox(QObject::tr("Combine all layers"));
+
+            saveFileDialog->layout()->addWidget((QWidget *)checkBox_combinedSave);
+        }
+    /* Styling the QFileDialog widget - END */
+
+
+
+    while (1)
+    {
+        if (saveFileDialog->QFileDialog::exec() == QDialog::Accepted)
+        {
+            result.filePath = QDir::toNativeSeparators (QFileInfo (saveFileDialog->QFileDialog::selectedFiles().at(0)).absoluteFilePath());
+            result.dirPath  = QFileInfo(result.filePath).absolutePath();
+            result.fileName = QFileInfo(result.filePath).fileName();
+
+            const QString selectedFilter = saveFileDialog->QFileDialog::selectedNameFilter();
+
+            result.fileType = filters_typeList [defaultFilters_indices [fileDialogMode]].at (
+
+                                    filters_stringList [defaultFilters_indices [fileDialogMode]].indexOf (selectedFilter)
+                              );
+
+            /* File save mode. */
+            if ((int) fileDialogMode >= (int) numberOf_openFileModes)
+            {
+                QString saveFileExtension = selectedFilter.mid (selectedFilter.lastIndexOf ('.'));
+                saveFileExtension.chop(1);
+
+                result.fileExtension = saveFileExtension;
+
+                if (!result.fileName.contains (saveFileExtension)) result.filePath += saveFileExtension;
+
+                #if !defined (_WIN32) && !defined (__APPLE__)
+                    /* Confirm if the user wants to overwrite an existing file. */
+                    if (QFileInfo(result.filePath).exists())
+                    {
+                        int replaceFileResponse = QMessageBox::warning(
+
+                                                      nullptr, 
+                                                      fileDialogTitles.at (fileDialogMode), 
+                                                      QObject::tr("File '%1' already exists. Do you want to replace it?").arg(result.fileName), 
+                                                      QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel, QMessageBox::Cancel 
+                                                  );
+
+                        if (replaceFileResponse != QMessageBox::Yes) continue;
+                    }
+                #endif
+            }
+
+            if (checkBox_combinedSave != nullptr) result.checkState = checkBox_combinedSave->checkState();
+
+
+            /* Writing to path settings - START */
+                RS_SETTINGS->beginGroup("/Paths");
+                RS_SETTINGS->writeEntry(fileIOSettingsPaths.at (fileDialogMode), result.dirPath);
+                RS_SETTINGS->writeEntry(filterSettingsPaths.at (fileDialogMode), selectedFilter);
+                RS_SETTINGS->endGroup();
+            /* Writing to path settings - END */
+
+
+            break;
+        }
+        else
+        {
+            result.checkState = -1;
+
+            result.filePath      = "";
+            result.dirPath       = "";
+            result.fileName      = "";
+            result.fileExtension = "";
+            result.fileType = RS2::FormatUnknown;
+
+            break;
+        }
+    }
+
+    delete saveFileDialog;
+
+    RS_DEBUG->print("LC_FileDialogService::getFileName: OK");
+
+    return result;
+}
+

--- a/librecad/src/ui/lc_filedialogservice.h
+++ b/librecad/src/ui/lc_filedialogservice.h
@@ -1,0 +1,63 @@
+/****************************************************************************
+**
+** This file is part of the LibreCAD project, a 2D CAD program
+**
+** Copyright (C) 2021 Melwyn Francis Carlo
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU General Public License version 2 as published by the Free Software
+** Foundation and appearing in the file gpl-2.0.txt included in the
+** packaging of this file.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+**
+** This copyright notice MUST APPEAR in all copies of the script!
+**
+**********************************************************************/
+
+
+#pragma once
+
+
+/*
+    This service class centralizes the file I/O user interface.
+*/
+
+
+class LC_FileDialogService
+{
+    public:
+
+        enum FileDialogMode
+        {
+            /* List of open modes. */
+
+
+            /* List of save modes.*/
+            SaveDrawing, 
+            ExportLayersSelected, 
+            ExportLayersVisible 
+        };
+
+        typedef struct
+        {
+            int checkState;
+
+            QString dirPath;
+            QString filePath;
+            QString fileName;
+            QString fileExtension;
+            RS2::FormatType fileType;
+
+        } FileDialogResult;
+
+        static LC_FileDialogService::FileDialogResult getFileDetails (FileDialogMode const& fileDialogMode);
+};
+

--- a/librecad/src/ui/lc_widgetfactory.cpp
+++ b/librecad/src/ui/lc_widgetfactory.cpp
@@ -111,6 +111,7 @@ LC_WidgetFactory::LC_WidgetFactory(QC_ApplicationWindow* main_win,
             << a_map["PolylineAdd"]
             << a_map["PolylineAppend"]
             << a_map["PolylineDel"]
+            << a_map["DeletePolylineNodePromptly"]
             << a_map["PolylineDelBetween"]
             << a_map["PolylineTrim"]
             << a_map["PolylineEquidistant"]
@@ -178,7 +179,9 @@ LC_WidgetFactory::LC_WidgetFactory(QC_ApplicationWindow* main_win,
             << a_map["LayersToggleLock"]
             << a_map["LayersToggleView"]
             << a_map["LayersTogglePrint"]
-            << a_map["LayersToggleConstruction"];
+            << a_map["LayersToggleConstruction"]
+            << a_map["LayersExportSelected"]
+            << a_map["LayersExportVisible"];
 
     block_actions
             << a_map["BlocksDefreezeAll"]

--- a/librecad/src/ui/qg_actionhandler.cpp
+++ b/librecad/src/ui/qg_actionhandler.cpp
@@ -110,6 +110,8 @@
 #include "rs_actionlayerstoggleview.h"
 #include "rs_actionlayerstoggleprint.h"
 #include "lc_actionlayerstoggleconstruction.h"
+#include "lc_actionlayersexport.h"
+#include "rs_actionlibraryinsert.h"
 #include "rs_actionlibraryinsert.h"
 #include "rs_actionlockrelativezero.h"
 #include "rs_actionmodifyattributes.h"
@@ -163,6 +165,8 @@
 #include "rs_actionpolylinesegment.h"
 #include "rs_selection.h"
 #include "rs_actionorder.h"
+
+#include "rs_modification.h"
 
 #include "qg_snaptoolbar.h"
 #include "rs_debug.h"
@@ -871,6 +875,12 @@ RS_ActionInterface* QG_ActionHandler::setCurrentAction(RS2::ActionType id) {
         break;
     case RS2::ActionLayersToggleConstruction:
         a = new LC_ActionLayersToggleConstruction(*document, *view, a_layer);
+        break;
+    case RS2::ActionLayersExportSelected:
+        a = new LC_ActionLayersExport(*document, *view, document->getLayerList(), LC_ActionLayersExport::SelectedMode);
+        break;
+    case RS2::ActionLayersExportVisible:
+        a = new LC_ActionLayersExport(*document, *view, document->getLayerList(), LC_ActionLayersExport::VisibleMode);
         break;
         // Block actions:
         //
@@ -1859,6 +1869,14 @@ void QG_ActionHandler::slotLayersToggleConstruction() {
     setCurrentAction(RS2::ActionLayersToggleConstruction);
 }
 
+void QG_ActionHandler::slotLayersExportSelected() {
+    setCurrentAction(RS2::ActionLayersExportSelected);
+}
+
+void QG_ActionHandler::slotLayersExportVisible() {
+    setCurrentAction(RS2::ActionLayersExportVisible);
+}
+
 
 void QG_ActionHandler::slotBlocksDefreezeAll() {
     setCurrentAction(RS2::ActionBlocksDefreezeAll);
@@ -1942,6 +1960,15 @@ void QG_ActionHandler::toggleConstruction(RS_Layer* layer)
 {
     auto a = new LC_ActionLayersToggleConstruction(*document, *view, layer);
     view->setCurrentAction(a);
+}
+
+void QG_ActionHandler::slotDeletePolylineNodePromptly()
+{
+    RS_Modification m(*document, view);
+
+    m.setDeletePolylineNodeMode();
+
+    m.remove();
 }
 
 // EOF

--- a/librecad/src/ui/qg_actionhandler.h
+++ b/librecad/src/ui/qg_actionhandler.h
@@ -241,6 +241,8 @@ public slots:
 	void slotLayersToggleLock();
 	void slotLayersTogglePrint();
 	void slotLayersToggleConstruction();
+    void slotLayersExportSelected();
+    void slotLayersExportVisible();
 
 	void slotBlocksDefreezeAll();
 	void slotBlocksFreezeAll();
@@ -254,6 +256,8 @@ public slots:
 	void slotBlocksCreate();
 	void slotBlocksExplode();
 	void slotOptionsDrawing();
+
+   void slotDeletePolylineNodePromptly();
 
     void toggleVisibility(RS_Layer* layer);
     void toggleLock(RS_Layer* layer);

--- a/librecad/src/ui/qg_layerwidget.cpp
+++ b/librecad/src/ui/qg_layerwidget.cpp
@@ -583,6 +583,15 @@ void QG_LayerWidget::contextMenuEvent(QContextMenuEvent *e) {
                                  SLOT(slotLayersAdd()), 0);
         contextMenu->addAction( tr("Edit Layer &Attributes"), actionHandler,
                                  SLOT(slotLayersEdit()), 0);
+
+        contextMenu->addSeparator();
+
+        contextMenu->addAction( tr("&Export Selected Layer(s)"), actionHandler,
+                                &QG_ActionHandler::slotLayersExportSelected, 0);
+
+        contextMenu->addAction( tr("Export &Visible Layer(s)"), actionHandler,
+                                &QG_ActionHandler::slotLayersExportVisible,  0);
+
         contextMenu->exec(QCursor::pos());
         delete contextMenu;
     }


### PR DESCRIPTION
* Solved issue #1327

Using this tool, you may now save either selected layers or visible layers, either as individual drawing files, or combined into a single drawing file. The layer names and attributes are saved as well.

To accomplish this task, I have also created the `LC_FileDialogService` class. This class centralizes the file I/O user interface. So, basically, this file dialog can be made to serve multiple purposes by tweaking the `*.cpp` file itself, and passing in just one argument: the `FileDialogMode` enumeration. This enumeration tells the class functions how to design the file dialog. So, for example, a specific dialog title, specific file filters, and particularly, in my case, the `Checkbox` element embedded within the file dialog.

<hr>

Video link :  [https://youtu.be/9_qHtZfwMdY](https://youtu.be/9_qHtZfwMdY)