### PR TITLE
Fixes for glowing effect on mouse hovering

### DIFF
--- a/librecad/src/actions/lc_actionlayersexport.cpp
+++ b/librecad/src/actions/lc_actionlayersexport.cpp
@@ -240,7 +240,7 @@ void LC_ActionLayersExport::trigger()
         /* Individualize all layers. */
         else
         {
-            if (layersToExport.at (currentExportLayerIndex).compare("0") == 0) exportLayer0 = true;
+            if (layersToExport.at(currentExportLayerIndex).compare("0") == 0) exportLayer0 = true;
 
             RS_Layer *duplicateLayer = originalLayersList->find (layersToExport.at (currentExportLayerIndex))->clone();
 

--- a/librecad/src/actions/rs_actiondefault.cpp
+++ b/librecad/src/actions/rs_actiondefault.cpp
@@ -570,4 +570,23 @@ void RS_ActionDefault::updateMouseCursor() {
     }
 }
 
+
+const std::vector<RS_Entity*>& RS_ActionDefault::getHighLightingDuplicates() const
+{
+    return highlightedEntityDuplicates;
+}
+
+void RS_ActionDefault::clearHighLighting(RS_Entity* entity)
+{
+    if (highlightedEntity!=nullptr && highlightedEntity->getHighlightedEntityParent() == entity)
+        highlightedEntity=nullptr;
+    for (unsigned int i = 0; i < numberOf_highlightedEntityDuplicates; i++)
+    {
+        if (highlightedEntityDuplicates.at(i) != nullptr
+                && highlightedEntityDuplicates.at(i)->getHighlightedEntityParent() == entity)
+            container->removeEntity(highlightedEntityDuplicates.at(i));
+    }
+
+    graphicView->redraw(RS2::RedrawDrawing);
+}
 // EOF

--- a/librecad/src/actions/rs_actiondefault.cpp
+++ b/librecad/src/actions/rs_actiondefault.cpp
@@ -47,6 +47,18 @@ struct RS_ActionDefault::Points {
 	RS_Vector v2;
 };
 
+namespace {
+
+constexpr double minimumHoverTolerance =  1.0;
+
+constexpr double hoverToleranceFactor1 =  1.0;
+constexpr double hoverToleranceFactor2 = 10.0;
+
+constexpr size_t minHighLightDuplicates = 10;
+constexpr size_t maxHighLightDuplicates = 20;
+
+}
+
 /**
  * Constructor.
  */
@@ -56,11 +68,10 @@ RS_ActionDefault::RS_ActionDefault(RS_EntityContainer& container,
 								container, graphicView)
 	, pPoints(std::make_unique<Points>())
 	, restrBak(RS2::RestrictNothing)
-    , highlightedEntity(nullptr)
 {
 
     RS_DEBUG->print("RS_ActionDefault::RS_ActionDefault");
-	actionType=RS2::ActionDefault;
+    setActionType(RS2::ActionDefault);
     RS_DEBUG->print("RS_ActionDefault::RS_ActionDefault: OK");
 }
 
