### PR TITLE
Fix linker error when linking freetype w/ ttf2lff

### DIFF
--- a/tools/ttf2lff/freetype.pri
+++ b/tools/ttf2lff/freetype.pri
@@ -21,7 +21,7 @@ win32 {
 
     exists($${FREETYPE_DIR}/include/ft2build.h) {
         INCLUDEPATH += "$${FREETYPE_DIR}/include" "$${FREETYPE_DIR}/include/freetype2"
-        LIBS += -L"$${FREETYPE_DIR}/lib" -lfreetype
+        LIBS += -L"$${FREETYPE_DIR}/lib" -lfreetype -lz
 
         message(ttf2lff using includes in $${FREETYPE_DIR}/include and $${FREETYPE_DIR}/include/freetype2)
         message(ttf2lff using libs in $${FREETYPE_DIR}/lib)


### PR DESCRIPTION
```
clang++ -stdlib=libc++ -headerpad_max_install_names  -arch x86_64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk -mmacosx-version-min=10.13 -Wl,-rpath,@executable_path/../Frameworks -o ../../LibreCAD.app/Contents/MacOS/ttf2lff generated/obj/main.o   -L/usr/local/lib -lfreetype
Undefined symbols for architecture x86_64:
  "_inflate", referenced from:
      _FT_Gzip_Uncompress in libfreetype.a(ftgzip.o)
      _ft_gzip_file_fill_output in libfreetype.a(ftgzip.o)
  "_inflateEnd", referenced from:
      _FT_Stream_OpenGzip in libfreetype.a(ftgzip.o)
      _ft_gzip_stream_close in libfreetype.a(ftgzip.o)
      _FT_Gzip_Uncompress in libfreetype.a(ftgzip.o)
  "_inflateInit2_", referenced from:
      _FT_Stream_OpenGzip in libfreetype.a(ftgzip.o)
      _FT_Gzip_Uncompress in libfreetype.a(ftgzip.o)
  "_inflateReset", referenced from:
      _ft_gzip_file_io in libfreetype.a(ftgzip.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
