### PR TITLE
CI: windows x64: avoid extra Qt tools

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -211,7 +211,6 @@ jobs:
           cache: 'false'
           cache-key-prefix: 'install-qt-action'
           setup-python: 'true'
-          tools: 'tools_ifw tools_qtcreator,qt.tools.qtcreator'
           set-env: 'true'
           tools-only: 'false'
           aqtversion: '==3.1.*'


### PR DESCRIPTION
CI: windows x64: avoid extra Qt tools

avoid failures due to downloading Qt tools