### PR TITLE
unit conversion when switching between drawings, fixes #1482

### DIFF
--- a/librecad/src/lib/engine/rs_dimaligned.cpp
+++ b/librecad/src/lib/engine/rs_dimaligned.cpp
@@ -34,6 +34,7 @@
 #include "rs_constructionline.h"
 #include "rs_math.h"
 #include "rs_debug.h"
+#include "rs_settings.h"
 
 RS_DimAlignedData::RS_DimAlignedData():
 	extensionPoint1(false),
@@ -106,7 +107,11 @@ RS_VectorSolutions RS_DimAligned::getRefPoints() const
  * measurement of this dimension.
  */
 QString RS_DimAligned::getMeasuredLabel() {
-	double dist = RS_Units::convert(edata.extensionPoint1.distanceTo(edata.extensionPoint2) * getGeneralFactor());
+	double dist = edata.extensionPoint1.distanceTo(edata.extensionPoint2) * getGeneralFactor();
+
+    RS_SETTINGS->beginGroup("/Appearance");
+    if (RS_SETTINGS->readNumEntry("/UnitlessGrid", 1) != 1) dist = RS_Units::convert(dist);
+    RS_SETTINGS->endGroup();
 
     RS_Graphic* graphic = getGraphic();
     QString ret;

--- a/librecad/src/lib/engine/rs_dimaligned.cpp
+++ b/librecad/src/lib/engine/rs_dimaligned.cpp
@@ -106,7 +106,7 @@ RS_VectorSolutions RS_DimAligned::getRefPoints() const
  * measurement of this dimension.
  */
 QString RS_DimAligned::getMeasuredLabel() {
-	double dist = edata.extensionPoint1.distanceTo(edata.extensionPoint2) * getGeneralFactor();
+	double dist = RS_Units::convert(edata.extensionPoint1.distanceTo(edata.extensionPoint2) * getGeneralFactor());
 
     RS_Graphic* graphic = getGraphic();
     QString ret;

--- a/librecad/src/lib/engine/rs_dimdiametric.cpp
+++ b/librecad/src/lib/engine/rs_dimdiametric.cpp
@@ -86,7 +86,7 @@ RS_Entity* RS_DimDiametric::clone() const {
 QString RS_DimDiametric::getMeasuredLabel() {
 
     // Definitive dimension line:
-	double dist = data.definitionPoint.distanceTo(edata.definitionPoint) * getGeneralFactor();
+	double dist = RS_Units::convert(data.definitionPoint.distanceTo(edata.definitionPoint) * getGeneralFactor());
 
     RS_Graphic* graphic = getGraphic();
 

--- a/librecad/src/lib/engine/rs_dimdiametric.cpp
+++ b/librecad/src/lib/engine/rs_dimdiametric.cpp
@@ -31,6 +31,7 @@
 #include "rs_graphic.h"
 #include "rs_units.h"
 #include "rs_debug.h"
+#include "rs_settings.h"
 
 RS_DimDiametricData::RS_DimDiametricData():
 	definitionPoint(false),
@@ -86,7 +87,11 @@ RS_Entity* RS_DimDiametric::clone() const {
 QString RS_DimDiametric::getMeasuredLabel() {
 
     // Definitive dimension line:
-	double dist = RS_Units::convert(data.definitionPoint.distanceTo(edata.definitionPoint) * getGeneralFactor());
+	double dist = data.definitionPoint.distanceTo(edata.definitionPoint) * getGeneralFactor();
+
+    RS_SETTINGS->beginGroup("/Appearance");
+    if (RS_SETTINGS->readNumEntry("/UnitlessGrid", 1) != 1) dist = RS_Units::convert(dist);
+    RS_SETTINGS->endGroup();
 
     RS_Graphic* graphic = getGraphic();
 

--- a/librecad/src/lib/engine/rs_dimlinear.cpp
+++ b/librecad/src/lib/engine/rs_dimlinear.cpp
@@ -34,6 +34,7 @@
 #include "rs_graphic.h"
 #include "rs_math.h"
 #include "rs_debug.h"
+#include "rs_settings.h"
 
 
 RS_DimLinearData::RS_DimLinearData():
@@ -113,7 +114,11 @@ QString RS_DimLinear::getMeasuredLabel() {
     RS_Vector dimP2 = dimLine.getNearestPointOnEntity(edata.extensionPoint2);
 
     // Definitive dimension line:
-    double dist = RS_Units::convert(dimP1.distanceTo(dimP2) * getGeneralFactor());
+    double dist = dimP1.distanceTo(dimP2) * getGeneralFactor();
+
+    RS_SETTINGS->beginGroup("/Appearance");
+    if (RS_SETTINGS->readNumEntry("/UnitlessGrid", 1) != 1) dist = RS_Units::convert(dist);
+    RS_SETTINGS->endGroup();
 
         RS_Graphic* graphic = getGraphic();
 

--- a/librecad/src/lib/engine/rs_dimlinear.cpp
+++ b/librecad/src/lib/engine/rs_dimlinear.cpp
@@ -113,7 +113,7 @@ QString RS_DimLinear::getMeasuredLabel() {
     RS_Vector dimP2 = dimLine.getNearestPointOnEntity(edata.extensionPoint2);
 
     // Definitive dimension line:
-    double dist = dimP1.distanceTo(dimP2) * getGeneralFactor();
+    double dist = RS_Units::convert(dimP1.distanceTo(dimP2) * getGeneralFactor());
 
         RS_Graphic* graphic = getGraphic();
 

--- a/librecad/src/lib/engine/rs_dimradial.cpp
+++ b/librecad/src/lib/engine/rs_dimradial.cpp
@@ -32,6 +32,7 @@
 #include "rs_solid.h"
 #include "rs_graphic.h"
 #include "rs_debug.h"
+#include "rs_settings.h"
 
 RS_DimRadialData::RS_DimRadialData():
 	definitionPoint(false),
@@ -85,7 +86,11 @@ RS_Entity* RS_DimRadial::clone() const {
 QString RS_DimRadial::getMeasuredLabel() {
 
     // Definitive dimension line:
-	double dist = RS_Units::convert(data.definitionPoint.distanceTo(edata.definitionPoint) * getGeneralFactor());
+	double dist = data.definitionPoint.distanceTo(edata.definitionPoint) * getGeneralFactor();
+
+    RS_SETTINGS->beginGroup("/Appearance");
+    if (RS_SETTINGS->readNumEntry("/UnitlessGrid", 1) != 1) dist = RS_Units::convert(dist);
+    RS_SETTINGS->endGroup();
 
     RS_Graphic* graphic = getGraphic();
 

--- a/librecad/src/lib/engine/rs_dimradial.cpp
+++ b/librecad/src/lib/engine/rs_dimradial.cpp
@@ -85,7 +85,7 @@ RS_Entity* RS_DimRadial::clone() const {
 QString RS_DimRadial::getMeasuredLabel() {
 
     // Definitive dimension line:
-	double dist = data.definitionPoint.distanceTo(edata.definitionPoint) * getGeneralFactor();
+	double dist = RS_Units::convert(data.definitionPoint.distanceTo(edata.definitionPoint) * getGeneralFactor());
 
     RS_Graphic* graphic = getGraphic();
 

--- a/librecad/src/lib/engine/rs_units.cpp
+++ b/librecad/src/lib/engine/rs_units.cpp
@@ -33,6 +33,10 @@
 #include "rs_vector.h"
 #include "rs_debug.h"
 
+
+RS2::Unit RS_Units::currentDrawingUnits = (RS2::Unit) 0;
+
+
 /**
  * Converts a DXF integer () to a Unit enum.
  */
@@ -355,6 +359,13 @@ double RS_Units::getFactorToMM(RS2::Unit u) {
 		return 3.0856776e19;
     }
 
+}
+
+
+/* Default conversion : From RS2::Millimeter to Current Drawing Units. */
+double RS_Units::convert(double val)
+{
+    return convert(val, RS2::Millimeter, currentDrawingUnits);
 }
 
 

--- a/librecad/src/lib/engine/rs_units.h
+++ b/librecad/src/lib/engine/rs_units.h
@@ -39,8 +39,24 @@ class QString;
  *
  * @author Andrew Mustun
  */
-class RS_Units {
-public:
+class RS_Units
+{
+    private:
+
+        static RS2::Unit currentDrawingUnits;
+
+
+    public:
+
+        static void setCurrentDrawingUnits(RS2::Unit input_units)
+        {
+            currentDrawingUnits = input_units;
+        }
+
+        static RS2::Unit getCurrentDrawingUnits()
+        {
+            return currentDrawingUnits;
+        }
 
     //static char* unit2sign(RS2::Unit unit);
 
@@ -54,6 +70,7 @@ public:
 
 	static bool isMetric(RS2::Unit u);
 	static double getFactorToMM(RS2::Unit u);
+    static double convert(double val);
 	static double convert(double val, RS2::Unit src, RS2::Unit dest);
 	static RS_Vector convert(const RS_Vector& val, RS2::Unit src, RS2::Unit dest);
 	

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -995,6 +995,8 @@ void QC_ApplicationWindow::slotWindowActivated(QMdiSubWindow* w) {
     QC_MDIWindow* m = qobject_cast<QC_MDIWindow*>(w);
     enableFileActions(m);
 
+    RS_Units::setCurrentDrawingUnits(m->getDocument()->getGraphic()->getUnit());
+
     if (m && m->getDocument()) {
 
         RS_DEBUG->print("QC_ApplicationWindow::slotWindowActivated: "

--- a/librecad/src/ui/forms/qg_coordinatewidget.cpp
+++ b/librecad/src/ui/forms/qg_coordinatewidget.cpp
@@ -92,10 +92,15 @@ void QG_CoordinateWidget::setCoordinates(double x, double y,
             aprec = graphic->getAnglePrecision();
         }
 
-        x  = RS_Units::convert(x);
-        y  = RS_Units::convert(y);
-        rx = RS_Units::convert(rx);
-        ry = RS_Units::convert(ry);
+        RS_SETTINGS->beginGroup("/Appearance");
+        if (RS_SETTINGS->readNumEntry("/UnitlessGrid", 1) != 1)
+        {
+            x  = RS_Units::convert(x);
+            y  = RS_Units::convert(y);
+            rx = RS_Units::convert(rx);
+            ry = RS_Units::convert(ry);
+        }
+        RS_SETTINGS->endGroup();
 
         // abs / rel coordinates:
         QString absX = RS_Units::formatLinear(x,

--- a/librecad/src/ui/forms/qg_coordinatewidget.cpp
+++ b/librecad/src/ui/forms/qg_coordinatewidget.cpp
@@ -92,6 +92,11 @@ void QG_CoordinateWidget::setCoordinates(double x, double y,
             aprec = graphic->getAnglePrecision();
         }
 
+        x  = RS_Units::convert(x);
+        y  = RS_Units::convert(y);
+        rx = RS_Units::convert(rx);
+        ry = RS_Units::convert(ry);
+
         // abs / rel coordinates:
         QString absX = RS_Units::formatLinear(x,
                                                graphic->getUnit(),

--- a/librecad/src/ui/forms/qg_dlgoptionsdrawing.cpp
+++ b/librecad/src/ui/forms/qg_dlgoptionsdrawing.cpp
@@ -416,6 +416,8 @@ void QG_DlgOptionsDrawing::validate() {
         RS2::Unit unit = static_cast<RS2::Unit>(cbUnit->currentIndex());
 		graphic->setUnit(unit);
 
+        RS_Units::setCurrentDrawingUnits(unit);
+
         graphic->addVariable("$LUNITS", cbLengthFormat->currentIndex()+1, 70);
         graphic->addVariable("$LUPREC", cbLengthPrecision->currentIndex(), 70);
         graphic->addVariable("$AUNITS", cbAngleFormat->currentIndex(), 70);

--- a/librecad/src/ui/forms/qg_dlgoptionsgeneral.cpp
+++ b/librecad/src/ui/forms/qg_dlgoptionsgeneral.cpp
@@ -133,6 +133,9 @@ void QG_DlgOptionsGeneral::init()
     int checked = RS_SETTINGS->readNumEntry("/Antialiasing");
     cb_antialiasing->setChecked(checked?true:false);
 
+    checked = RS_SETTINGS->readNumEntry("/UnitlessGrid", 1);
+    cb_unitless_grid->setChecked(checked?true:false);
+
     checked = RS_SETTINGS->readNumEntry("/ScrollBars");
     scrollbars_check_box->setChecked(checked?true:false);
 
@@ -249,6 +252,7 @@ void QG_DlgOptionsGeneral::ok()
         RS_SETTINGS->writeEntry("/indicator_shape_state", indicator_shape_checkbox->isChecked());      
         RS_SETTINGS->writeEntry("/indicator_shape_type", indicator_shape_combobox->currentText());
         RS_SETTINGS->writeEntry("/cursor_hiding", cursor_hiding_checkbox->isChecked());
+        RS_SETTINGS->writeEntry("/UnitlessGrid", cb_unitless_grid->isChecked()?1:0);
         RS_SETTINGS->writeEntry("/Antialiasing", cb_antialiasing->isChecked()?1:0);
         RS_SETTINGS->writeEntry("/ScrollBars", scrollbars_check_box->isChecked()?1:0);
         RS_SETTINGS->endGroup();

--- a/librecad/src/ui/forms/qg_dlgoptionsgeneral.ui
+++ b/librecad/src/ui/forms/qg_dlgoptionsgeneral.ui
@@ -179,20 +179,27 @@
            </widget>
           </item>
           <item row="3" column="0">
+           <widget class="QCheckBox" name="cb_unitless_grid">
+            <property name="text">
+             <string>Unitless grid</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
            <widget class="QCheckBox" name="cb_antialiasing">
             <property name="text">
              <string>Anti-aliasing</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="5" column="0">
            <widget class="QCheckBox" name="scrollbars_check_box">
             <property name="text">
              <string>Scrollbars</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
+          <item row="6" column="0">
            <widget class="QCheckBox" name="cbScaleGrid">
             <property name="text">
              <string>A&amp;utomatically scale grid</string>
@@ -202,7 +209,7 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
+          <item row="7" column="0">
            <widget class="QLabel" name="lMinGridSpacing">
             <property name="text">
              <string>Minimal Grid Spacing (p&amp;x):</string>
@@ -215,7 +222,7 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="1">
+          <item row="7" column="1">
            <widget class="QComboBox" name="cbMinGridSpacing">
             <property name="editable">
              <bool>true</bool>
@@ -262,7 +269,7 @@
             </item>
            </widget>
           </item>
-          <item row="7" column="0">
+          <item row="8" column="0">
            <widget class="QLabel" name="lMaxPreview">
             <property name="text">
              <string>N&amp;umber of preview entities:</string>
@@ -275,7 +282,7 @@
             </property>
            </widget>
           </item>
-          <item row="7" column="1">
+          <item row="8" column="1">
            <widget class="QComboBox" name="cbMaxPreview">
             <property name="editable">
              <bool>true</bool>


### PR DESCRIPTION
* Solved issue #1482

When switching between drawings, the mouse position and dimensions would, thereafter, adjust themselves accordingly to suit the current drawing sheet's units, subject to toggling off the 'Unitless grid' option in the 'Application Preferences' menu.

Note that the foci of the video are the dimension text label and the coordinate widget.

<hr>

Video link : https://youtu.be/24wm4jFrCDA