### PR TITLE
tangent 3 circle sometimes fails with parallels, fixes #1386

### DIFF
--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -847,11 +847,14 @@ bool RS_Math::linearSolver(const std::vector<std::vector<double> >& mt, std::vec
 		size_t imax(i);
         double cmax(fabs(mt0[i][i]));
 		for(size_t j=i+1;j<mSize;++j) {
-            if(fabs(mt0[j][i]) > cmax ) {
+            if(std::abs(mt0[j][i]) > cmax ) {
                 imax=j;
-                cmax=fabs(mt0[j][i]);
+                cmax=std::abs(mt0[j][i]);
             }
         }
+	
+	// issue #1386: relax singular condition
+	// TODO: switch to QR-decomposition based algorithms
         if(cmax<RS_TOLERANCE) return false; //singular matrix
         if(imax != i) {//move the line with largest absolute value at column i to row i, to avoid division by zero
             std::swap(mt0[i],mt0[imax]);

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -852,7 +852,7 @@ bool RS_Math::linearSolver(const std::vector<std::vector<double> >& mt, std::vec
                 cmax=fabs(mt0[j][i]);
             }
         }
-        if(cmax<RS_TOLERANCE2) return false; //singular matrix
+        if(cmax<RS_TOLERANCE) return false; //singular matrix
         if(imax != i) {//move the line with largest absolute value at column i to row i, to avoid division by zero
             std::swap(mt0[i],mt0[imax]);
 		}


### PR DESCRIPTION
* Solved issue #1386

<hr>

It fails because the two _parallel_ lines are always registered as _intersecting_ lines. The actual problem lies in the `RS_Math::linearSolver()` function that is called by the `LC_Quadratic::getIntersection()` function.

The tolerance set was too low (`TOLERANCE2 = 1.0E-20`), and such a tolerance (by its definition) is only meant to be used when dealing with decimal multiplication. I've set it to the basic `TOLERANCE = 1.0E-10`.

It seems to be working all fine now.

<hr>

Video link :  [https://youtu.be/ldPNDQmRnqA](https://youtu.be/ldPNDQmRnqA)