### PR TITLE
Added NULL check for DXF hatch code 93, Fixing issue #1468

### DIFF
--- a/libraries/libdxfrw/src/drw_entities.cpp
+++ b/libraries/libdxfrw/src/drw_entities.cpp
@@ -1805,7 +1805,7 @@ void DRW_Hatch::parseCode(int code, dxfReader *reader){
         break;
     case 93:
         if (pline) pline->vertexnum = reader->getInt32();
-        else loop->numedges = reader->getInt32();//aqui reserve
+        else if (loop) loop->numedges = reader->getInt32();//aqui reserve
         break;
     case 98: //seed points ??
         clearEntities();


### PR DESCRIPTION
This fixes issue #1468

This patch is based on other similar code in the same function, e.g.
```c++
    case 73:
        if (arc) arc->isccw = reader->getInt32();
        else if (pline) pline->flags = reader->getInt32();
        break;
```

The end result is that if code 93 comes before the code 92 which would initialize the `loop` pointer, the code 93 is ignored.