### PR TITLE
improve arc SVG export, fixes #1493

### DIFF
--- a/librecad/src/lib/gui/rs_painterqt.cpp
+++ b/librecad/src/lib/gui/rs_painterqt.cpp
@@ -263,19 +263,30 @@ void RS_PainterQt::drawArc(const RS_Vector& cp, double radius,
  * @param a2 Angle 2 in rad
  * @param reversed true: clockwise, false: counterclockwise
  */
-void RS_PainterQt::drawArc(const RS_Vector& cp, double radius,
-                           double a1, double a2,
-                           bool reversed) {
-    if(radius<=0.5) {
+void RS_PainterQt::drawArc( const RS_Vector& cp, 
+                            double radius,
+                            double a1, 
+                            double a2,
+                            bool reversed)
+{
+    if (radius <= 0.5)
+    {
         drawGridPoint(cp);
-    } else {
-#ifdef __APPL1E__
-                drawArcMac(cp, radius, a1, a2, reversed);
-#else
-        QPolygon pa;
-        createArc(pa, cp, radius, a1, a2, reversed);
-        drawPolyline(pa);
-#endif
+    }
+    else
+    {
+        if (reversed)
+        {
+            a1 = 360.0 - a1;
+            a2 = 360.0 - a2;
+        }
+
+        QPainter::drawArc( toScreenX(cp.x - radius), 
+                           toScreenY(cp.y - radius), 
+                           2.0 * radius, 
+                           2.0 * radius, 
+                           a1  * 16.0 * 180.0 / M_PI, 
+                       (a2-a1) * 16.0 * 180.0 / M_PI);
     }
 }
 


### PR DESCRIPTION
* Solving issue #1493 

<hr>

I wonder if it works on Mac as well.

Still got to look into fixing the broken text.
The text looks broken because the text is basically drawn using `RS_Polyline` entities;
hence, linear graphics like `1` and `7` look great, but other curved graphics look incoherent.

<hr>

![A_Crisp_SVG_Arc](https://user-images.githubusercontent.com/66683108/148682152-1a61343d-ec19-4f39-9ebc-3ff7315a2305.png)
