### PR TITLE
don't scroll layer widget after toggling layer visibility, fixes #1515

### DIFF
--- a/librecad/src/ui/qg_blockwidget.cpp
+++ b/librecad/src/ui/qg_blockwidget.cpp
@@ -256,7 +256,6 @@ QG_BlockWidget::~QG_BlockWidget() {
 void QG_BlockWidget::update() {
     RS_DEBUG->print("QG_BlockWidget::update()");
 
-    int yPos = blockView->verticalScrollBar()->value();
     RS_Block* activeBlock;
 
     if (blockList) {
@@ -277,7 +276,6 @@ void QG_BlockWidget::update() {
     activateBlock(activeBlock);
     lastBlock = b;
     blockView->resizeRowsToContents();
-    blockView->verticalScrollBar()->setValue(yPos);
 
     restoreSelections();
 
@@ -314,6 +312,7 @@ void QG_BlockWidget::activateBlock(RS_Block* block) {
 
     lastBlock = blockList->getActive();
     blockList->activate(block);
+    int yPos = blockView->verticalScrollBar()->value();
     QModelIndex idx = blockModel->getIndex (block);
 
     // remember selected status of the block
@@ -332,6 +331,7 @@ void QG_BlockWidget::activateBlock(RS_Block* block) {
     }
     block->selectedInBlockList(selected);
     blockView->selectionModel()->select(QItemSelection(idx, idx), selFlag);
+    blockView->verticalScrollBar()->setValue(yPos);
 }
 
 /**

--- a/librecad/src/ui/qg_layerwidget.cpp
+++ b/librecad/src/ui/qg_layerwidget.cpp
@@ -367,7 +367,6 @@ void QG_LayerWidget::update() {
         layerModel->setActiveLayer(nullptr);
         return;
     }
-    activateLayer(activeLayer);
 
     if (!lastLayer) {
         RS_DEBUG->print(RS_Debug::D_WARNING, "QG_LayerWidget::update: nullptr lastLayer");


### PR DESCRIPTION
Before the change, toggling layer visibility (or in essence updating
contents of layerwidget) caused it to scroll to the active layer. Such
behaviour is problematic especially for drawings with large number of
layers.

Fix is simple - don't set active layer during layerwidget update.