### PR TITLE
Add IfSilent jump instruction to skip browser launch after install

### DIFF
--- a/scripts/postprocess-windows/nsis-4.8.nsi
+++ b/scripts/postprocess-windows/nsis-4.8.nsi
@@ -120,6 +120,7 @@ Section "Install Section" SecInstall
   createShortCut "$SMPROGRAMS\LibreCAD\Uninstall.lnk" "$INSTDIR\Uninstall.exe"
 
   ; Open Donate URL
+  IfSilent +2
   Exec "rundll32 url.dll,FileProtocolHandler http://librecad.org/donate.html"
 
 SectionEnd

--- a/scripts/postprocess-windows/nsis-5.0.nsi
+++ b/scripts/postprocess-windows/nsis-5.0.nsi
@@ -153,6 +153,7 @@ Section "Install Section" SecInstall
   createShortCut "$SMPROGRAMS\LibreCAD\Uninstall.lnk" "$INSTDIR\Uninstall.exe"
 
   ; Open Donate URL
+  IfSilent +2
   Exec "rundll32 url.dll,FileProtocolHandler http://librecad.org/donate.html"
 
 SectionEnd

--- a/scripts/postprocess-windows/nsis-5.1.nsi
+++ b/scripts/postprocess-windows/nsis-5.1.nsi
@@ -200,6 +200,7 @@ Section "Install Section" SecInstall
   WriteRegDWORD HKLM "${UNINSTKEY}" "NoRepair" "1"
 
   ; Open Donate URL
+  IfSilent +2
   Exec "rundll32 url.dll,FileProtocolHandler http://librecad.org/donate.html"
 
 SectionEnd

--- a/scripts/postprocess-windows/nsis-5.2.nsi
+++ b/scripts/postprocess-windows/nsis-5.2.nsi
@@ -200,6 +200,7 @@ Section "Install Section" SecInstall
   WriteRegDWORD HKLM "${UNINSTKEY}" "NoRepair" "1"
 
   ; Open Donate URL
+  IfSilent +2
   Exec "rundll32 url.dll,FileProtocolHandler http://librecad.org/donate.html"
 
 SectionEnd

--- a/scripts/postprocess-windows/nsis-5.3.nsi
+++ b/scripts/postprocess-windows/nsis-5.3.nsi
@@ -153,6 +153,7 @@ Section "Install Section" SecInstall
   WriteRegDWORD HKLM "${UNINSTKEY}" "NoRepair" "1"
 
   ; Open Donate URL
+  IfSilent +2
   Exec "rundll32 url.dll,FileProtocolHandler http://librecad.org/donate.html"
 
 SectionEnd

--- a/scripts/postprocess-windows/nsis-5.4.nsi
+++ b/scripts/postprocess-windows/nsis-5.4.nsi
@@ -157,6 +157,7 @@ Section "Install Section" SecInstall
   WriteRegDWORD HKLM "${UNINSTKEY}" "NoRepair" "1"
 
   ; Open Donate URL
+  IfSilent +2
   Exec "rundll32 url.dll,FileProtocolHandler http://librecad.org/donate.html"
 
 SectionEnd


### PR DESCRIPTION
Possibly closes #1600

I am not on a Windows machine so this PR is untested, but I don't see a reason why it shouldn't work. The added instruction simply skips over the command to navigate to the website. If it's required I can try spinning up a VM with Windows to really test it out, or maybe someone else can do it on their PC?