### PR TITLE
Issue #1572 : add topology sorting for hatch loops

### DIFF
--- a/librecad/src/lib/engine/rs_entitycontainer.cpp
+++ b/librecad/src/lib/engine/rs_entitycontainer.cpp
@@ -47,8 +47,6 @@
 #include "rs_solid.h"
 #include "rs_spline.h"
 
-bool RS_EntityContainer::autoUpdateBorders = true;
-
 namespace {
 
 // the tolerance used to check topology of contours in hatching

--- a/librecad/src/lib/engine/rs_entitycontainer.cpp
+++ b/librecad/src/lib/engine/rs_entitycontainer.cpp
@@ -2045,7 +2045,7 @@ std::unique_ptr<RS_EntityContainer> findLoop(RS_EntityContainer& container)
         if (startPoint.squaredTo(points[1])<RS_TOLERANCE15)
             std::swap(points[0], points[1]);
         ec->addEntity(next);
-        container.removeEntity(ec);
+        container.removeEntity(ec.get());
         endPoint=points[1];
     }
     return ec;
@@ -2075,18 +2075,19 @@ std::vector<std::unique_ptr<RS_EntityContainer>> RS_EntityContainer::getLoops() 
         switch(e1->rtti()){
         case RS2::EntityEllipse:
         if(static_cast<RS_Ellipse*>(e1)->isEllipticArc()) {
-            edges.add(e1);
-            continue;
+            edges.addEntity(e1);
+            break;
         }
         // fall-through
         case RS2::EntityCircle:
+        {
         auto ec = std::make_unique<RS_EntityContainer>(nullptr, false);
         ec->addEntity(e1);
         loops.push_back(std::move(ec));
-        continue;
+        }
+        break;
         default:
         edges.addEntity(e1);
-        continue;
         }
     }
 

--- a/librecad/src/lib/engine/rs_entitycontainer.cpp
+++ b/librecad/src/lib/engine/rs_entitycontainer.cpp
@@ -72,19 +72,21 @@ bool isReversed(const RS_Entity *entity)
     }
 }
 
+// For validate hatch contours, whether an entity in the contour is a closed
+// loop itself
 bool isClosedLoop(RS_Entity& entity)
 {
     switch (entity.rtti()){
     case RS2::EntityCircle:
+    // Sub containers are always closed
     case RS2::EntityContainer:
-        return true;
+    return true;
     case RS2::EntityEllipse:
-        return !static_cast<RS_Ellipse*>(&entity)->isArc();
+    return !static_cast<RS_Ellipse*>(&entity)->isArc();
     default:
-        return false;
+    return false;
     }
 }
-
 }
 
 /**
@@ -1206,7 +1208,6 @@ RS_Vector RS_EntityContainer::getNearestEndpoint(const RS_Vector& coord,
 }
 
 
-
 /**
  * @return The point which is closest to 'coord'
  * (one of the vertices)
@@ -2041,11 +2042,9 @@ std::vector<std::unique_ptr<RS_EntityContainer>> findLoop(RS_EntityContainer& co
         container.removeEntity(e);
         RS_Vector target = e->getStartpoint();
         auto ec = std::make_unique<RS_EntityContainer>(nullptr, false);
-    std::cout<<__func__<<"(): create edge container: "<<ec->getId()<<std::endl;
         ec->addEntity(e);
         RS_Vector endPoint = e->getEndpoint();
         while (endPoint.squaredTo(target) > RS_TOLERANCE && !container.isEmpty()) {
-            std::cout<<__func__<<"(): "<<container.count()<<std::endl;
             double distance=0.;
             RS_Entity* next=nullptr;
             RS_Vector startPoint = container.getNearestEndpoint(endPoint, &distance, &next);
@@ -2059,7 +2058,6 @@ std::vector<std::unique_ptr<RS_EntityContainer>> findLoop(RS_EntityContainer& co
         if (endPoint.squaredTo(target) < RS_TOLERANCE)
             ret.push_back(std::move(ec));
     }
-    std::cout<<__func__<<"(): create edge container: "<<ret.size()<<std::endl;
     return ret;
 }
 }
@@ -2071,7 +2069,6 @@ std::vector<std::unique_ptr<RS_EntityContainer>> RS_EntityContainer::getLoops() 
 
     std::vector<std::unique_ptr<RS_EntityContainer>> loops;
     RS_EntityContainer edges(nullptr, false);
-    std::cout<<"create edge container: "<<edges.getId()<<std::endl;
     for(auto* e1: entities){
         if (e1->isContainer())
         {
@@ -2096,7 +2093,6 @@ std::vector<std::unique_ptr<RS_EntityContainer>> RS_EntityContainer::getLoops() 
         {
         auto ec = std::make_unique<RS_EntityContainer>(nullptr, false);
         ec->addEntity(e1);
-        std::cout<<__func__<<"(): add to container: "<<ec->getId()<<", circle: "<<e1->getId()<<std::endl;
         loops.push_back(std::move(ec));
         break;
         }

--- a/librecad/src/lib/engine/rs_entitycontainer.h
+++ b/librecad/src/lib/engine/rs_entitycontainer.h
@@ -28,6 +28,7 @@
 #ifndef RS_ENTITYCONTAINER_H
 #define RS_ENTITYCONTAINER_H
 
+#include <memory>
 #include <vector>
 #include <QList>
 #include "rs_entity.h"

--- a/librecad/src/lib/engine/rs_entitycontainer.h
+++ b/librecad/src/lib/engine/rs_entitycontainer.h
@@ -249,7 +249,7 @@ protected:
      * Automatically update the borders of the container when entities
      * are added or removed.
      */
