### PR TITLE
dimension ticks missing on radial and angular, fixes #1328

### DIFF
--- a/librecad/src/lib/engine/rs_dimangular.cpp
+++ b/librecad/src/lib/engine/rs_dimangular.cpp
@@ -241,41 +241,49 @@ void RS_DimAngular::arrow(const RS_Vector& point,
                           const LC_DimAngularVars& av,
                           const RS_Pen& pen)
 {
-    if (RS_TOLERANCE_ANGLE >= av.arrow()) {
-        // arrow size is 0, no need to add an arrow
-        return;
-    }
+    if ((getTickSize() * getGeneralScale()) < 0.01)
+    {
+        double arrowAngle {0.0};
 
-    double arrowAngle {0.0};
+        if (outsideArrows) {
+            // for outside arrows use tangent angle on endpoints
+            // because for small radius the arrows looked inclined
+            arrowAngle = angle + std::copysign( M_PI_2, direction);
+        }
+        else
+        {
+            // compute the angle from center to the endpoint of the arrow on the arc
+            double endAngle {0.0};
 
-    if (outsideArrows) {
-        // for outside arrows use tangent angle on endpoints
-        // because for small radius the arrows looked inclined
-        arrowAngle = angle + std::copysign( M_PI_2, direction);
-    }
-    else {
-        // compute the angle from center to the endpoint of the arrow on the arc
-        double endAngle {0.0};
-        if (RS_TOLERANCE_ANGLE < dimRadius) {
-            endAngle = av.arrow() / dimRadius;
+            if (RS_TOLERANCE_ANGLE < dimRadius) endAngle = av.arrow() / dimRadius;
+
+            // compute the endpoint of the arrow on the arc
+            RS_Vector arrowEnd;
+            arrowEnd.setPolar(dimRadius, angle + std::copysign(endAngle, direction));
+            arrowEnd  += dimCenter;
+            arrowAngle = arrowEnd.angleTo( point);
         }
 
-        // compute the endpoint of the arrow on the arc
-        RS_Vector arrowEnd;
-        arrowEnd.setPolar( dimRadius, angle + std::copysign( endAngle, direction));
-        arrowEnd += dimCenter;
-        arrowAngle = arrowEnd.angleTo( point);
+        RS_SolidData sd;
+        RS_Solid* arrow;
+
+        arrow = new RS_Solid(this, sd);
+        arrow->shapeArrow(point, arrowAngle, av.arrow());
+        arrow->setPen( pen);
+        arrow->setLayer(nullptr);
+        addEntity(arrow);
     }
+    else
+    {
+        RS_Line* tick;
+        RS_Vector tickVector = RS_Vector::polar( getTickSize() * getGeneralScale(), 
+                                                 (dimAngleL1 + dimAngleL2) / 2.0);
 
-    RS_SolidData sd;
-    RS_Solid* arrow;
-
-    arrow = new RS_Solid( this, sd);
-    arrow->shapeArrow( point, arrowAngle, av.arrow());
-    arrow->setPen( pen);
-    arrow->setLayer( nullptr);
-    addEntity( arrow);
-
+        tick = new RS_Line(this, point - tickVector, point + tickVector);
+        tick->setPen(pen);
+        tick->setLayer(nullptr);
+        addEntity(tick);
+    }
 }
 
 /**

--- a/librecad/src/lib/engine/rs_dimradial.cpp
+++ b/librecad/src/lib/engine/rs_dimradial.cpp
@@ -164,25 +164,26 @@ void RS_DimRadial::updateDim(bool autoText) {
     RS_MText* text = new RS_MText(this, textData);
     double textWidth = text->getSize().x;
 
-    double tick_size = getTickSize()*dimscale;
     double arrow_size = getArrowSize()*dimscale;
     double length = p1.distanceTo(p2); // line length
 
-    bool outsideArrow = false;
+    // do we have to put the arrow / text outside of the arc?
+    bool outsideArrow = (length < ((arrow_size * 2.0) + textWidth));
 
-    if (tick_size == 0 && arrow_size != 0)
+    double arrowAngle;
+
+    if (outsideArrow)
     {
-        // do we have to put the arrow / text outside of the arc?
-        outsideArrow = (length < arrow_size*2+textWidth);
-        double arrowAngle;
+        length += (arrow_size * 2) + textWidth;
+        arrowAngle = angle + M_PI;
+    }
+    else
+    {
+        arrowAngle = angle;
+    }
 
-        if (outsideArrow) {
-            length += arrow_size*2 + textWidth;
-            arrowAngle = angle+M_PI;
-        } else {
-            arrowAngle = angle;
-        }
-
+    if ((getTickSize() * getGeneralScale()) < 0.01)
+    {
         // create arrow:
         RS_SolidData sd;
         RS_Solid* arrow;
@@ -192,6 +193,17 @@ void RS_DimRadial::updateDim(bool autoText) {
         arrow->setPen(pen);
         arrow->setLayer(nullptr);
         addEntity(arrow);
+    }
+    else
+    {
+        RS_Line* tick;
+        RS_Vector tickVector = RS_Vector::polar( getTickSize() * dimscale, 
+                                                 arrowAngle + (M_PI_2 / 2.0));
+
+        tick = new RS_Line(this, p2 - tickVector, p2 + tickVector);
+        tick->setPen(pen);
+        tick->setLayer(nullptr);
+        addEntity(tick);
     }
 
 	RS_Vector p3 = RS_Vector::polar(length, angle);


### PR DESCRIPTION
* Solved issue #1328

<hr>

![No_ticks_before](https://user-images.githubusercontent.com/66683108/143776527-9a810164-3948-4d54-bec9-45910cb33154.png)

<hr>

![Ticks_after](https://user-images.githubusercontent.com/66683108/143776537-51f28951-1fdf-4d97-8c19-943e8d18d529.png)
