### PR TITLE
fix versioning to reflect 2.2.0 final

### DIFF
--- a/librecad/src/src.pro
+++ b/librecad/src/src.pro
@@ -10,7 +10,7 @@ DISABLE_POSTSCRIPT = false
 DEFINES += DWGSUPPORT
 DEFINES -= JWW_WRITE_SUPPORT
 
-LC_VERSION="2.2.0-alpha"
+LC_VERSION="2.2.0"
 VERSION=$${LC_VERSION}
 
 # Store intermedia stuff somewhere else


### PR DESCRIPTION
Signed-off-by: Tom Callaway <spot@fedoraproject.org>

I noticed in updating to 2.2.0 final that LibreCad was still self-reporting "2.2.0-alpha" (Help->About). This fix to librecad/src/src.pro should resolve that.