-    static bool autoUpdateBorders;
+    bool autoUpdateBorders = true;
 
 private:
 	/**

--- a/librecad/src/lib/engine/rs_entitycontainer.h
+++ b/librecad/src/lib/engine/rs_entitycontainer.h
@@ -153,9 +153,9 @@ public:
 								RS2::ResolveLevel level=RS2::ResolveAll) const;
 
 	RS_Vector getNearestPointOnEntity(const RS_Vector& coord,
-            bool onEntity = true,
-						double* dist = nullptr,
-			RS_Entity** entity=nullptr)const override;
+                                      bool onEntity = true,
+                                      double* dist = nullptr,
+                                      RS_Entity** entity=nullptr)const override;
 
 	RS_Vector getNearestCenter(const RS_Vector& coord,
 									   double* dist = nullptr)const override;

--- a/librecad/src/lib/engine/rs_entitycontainer.h
+++ b/librecad/src/lib/engine/rs_entitycontainer.h
@@ -236,6 +236,7 @@ public:
     const QList<RS_Entity*>& getEntityList();
 
 protected:
+    virtual std::vector<std::unique_ptr<RS_EntityContainer>> getLoops() const;
 
     /** entities in the container */
     QList<RS_Entity *> entities;
@@ -256,7 +257,7 @@ private:
 	 */
 	bool ignoredSnap() const;
     mutable int entIdx;
-    bool autoDelete;
+    bool autoDelete = false;
 };
 
 #endif

