### PR TITLE
Issue #1645: user option for mouse-over effects

### DIFF
--- a/librecad/src/actions/rs_actiondefault.cpp
+++ b/librecad/src/actions/rs_actiondefault.cpp
@@ -41,6 +41,7 @@
 #include "rs_overlaybox.h"
 #include "rs_preview.h"
 #include "rs_selection.h"
+#include "rs_settings.h"
 
 
 struct RS_ActionDefault::Points {
@@ -140,6 +141,13 @@ void RS_ActionDefault::keyReleaseEvent(QKeyEvent* e) {
 */
 void RS_ActionDefault::highlightHoveredEntities(QMouseEvent* event)
 {
+    clearHighLighting();
+
+    auto guard = RS_SETTINGS->beginGroupGuard("/Appearance");
+    bool showHighlightEntity = RS_SETTINGS->readNumEntry("/visualizeHovering", 0) != 0;
+    if (!showHighlightEntity)
+        return;
+
     RS_Entity* entity = catchEntity(event);
     if (entity == nullptr)
         return;

--- a/librecad/src/actions/rs_actiondefault.cpp
+++ b/librecad/src/actions/rs_actiondefault.cpp
@@ -567,7 +567,8 @@ void RS_ActionDefault::highlightEntity(RS_Entity* entity) {
 
         const double gradientFactor { 1.25 * (double) (i + 1) / (double) pPoints->nHighLightDuplicates };
 
-        double effectWidth = 25.0 * duplicatedPen_width * gradientFactor;
+        double effectWidth = std::min(10., 25.0 * duplicatedPen_width * gradientFactor);
+        effectWidth = std::max(2., effectWidth);
 
         duplicatedPen.setScreenWidth(effectWidth);
 

--- a/librecad/src/actions/rs_actiondefault.cpp
+++ b/librecad/src/actions/rs_actiondefault.cpp
@@ -144,7 +144,7 @@ void RS_ActionDefault::highlightHoveredEntities(QMouseEvent* event)
     clearHighLighting();
 
     auto guard = RS_SETTINGS->beginGroupGuard("/Appearance");
-    bool showHighlightEntity = RS_SETTINGS->readNumEntry("/visualizeHovering", 0) != 0;
+    bool showHighlightEntity = RS_SETTINGS->readNumEntry("/VisualizeHovering", 0) != 0;
     if (!showHighlightEntity)
         return;
 
@@ -534,6 +534,7 @@ void RS_ActionDefault::highlightEntity(RS_Entity* entity) {
     pPoints->highlightedEntity = entity;
 
     RS_Pen duplicatedPen = pPoints->highlightedEntity->getPen(true);
+    double originalWidth = std::max(duplicatedPen.getScreenWidth(), 1.);
 
     const double zoomFactor = 200.;
 
@@ -567,7 +568,7 @@ void RS_ActionDefault::highlightEntity(RS_Entity* entity) {
 
         const double gradientFactor { 1.25 * (double) (i + 1) / (double) pPoints->nHighLightDuplicates };
 
-        double effectWidth = std::min(10., 25.0 * duplicatedPen_width * gradientFactor);
+        double effectWidth = std::min(2.0 * originalWidth, 25.0 * duplicatedPen_width * gradientFactor);
         effectWidth = std::max(2., effectWidth);
 
         duplicatedPen.setScreenWidth(effectWidth);

--- a/librecad/src/ui/forms/qg_dlgoptionsgeneral.cpp
+++ b/librecad/src/ui/forms/qg_dlgoptionsgeneral.cpp
@@ -122,7 +122,7 @@ void QG_DlgOptionsGeneral::init()
 
     bool hideRelativeZero = RS_SETTINGS->readNumEntry("/hideRelativeZero", 0);
     cbHideRelativeZero->setChecked(hideRelativeZero);
-    bool visualizeHovering = RS_SETTINGS->readNumEntry("/visualizeOnHovering", 0);
+    bool visualizeHovering = RS_SETTINGS->readNumEntry("/VisualizeHovering", 0);
     cbVisualizeHovering->setChecked(visualizeHovering);
 
     // scale grid:
@@ -243,7 +243,7 @@ void QG_DlgOptionsGeneral::ok()
         RS_SETTINGS->beginGroup("/Appearance");
         RS_SETTINGS->writeEntry("/ScaleGrid", QString("%1").arg((int)cbScaleGrid->isChecked()));
         RS_SETTINGS->writeEntry("/hideRelativeZero", QString("%1").arg((int)cbHideRelativeZero->isChecked()));
-        RS_SETTINGS->writeEntry("/visualizeHovering", QString{cbVisualizeHovering->isChecked() ? "1" : "0"});
+        RS_SETTINGS->writeEntry("/VisualizeHovering", QString{cbVisualizeHovering->isChecked() ? "1" : "0"});
         RS_SETTINGS->writeEntry("/MinGridSpacing", cbMinGridSpacing->currentText());
         RS_SETTINGS->writeEntry("/MaxPreview", cbMaxPreview->currentText());
         RS_SETTINGS->writeEntry("/Language",cbLanguage->itemData(cbLanguage->currentIndex()));

--- a/librecad/src/ui/forms/qg_dlgoptionsgeneral.cpp
+++ b/librecad/src/ui/forms/qg_dlgoptionsgeneral.cpp
@@ -122,7 +122,9 @@ void QG_DlgOptionsGeneral::init()
 
     bool hideRelativeZero = RS_SETTINGS->readNumEntry("/hideRelativeZero", 0);
     cbHideRelativeZero->setChecked(hideRelativeZero);
-    
+    bool visualizeHovering = RS_SETTINGS->readNumEntry("/visualizeOnHovering", 0);
+    cbVisualizeHovering->setChecked(visualizeHovering);
+
     // scale grid:
     QString scaleGrid = RS_SETTINGS->readEntry("/ScaleGrid", "1");
     cbScaleGrid->setChecked(scaleGrid=="1");
@@ -241,6 +243,7 @@ void QG_DlgOptionsGeneral::ok()
         RS_SETTINGS->beginGroup("/Appearance");
         RS_SETTINGS->writeEntry("/ScaleGrid", QString("%1").arg((int)cbScaleGrid->isChecked()));
         RS_SETTINGS->writeEntry("/hideRelativeZero", QString("%1").arg((int)cbHideRelativeZero->isChecked()));
+        RS_SETTINGS->writeEntry("/visualizeHovering", QString{cbVisualizeHovering->isChecked() ? "1" : "0"});
         RS_SETTINGS->writeEntry("/MinGridSpacing", cbMinGridSpacing->currentText());
         RS_SETTINGS->writeEntry("/MaxPreview", cbMaxPreview->currentText());
         RS_SETTINGS->writeEntry("/Language",cbLanguage->itemData(cbLanguage->currentIndex()));

--- a/librecad/src/ui/forms/qg_dlgoptionsgeneral.ui
+++ b/librecad/src/ui/forms/qg_dlgoptionsgeneral.ui
@@ -329,6 +329,19 @@
             </property>
            </widget>
           </item>
+          <item row="9" column="0">
+           <widget class="QCheckBox" name="cbVisualizeHovering">
+            <property name="toolTip">
+             <string>Visualize the entity under the cursor</string>
+            </property>
+            <property name="text">
+             <string>Mouse-over effects</string>
+            </property>
+            <property name="shortcut">
+             <string>Alt+Z</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/librecad/src/ui/forms/qg_dlgoptionsgeneral.ui
+++ b/librecad/src/ui/forms/qg_dlgoptionsgeneral.ui
@@ -105,133 +105,23 @@
           <string>Graphic View</string>
          </property>
          <layout class="QGridLayout" name="graphic_view_layout">
-          <item row="10" column="1">
-           <widget class="QComboBox" name="cbMaxPreview">
-            <property name="editable">
-             <bool>true</bool>
-            </property>
-            <item>
-             <property name="text">
-              <string notr="true">0</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string notr="true">50</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string notr="true">100</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string notr="true">200</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string notr="true">400</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string notr="true">800</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QCheckBox" name="cb_antialiasing">
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="cb_autopanning">
             <property name="text">
-             <string>Anti-aliasing</string>
+             <string>Auto-panning</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="indicator_lines_combobox">
-            <property name="accessibleDescription">
-             <string notr="true"/>
-            </property>
-            <item>
-             <property name="text">
-              <string notr="true">Crosshair</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string notr="true">Crosshair2</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string notr="true">Isometric</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string notr="true">Spiderweb</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="7" column="0">
-           <widget class="QCheckBox" name="cbScaleGrid">
+          <item row="11" column="0">
+           <widget class="QLabel" name="lMaxPreview">
             <property name="text">
-             <string>A&amp;utomatically scale grid</string>
-            </property>
-            <property name="shortcut">
-             <string>Alt+U</string>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="0">
-           <widget class="QLabel" name="lMinGridSpacing">
-            <property name="text">
-             <string>Minimal Grid Spacing (p&amp;x):</string>
+             <string>N&amp;umber of preview entities:</string>
             </property>
             <property name="wordWrap">
              <bool>false</bool>
             </property>
             <property name="buddy">
              <cstring>cbMaxPreview</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QComboBox" name="indicator_shape_combobox">
-            <property name="accessibleDescription">
-             <string notr="true"/>
-            </property>
-            <item>
-             <property name="text">
-              <string notr="true">Circle</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string notr="true">Point</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string notr="true">Square</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QCheckBox" name="cursor_hiding_checkbox">
-            <property name="text">
-             <string>Hide cursor when snapping</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QCheckBox" name="cb_autopanning">
-            <property name="text">
-             <string>Auto-panning</string>
             </property>
            </widget>
           </item>
@@ -242,24 +132,7 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
-           <widget class="QCheckBox" name="scrollbars_check_box">
-            <property name="text">
-             <string>Scrollbars</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QCheckBox" name="indicator_lines_checkbox">
-            <property name="text">
-             <string>Snap indicator lines</string>
-            </property>
-            <property name="shortcut">
-             <string>Alt+S</string>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="1">
+          <item row="10" column="1">
            <widget class="QComboBox" name="cbMinGridSpacing">
             <property name="editable">
              <bool>true</bool>
@@ -306,16 +179,83 @@
             </item>
            </widget>
           </item>
-          <item row="10" column="0">
-           <widget class="QLabel" name="lMaxPreview">
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="cursor_hiding_checkbox">
             <property name="text">
-             <string>N&amp;umber of preview entities:</string>
+             <string>Hide cursor when snapping</string>
             </property>
-            <property name="wordWrap">
-             <bool>false</bool>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QCheckBox" name="scrollbars_check_box">
+            <property name="text">
+             <string>Scrollbars</string>
             </property>
-            <property name="buddy">
-             <cstring>cbMaxPreview</cstring>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QCheckBox" name="cb_antialiasing">
+            <property name="text">
+             <string>Anti-aliasing</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="indicator_lines_combobox">
+            <property name="accessibleDescription">
+             <string notr="true"/>
+            </property>
+            <item>
+             <property name="text">
+              <string notr="true">Crosshair</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">Crosshair2</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">Isometric</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">Spiderweb</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="indicator_shape_combobox">
+            <property name="accessibleDescription">
+             <string notr="true"/>
+            </property>
+            <item>
+             <property name="text">
+              <string notr="true">Circle</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">Point</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">Square</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QCheckBox" name="cbScaleGrid">
+            <property name="text">
+             <string>A&amp;utomatically scale grid</string>
+            </property>
+            <property name="shortcut">
+             <string>Alt+U</string>
             </property>
            </widget>
           </item>
@@ -329,6 +269,66 @@
             </property>
            </widget>
           </item>
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="indicator_lines_checkbox">
+            <property name="text">
+             <string>Snap indicator lines</string>
+            </property>
+            <property name="shortcut">
+             <string>Alt+S</string>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="1">
+           <widget class="QComboBox" name="cbMaxPreview">
+            <property name="editable">
+             <bool>true</bool>
+            </property>
+            <item>
+             <property name="text">
+              <string notr="true">0</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">50</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">100</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">200</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">400</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">800</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="10" column="0">
+           <widget class="QLabel" name="lMinGridSpacing">
+            <property name="text">
+             <string>Minimal Grid Spacing (p&amp;x):</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+            <property name="buddy">
+             <cstring>cbMaxPreview</cstring>
+            </property>
+           </widget>
+          </item>
           <item row="9" column="0">
            <widget class="QCheckBox" name="cbVisualizeHovering">
             <property name="toolTip">
@@ -336,9 +336,6 @@
             </property>
             <property name="text">
              <string>Mouse-over effects</string>
-            </property>
-            <property name="shortcut">
-             <string>Alt+Z</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Add an application option to enable the glowing effects for mouse-over events on an entity.

The option is disabled by default.