### PR TITLE
FIx various source comment typos

### DIFF
--- a/librecad/src/lib/engine/rs_ellipse.cpp
+++ b/librecad/src/lib/engine/rs_ellipse.cpp
@@ -466,7 +466,7 @@ RS_Vector  RS_Ellipse::getEllipsePoint(const double& a) const {
     return p;
 }
 
-/** \brief implemented using an analytical aglorithm
+/** \brief implemented using an analytical algorithm
 * find nearest point on ellipse to a given point
 *
 * @author Dongxu Li <dongxuli2011@gmail.com>

--- a/librecad/src/lib/engine/rs_system.cpp
+++ b/librecad/src/lib/engine/rs_system.cpp
@@ -572,9 +572,9 @@ QStringList RS_System::getDirectoryList(const QString& _subDirectory) {
 #ifdef Q_OS_UNIX
     RS_DEBUG->print( RS_Debug::D_ERROR, "RS_System::getDirectoryList: %s", appDir.toStdString().c_str());
     // for AppImage use relative paths from executable
-    // from packet manager the executable is in /usr/bin
+    // from package manager the executable is in /usr/bin
     // in AppImage the executable is APPDIR/usr/bin
-    // so this should work for paket manager and AppImage distribution
+    // so this should work for package manager and AppImage distribution
     dirList.append( QDir::cleanPath( appDir + "/../share/doc/" + appDirName + "/" + subDirectory));
 
     // Redhat style:


### PR DESCRIPTION
Found via `codespell -q 3 -S *.ts,./libraries,*.dxf,*.lff,*.desktop -L ans,atleast,ba,bload,ded,inout,lightyear,recources,trun`