--- a/librecad/src/lib/engine/rs_hatch.cpp
+++ b/librecad/src/lib/engine/rs_hatch.cpp
@@ -55,7 +55,12 @@ double getSizeSquared(const RS_EntityContainer* loop) {
 struct CompareBoxSize{
     bool operator () (const RS_EntityContainer* lhs, const RS_EntityContainer* rhs) const
     {
-        return getSizeSquared(lhs) + RS_TOLERANCE < getSizeSquared(rhs);
+        const lSize=getSizeSquared(lhs);
+        const rSize=getSizeSquared(rhs);
+        if (lSize + RS_TOLERANCE < rSize)
+            return true;
+        if (lSize - RS_TOLERANCE > rSize)
+            return false;
     }
 };
 

--- a/librecad/src/lib/engine/rs_hatch.cpp
+++ b/librecad/src/lib/engine/rs_hatch.cpp
@@ -44,6 +44,25 @@
 #include "rs_math.h"
 #include "rs_debug.h"
 
+namespace
+{
+
+struct HatchLoop
+{
+    std::list<std::unique_ptr<RS_EntityContainer>> loops;
+    std::list<HatchLoop> inners;
+    HatchLoop(std::vector<std::unique_ptr<RS_EntityContainer>> loops) {
+        while (!loops.empty()) {
+
+        }
+    }
+};
+
+
+
+
+}
+
 
 RS_HatchData::RS_HatchData(bool _solid,
 						   double _scale,
@@ -690,6 +709,7 @@ void RS_Hatch::draw(RS_Painter* painter, RS_GraphicView* view, double& /*pattern
 
 //must be called after update()
 double RS_Hatch::getTotalArea() {
+    auto loops = getLoops();
 
     double totalArea=0.;
 
@@ -784,3 +804,5 @@ std::ostream& operator << (std::ostream& os, const RS_Hatch& p) {
     os << " Hatch: " << p.getData() << "\n";
     return os;
 }
+
+

--- a/librecad/src/lib/engine/rs_line.cpp
+++ b/librecad/src/lib/engine/rs_line.cpp
@@ -99,18 +99,9 @@ RS_Vector RS_Line::getNearestEndpoint(const RS_Vector& coord,
     double dist1((data.startpoint-coord).squared());
     double dist2((data.endpoint-coord).squared());
 
-    if (dist2<dist1) {
-		if (dist) {
-            *dist = sqrt(dist2);
-        }
-        return data.endpoint;
-    } else {
-		if (dist) {
-            *dist = sqrt(dist1);
-        }
-        return data.startpoint;
-    }
-
+    if (dist != nullptr)
+        *dist = std::sqrt(std::min(dist1, dist2));
+    return (dist1 < dist2) ? data.startpoint : data.endpoint;
 }
 
 /**

--- a/librecad/src/ui/forms/qg_dlgoptionsgeneral.ui
+++ b/librecad/src/ui/forms/qg_dlgoptionsgeneral.ui
@@ -177,30 +177,6 @@
               <string notr="true">20</string>
              </property>
             </item>
-            <item>
-             <property name="text">
-              <string notr="true">15</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string notr="true">20</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QCheckBox" name="cursor_hiding_checkbox">
-            <property name="text">
-             <string>Hide cursor when snapping</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QCheckBox" name="scrollbars_check_box">
-            <property name="text">
-             <string>Scrollbars</string>
-            </property>
            </widget>
           </item>
           <item row="2" column="0">
@@ -353,12 +329,6 @@
             </property>
            </widget>
           </item>
-          <item row="9" column="0">
-           <widget class="QCheckBox" name="cbVisualizeHovering">
-            <property name="toolTip">
-             <string>Visualize the entity under the cursor</string>
-            <property name="text">
-             <string>Mouse-over effects</string>
           <item row="9" column="0">
            <widget class="QCheckBox" name="cbVisualizeHovering">
             <property name="toolTip">

--- a/librecad/src/ui/forms/qg_dlgoptionsgeneral.ui
+++ b/librecad/src/ui/forms/qg_dlgoptionsgeneral.ui
@@ -177,6 +177,30 @@
               <string notr="true">20</string>
              </property>
             </item>
+            <item>
+             <property name="text">
+              <string notr="true">15</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">20</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="cursor_hiding_checkbox">
+            <property name="text">
+             <string>Hide cursor when snapping</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QCheckBox" name="scrollbars_check_box">
+            <property name="text">
+             <string>Scrollbars</string>
+            </property>
            </widget>
           </item>
           <item row="2" column="0">
@@ -333,12 +357,8 @@
            <widget class="QCheckBox" name="cbVisualizeHovering">
             <property name="toolTip">
              <string>Visualize the entity under the cursor</string>
-            </property>
             <property name="text">
              <string>Mouse-over effects</string>
-            </property>
-           </widget>
-          </item>
           <item row="9" column="0">
            <widget class="QCheckBox" name="cbVisualizeHovering">
             <property name="toolTip">
@@ -346,9 +366,6 @@
             </property>
             <property name="text">
              <string>Mouse-over effects</string>
-            </property>
-            <property name="shortcut">
-             <string>Alt+Z</string>
             </property>
            </widget>
           </item>

--- a/librecad/src/ui/forms/qg_dlgoptionsgeneral.ui
+++ b/librecad/src/ui/forms/qg_dlgoptionsgeneral.ui
@@ -339,6 +339,19 @@
             </property>
            </widget>
           </item>
+          <item row="9" column="0">
+           <widget class="QCheckBox" name="cbVisualizeHovering">
+            <property name="toolTip">
+             <string>Visualize the entity under the cursor</string>
+            </property>
+            <property name="text">
+             <string>Mouse-over effects</string>
+            </property>
+            <property name="shortcut">
+             <string>Alt+Z</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>


### PR DESCRIPTION
Find the hatch area using topology of the boundary loops.

1. support topologies like islands in lakes or lakes on islands;
2. The boundary loops are allowed to touch each other;
3. Shared boundary edges among loops not supported;
4. Boundary edges should have simple connectivity: each end point of an edge should be shared by exact two consecutive edges. 3 or more edges connected to a single point is not supported.

A test case dxf:
[hatch1.zip](https://github.com/LibreCAD/LibreCAD/files/12061078/hatch1.zip)