@@ -120,7 +131,8 @@ void RS_ActionDefault::keyReleaseEvent(QKeyEvent* e) {
 */
 void RS_ActionDefault::highlightHoveredEntities(const RS_Vector& currentMousePosition)
 {
-    for (auto entity : *graphicView->getContainer())
+    double screenTolerance = graphicView->toGraphDX( 0.01*std::min(graphicView->getWidth(), graphicView->getHeight()));
+    for (auto* entity : *graphicView->getContainer())
     {
         if (entity != nullptr)
         {
@@ -132,10 +144,11 @@ void RS_ActionDefault::highlightHoveredEntities(const RS_Vector& currentMousePos
 
                 const double hoverTolerance { hoverToleranceFactor / graphicView->getFactor().magnitude() };
 
-                const double hoverTolerance_adjusted = ((entity->rtti() != RS2::EntityEllipse) && (hoverTolerance < minimumHoverTolerance)) 
+                double hoverTolerance_adjusted = ((entity->rtti() != RS2::EntityEllipse) && (hoverTolerance < minimumHoverTolerance))
                                                      ? minimumHoverTolerance 
                                                      : hoverTolerance;
 
+                hoverTolerance_adjusted = std::min(hoverTolerance_adjusted, screenTolerance);
                 bool isPointOnEntity = false;
 
                 if (((entity->rtti() >= RS2::EntityDimAligned) && (entity->rtti() <= RS2::EntityDimLeader)) 
@@ -162,7 +175,7 @@ void RS_ActionDefault::highlightHoveredEntities(const RS_Vector& currentMousePos
                     {
                         highlightedEntity->setHovered(false);
 
-                        for (unsigned int i = 0; i < numberOf_highlightedEntityDuplicates; i++)
+                        for (unsigned int i = 0; i < nHighLightDuplicates; i++)
                         {
                             container->removeEntity(highlightedEntityDuplicates.at(i));
                         }
@@ -180,26 +193,25 @@ void RS_ActionDefault::highlightHoveredEntities(const RS_Vector& currentMousePos
                     double duplicatedPen_width = zoomFactor * duplicatedPen.getWidth() / 100.0;
                     if (duplicatedPen_width < 1.0) duplicatedPen_width = 1.0;
 
-                    numberOf_highlightedEntityDuplicates = 2.0 * zoomFactor;
+                    nHighLightDuplicates = 2.0 * zoomFactor;
+                    std::cout<<__func__<<": line "<<__LINE__<<" : nHighLightDuplicates="<<nHighLightDuplicates<<std::endl;
 
-                    if (numberOf_highlightedEntityDuplicates < minimumNumberOf_highlightedEntityDuplicates)
-                    {
-                        numberOf_highlightedEntityDuplicates = minimumNumberOf_highlightedEntityDuplicates;
-                    }
+                    nHighLightDuplicates = std::max(nHighLightDuplicates, minHighLightDuplicates);
+                    nHighLightDuplicates = std::min(nHighLightDuplicates, maxHighLightDuplicates);
 
-                    highlightedEntityDuplicates.resize(numberOf_highlightedEntityDuplicates);
+                    highlightedEntityDuplicates.resize(nHighLightDuplicates);
 
                     if (RS_DEBUG->getLevel() >= RS_Debug::D_INFORMATIONAL)
                     {
                         DEBUG_HEADER
 
                         std::cout << " Graphic view factor                = " << graphicView->getFactor() << std::endl 
-                                  << " Number of duplicate entities       = " << numberOf_highlightedEntityDuplicates << std::endl 
+                                  << " Number of duplicate entities       = " << nHighLightDuplicates << std::endl
                                   << " Duplicated pen width (mm)          = " << highlightedEntity->getPen(true).getWidth() / 100.0 << std::endl 
                                   << " Duplicated pen adjusted width (mm) = " << duplicatedPen_width << std::endl << std::endl;
                     }
 
-                    for (unsigned int i = 0; i < numberOf_highlightedEntityDuplicates; i++)
+                    for (unsigned int i = 0; i < nHighLightDuplicates; i++)
                     {
                         RS_Entity* duplicatedEntity = highlightedEntity->clone();
 
@@ -211,7 +223,7 @@ void RS_ActionDefault::highlightHoveredEntities(const RS_Vector& currentMousePos
 
                         /* Note that the coefficients '1.25', '8.0', and '25.0' have been chosen experimentally. */
 
-                        const double& gradientFactor { 1.25 * (double) (i + 1) / (double) numberOf_highlightedEntityDuplicates };
+                        const double& gradientFactor { 1.25 * (double) (i + 1) / (double) nHighLightDuplicates };
 
                         duplicatedPen.setScreenWidth(25.0 * duplicatedPen_width * gradientFactor);
 
@@ -234,7 +246,7 @@ void RS_ActionDefault::highlightHoveredEntities(const RS_Vector& currentMousePos
     }
 }
 
-
+#include <iostream>
 void RS_ActionDefault::mouseMoveEvent(QMouseEvent* e) {
 
     RS_Vector mouse = graphicView->toGraph(e->x(), e->y());
@@ -242,11 +254,12 @@ void RS_ActionDefault::mouseMoveEvent(QMouseEvent* e) {
 
     RS_DIALOGFACTORY->updateCoordinateWidget(mouse, relMouse);
 
+    std::cout<<__func__<<": line "<<__LINE__<<" : container.size="<<container->count()<<std::endl;
     if (highlightedEntity != nullptr)
     {
         highlightedEntity->setHovered(false);
 
-        for (unsigned int i = 0; i < numberOf_highlightedEntityDuplicates; i++)
+        for (unsigned int i = 0; i < nHighLightDuplicates; i++)
         {
             container->removeEntity(highlightedEntityDuplicates.at(i));
         }
@@ -254,6 +267,7 @@ void RS_ActionDefault::mouseMoveEvent(QMouseEvent* e) {
         highlightedEntity = nullptr;
         graphicView->redraw(RS2::RedrawDrawing);
     }
+    std::cout<<__func__<<": line "<<__LINE__<<" : container.size="<<container->count()<<std::endl;
 
     switch (getStatus()) {
     case Neutral:
@@ -580,7 +594,7 @@ void RS_ActionDefault::clearHighLighting(RS_Entity* entity)
 {
     if (highlightedEntity!=nullptr && highlightedEntity->getHighlightedEntityParent() == entity)
         highlightedEntity=nullptr;
-    for (unsigned int i = 0; i < numberOf_highlightedEntityDuplicates; i++)
+    for (unsigned int i = 0; i < nHighLightDuplicates; i++)
     {
         if (highlightedEntityDuplicates.at(i) != nullptr
                 && highlightedEntityDuplicates.at(i)->getHighlightedEntityParent() == entity)

--- a/librecad/src/actions/rs_actiondefault.cpp
+++ b/librecad/src/actions/rs_actiondefault.cpp
@@ -49,14 +49,17 @@ struct RS_ActionDefault::Points {
 
 namespace {
 
+// snap angle tolerance in degrees
+constexpr double SnapAngle_Tolerance = 15.;
+
+// Glowing effects on Mouse hover
 constexpr double minimumHoverTolerance =  1.0;
 
 constexpr double hoverToleranceFactor1 =  1.0;
 constexpr double hoverToleranceFactor2 = 10.0;
 
-constexpr size_t minHighLightDuplicates = 10;
+constexpr size_t minHighLightDuplicates = 4;
 constexpr size_t maxHighLightDuplicates = 20;
-
 }
 
 /**
@@ -246,7 +249,6 @@ void RS_ActionDefault::highlightHoveredEntities(const RS_Vector& currentMousePos
     }
 }
 
-#include <iostream>
 void RS_ActionDefault::mouseMoveEvent(QMouseEvent* e) {
 
     RS_Vector mouse = graphicView->toGraph(e->x(), e->y());
@@ -254,7 +256,6 @@ void RS_ActionDefault::mouseMoveEvent(QMouseEvent* e) {
 
     RS_DIALOGFACTORY->updateCoordinateWidget(mouse, relMouse);
 
-    std::cout<<__func__<<": line "<<__LINE__<<" : container.size="<<container->count()<<std::endl;
     if (highlightedEntity != nullptr)
     {
         highlightedEntity->setHovered(false);
@@ -267,7 +268,6 @@ void RS_ActionDefault::mouseMoveEvent(QMouseEvent* e) {
         highlightedEntity = nullptr;
         graphicView->redraw(RS2::RedrawDrawing);
     }
-    std::cout<<__func__<<": line "<<__LINE__<<" : container.size="<<container->count()<<std::endl;
 
     switch (getStatus()) {
     case Neutral:
@@ -315,7 +315,7 @@ void RS_ActionDefault::mouseMoveEvent(QMouseEvent* e) {
 		RS_DIALOGFACTORY->updateCoordinateWidget(pPoints->v2, pPoints->v2 - graphicView->getRelativeZero());
 
         if (e->modifiers() & Qt::ShiftModifier) {
-            mouse = snapToAngle(mouse, pPoints->v1, 15.);
+            mouse = snapToAngle(mouse, pPoints->v1, SnapAngle_Tolerance);
             pPoints->v2 = mouse;
         }
 
@@ -337,7 +337,7 @@ void RS_ActionDefault::mouseMoveEvent(QMouseEvent* e) {
 		RS_DIALOGFACTORY->updateCoordinateWidget(pPoints->v2, pPoints->v2 - graphicView->getRelativeZero());
 
         if (e->modifiers() & Qt::ShiftModifier) {
-            mouse = snapToAngle(mouse, pPoints->v1, 15.);
+            mouse = snapToAngle(mouse, pPoints->v1, SnapAngle_Tolerance);
             pPoints->v2 = mouse;
         }
 
@@ -404,7 +404,7 @@ void RS_ActionDefault::mousePressEvent(QMouseEvent* e) {
         case Moving: {
 			pPoints->v2 = snapPoint(e);
             if (e->modifiers() & Qt::ShiftModifier) {
-                pPoints->v2 = snapToAngle(pPoints->v2, pPoints->v1, 15.);
+                pPoints->v2 = snapToAngle(pPoints->v2, pPoints->v1, SnapAngle_Tolerance);
             }
             deletePreview();
             RS_Modification m(*container, graphicView);
@@ -424,7 +424,7 @@ void RS_ActionDefault::mousePressEvent(QMouseEvent* e) {
         case MovingRef: {
 			pPoints->v2 = snapPoint(e);
             if (e->modifiers() & Qt::ShiftModifier) {
-                pPoints->v2 = snapToAngle(pPoints->v2, pPoints->v1, 15.);
+                pPoints->v2 = snapToAngle(pPoints->v2, pPoints->v1, SnapAngle_Tolerance);
             }
             deletePreview();
             RS_Modification m(*container, graphicView);

--- a/librecad/src/actions/rs_actiondefault.h
+++ b/librecad/src/actions/rs_actiondefault.h
@@ -80,6 +80,10 @@ public:
 	void updateMouseCursor() override;
 //    void resume() override;
 
+    // clear temporary entities for highlighting
+    void clearHighLighting(RS_Entity* entity);
+    const std::vector<RS_Entity*>& getHighLightingDuplicates() const;
+
 protected:
 	struct Points;
 	std::unique_ptr<Points> pPoints;

--- a/librecad/src/actions/rs_actiondefault.h
+++ b/librecad/src/actions/rs_actiondefault.h
@@ -92,16 +92,9 @@ protected:
 
     private:
 
-        static constexpr double minimumHoverTolerance =  1.0;
+        size_t nHighLightDuplicates;
 
-        static constexpr double hoverToleranceFactor1 =  1.0;
-        static constexpr double hoverToleranceFactor2 = 10.0;
-
-        static constexpr size_t minimumNumberOf_highlightedEntityDuplicates = 10;
-
-        size_t numberOf_highlightedEntityDuplicates;
-
-        RS_Entity* highlightedEntity;
+        RS_Entity* highlightedEntity = nullptr;
         std::vector<RS_Entity*> highlightedEntityDuplicates;
 
         void highlightHoveredEntities(const RS_Vector& currentMousePosition);

--- a/librecad/src/lib/actions/rs_snapper.cpp
+++ b/librecad/src/lib/actions/rs_snapper.cpp
@@ -647,6 +647,8 @@ RS_Entity* RS_Snapper::catchEntity(const RS_Vector& pos,
     if (entity != nullptr && entity->getParent()) {
         idx = entity->getParent()->findEntity(entity);
     }
+    while(entity->getHighlightedEntityParent() != nullptr)
+        entity = entity->getHighlightedEntityParent();
 
     if (entity != nullptr && dist <= getCatchDistance(getSnapRange(), catchEntityGuiRange, graphicView)) {
         // highlight:
@@ -720,6 +722,8 @@ RS_Entity* RS_Snapper::catchEntity(const RS_Vector& pos, RS2::EntityType enType,
         idx = entity->getParent()->findEntity(entity);
     }
 
+    while(entity != nullptr && entity->getHighlightedEntityParent() != nullptr)
+        entity = entity->getHighlightedEntityParent();
     if (entity != nullptr && dist <= getCatchDistance(getSnapRange(), catchEntityGuiRange, graphicView)) {
         // highlight:
         RS_DEBUG->print("RS_Snapper::catchEntity: found: %d", idx);
@@ -742,10 +746,11 @@ RS_Entity* RS_Snapper::catchEntity(const RS_Vector& pos, RS2::EntityType enType,
 RS_Entity* RS_Snapper::catchEntity(QMouseEvent* e,
                                    RS2::ResolveLevel level) {
 
-    return catchEntity(
+    RS_Entity* entity = catchEntity(
                RS_Vector(graphicView->toGraphX(e->x()),
                          graphicView->toGraphY(e->y())),
                level);
+    return entity;
 }
 
 


### PR DESCRIPTION
Issue #1640 : limit the effect size by screen units

Fixed a crash due to the glowing effect

ToDo: separate glowing effects from the geometry layer. 

Also fixed issue #1637, a building issue due to qt-5.15 support changes
