### PR TITLE
renaming of nested blocks, fixes #1527

### DIFF
--- a/librecad/src/lib/engine/rs_blocklist.cpp
+++ b/librecad/src/lib/engine/rs_blocklist.cpp
@@ -173,8 +173,15 @@ void RS_BlockList::remove(RS_Block* block) {
 bool RS_BlockList::rename(RS_Block* block, const QString& name) {
 	if (block) {
 		if (!find(name)) {
+			QString oldName = block->getName();
 			block->setName(name);
 			setModified(true);
+
+			// when the renamed block is nested within other block, we need to rename its inserts as well
+			for(RS_Block* b: blocks) {
+				b->renameInserts(oldName, name);
+			}
+
 			return true;
 		}
 	}

--- a/librecad/src/lib/engine/rs_entitycontainer.cpp
+++ b/librecad/src/lib/engine/rs_entitycontainer.cpp
@@ -706,7 +706,8 @@ void RS_EntityContainer::renameInserts(const QString& oldName,
             if (i->getName()==oldName) {
                 i->setName(newName);
             }
-        } else if (e->isContainer()) {
+        }
+        if (e->isContainer()) {
             ((RS_EntityContainer*)e)->renameInserts(oldName, newName);
         }
     }


### PR DESCRIPTION
Block list fix:
When block A that is nested within block B is renamed, then rename
also all inserts of block A withing block B in the blocklist.

Entity container fix:
RS_Insert is a subclass of RS_EntityContainer. Inserts within
inserts (in entity tree of a graphic) should be renamed as well.

Fixes issue #1527