### PR TITLE
Set relative zero while doing copy/paste, w.r.t issue #1404

### DIFF
--- a/librecad/src/actions/rs_actioneditcopy.cpp
+++ b/librecad/src/actions/rs_actioneditcopy.cpp
@@ -88,11 +88,12 @@ void RS_ActionEditCopy::mouseReleaseEvent(QMouseEvent* e) {
 
 
 
-void RS_ActionEditCopy::coordinateEvent(RS_CoordinateEvent* e) {
-	if (!e)
-        return;
+void RS_ActionEditCopy::coordinateEvent(RS_CoordinateEvent* e)
+{
+    if (!e) return;
 
-	*referencePoint = e->getCoordinate();
+    graphicView->moveRelativeZero(e->getCoordinate());
+   *referencePoint = e->getCoordinate();
     trigger();
 }
 

--- a/librecad/src/actions/rs_actioneditpaste.cpp
+++ b/librecad/src/actions/rs_actioneditpaste.cpp
@@ -108,10 +108,12 @@ void RS_ActionEditPaste::mouseReleaseEvent(QMouseEvent* e) {
 
 
 
-void RS_ActionEditPaste::coordinateEvent(RS_CoordinateEvent* e) {
-	if (e==nullptr) return;
+void RS_ActionEditPaste::coordinateEvent(RS_CoordinateEvent* e)
+{
+    if (e == nullptr) return;
 
-	*targetPoint = e->getCoordinate();
+    graphicView->moveRelativeZero(e->getCoordinate());
+   *targetPoint = e->getCoordinate();
     trigger();
 }
 


### PR DESCRIPTION
* Set relative zero while doing copy/paste, w.r.t issue #1404

<hr>

In the file `rs_actionmodifymove.cpp` (which deals with the `Cut` operation), at line numbers _139_ and _145_, the `moveRelativeZero()` functions are present. However, they were not present in the `Copy` and `Paste` class files; now they are.

As @gerardbm had stated, it assists in copy-pasting at the correct locations.