### PR TITLE
Change DXF Export to use ext Style handle ID for 340 Dimstyle field.

### DIFF
--- a/libraries/libdxfrw/src/libdxfrw.h
+++ b/libraries/libdxfrw/src/libdxfrw.h
@@ -150,6 +150,7 @@ private:
     bool writingBlock;
     int elParts;  /*!< parts number when convert ellipse to polyline */
     std::unordered_map<std::string,int> blockMap;
+    std::unordered_map<std::string,int> textStyleMap;
     std::vector<DRW_ImageDef*> imageDef;  /*!< imageDef list */
 
     int currHandle;


### PR DESCRIPTION
Dimstyle should use the Text Style handle ID not the name.

http://docs.autodesk.com/ACD/2011/ENU/filesDXF/WS1a9193826455f5ff18cb41610ec0a2e719-7a53.htm