### PR TITLE
fillets caused spurious lines, fixes #1496

### DIFF
--- a/librecad/src/ui/forms/qg_dlgpolyline.cpp
+++ b/librecad/src/ui/forms/qg_dlgpolyline.cpp
@@ -81,7 +81,7 @@ void QG_DlgPolyline::setPolyline(RS_Polyline& e) {
 
 
 void QG_DlgPolyline::updatePolyline() {
-    polyline->setClosed(cbClosed->isChecked(), 0.0);
+    polyline->setClosed(cbClosed->isChecked());
     polyline->setPen(wPen->getPen());
     polyline->setLayer(cbLayer->currentText());
         polyline->update();


### PR DESCRIPTION
* Solved issue #1496

<hr>

A very amusing fact is that you might think that the problem arises from the function that deals with setting the line type, but no, not at all. It comes from the function that deals with closing the polyline.

This change fixes the mentioned issue; though I am unaware of its implications elsewhere.
But, as it only deals with the extrinsic properties of lines, and _not_ their physical shape, it shouldn't pose any problem.