### PR TITLE
Issue #778 Painter: use Qt native dash pattern

### DIFF
--- a/librecad/src/actions/rs_actiondefault.cpp
+++ b/librecad/src/actions/rs_actiondefault.cpp
@@ -71,7 +71,7 @@ constexpr unsigned minHighLightDuplicates = 4;
 constexpr unsigned maxHighLightDuplicates = 20;
 
 // find pen screen width
-double getScreenWidth(RS_Graphic& graphic, RS_Pen& pen, RS_GraphicView& view)
+double getScreenWidth( RS_Pen& pen, RS_Graphic& graphic, RS_GraphicView& view)
 {
     double w = pen.getWidth();
     double wf = 1.0;
@@ -551,26 +551,24 @@ void RS_ActionDefault::highlightEntity(RS_Entity* entity) {
     pPoints->highlightedEntity = entity;
 
     RS_Pen duplicatedPen = pPoints->highlightedEntity->getPen(true);
-    double screenWidth = getScreenWidth(*graphic, duplicatedPen, *graphicView);
+    double screenWidth = getScreenWidth(duplicatedPen, *graphic, *graphicView);
     double originalWidth = std::max(screenWidth, 1.);
 
-    const double zoomFactor = 200.;
-
-    double duplicatedPen_width = zoomFactor * screenWidth / 100.0;
-    duplicatedPen_width = std::max(duplicatedPen_width, 1.0);
+    double duplicatedPen_width = 2. * std::max(originalWidth, 1.0);
+    const double zoomFactor = 2.;
+    duplicatedPen_width = zoomFactor * screenWidth;
 
     pPoints->nHighLightDuplicates = int(std::min(2.0 * zoomFactor, double(maxHighLightDuplicates)));
-
     pPoints->nHighLightDuplicates = std::max(pPoints->nHighLightDuplicates, minHighLightDuplicates);
 
     if (RS_DEBUG->getLevel() >= RS_Debug::D_INFORMATIONAL)
     {
-        DEBUG_HEADER
+        DEBUG_HEADER;
 
-                std::cout << " Graphic view factor                = " << graphicView->getFactor() << std::endl
-                          << " Number of duplicate entities       = " << pPoints->nHighLightDuplicates << std::endl
-                          << " Duplicated pen width (mm)          = " << pPoints->highlightedEntity->getPen(true).getWidth() / 100.0 << std::endl
-                          << " Duplicated pen adjusted width (mm) = " << duplicatedPen_width << std::endl << std::endl;
+        std::cout << " Graphic view factor                = " << graphicView->getFactor() << std::endl
+                  << " Number of duplicate entities       = " << pPoints->nHighLightDuplicates << std::endl
+                  << " Duplicated pen width (mm)          = " << pPoints->highlightedEntity->getPen(true).getWidth() / 100.0 << std::endl
+                  << " Duplicated pen adjusted width (mm) = " << duplicatedPen_width << std::endl << std::endl;
     }
 
     const double maxWidth = 2.*std::max(duplicatedPen_width, 1.);
@@ -584,7 +582,7 @@ void RS_ActionDefault::highlightEntity(RS_Entity* entity) {
 
         /* Note that the coefficients '1.25', '8.0', and '25.0' have been chosen experimentally. */
 
-        const double gradientFactor { 1.25 * (double) (i + 1) / (double) pPoints->nHighLightDuplicates };
+        const double gradientFactor { 1.25 * (double) (i + 1) / pPoints->nHighLightDuplicates };
 
         double effectWidth = std::min(2.0 * originalWidth, 25.0 * duplicatedPen_width * gradientFactor);
         effectWidth = std::max(2., effectWidth);

--- a/librecad/src/actions/rs_actiondefault.cpp
+++ b/librecad/src/actions/rs_actiondefault.cpp
@@ -556,8 +556,7 @@ void RS_ActionDefault::highlightEntity(RS_Entity* entity) {
     }
 
     const double maxWidth = 9.*std::max(duplicatedPen.getScreenWidth(), 1.);
-    //for (unsigned i = 0; i < pPoints->nHighLightDuplicates; i++)
-    unsigned i = 0;
+    for (unsigned i = 0; i < pPoints->nHighLightDuplicates; i++)
     {
         RS_Entity* duplicatedEntity = pPoints->highlightedEntity->clone();
 
@@ -572,7 +571,7 @@ void RS_ActionDefault::highlightEntity(RS_Entity* entity) {
         double effectWidth = std::min(2.0 * originalWidth, 25.0 * duplicatedPen_width * gradientFactor);
         effectWidth = std::max(2., effectWidth);
 
-        //duplicatedPen.setScreenWidth(effectWidth);
+        duplicatedPen.setScreenWidth(effectWidth);
 
         /* The minus sign in the -8.0 value denotes that the function is exponentially 'decreasing'. */
         const double exponentialFactor { std::exp(-8.0 * gradientFactor) };
@@ -580,6 +579,8 @@ void RS_ActionDefault::highlightEntity(RS_Entity* entity) {
         duplicatedPen.setAlpha(exponentialFactor);
 
         duplicatedEntity->setPen(duplicatedPen);
+        if (effectWidth >= maxWidth)
+            break;
     }
 
     graphicView->redraw(RS2::RedrawOverlay);

--- a/librecad/src/actions/rs_actiondefault.cpp
+++ b/librecad/src/actions/rs_actiondefault.cpp
@@ -556,7 +556,8 @@ void RS_ActionDefault::highlightEntity(RS_Entity* entity) {
     }
 
     const double maxWidth = 9.*std::max(duplicatedPen.getScreenWidth(), 1.);
-    for (unsigned i = 0; i < pPoints->nHighLightDuplicates; i++)
+    //for (unsigned i = 0; i < pPoints->nHighLightDuplicates; i++)
+    unsigned i = 0;
     {
         RS_Entity* duplicatedEntity = pPoints->highlightedEntity->clone();
 
@@ -571,7 +572,7 @@ void RS_ActionDefault::highlightEntity(RS_Entity* entity) {
         double effectWidth = std::min(2.0 * originalWidth, 25.0 * duplicatedPen_width * gradientFactor);
         effectWidth = std::max(2., effectWidth);
 
-        duplicatedPen.setScreenWidth(effectWidth);
+        //duplicatedPen.setScreenWidth(effectWidth);
 
         /* The minus sign in the -8.0 value denotes that the function is exponentially 'decreasing'. */
         const double exponentialFactor { std::exp(-8.0 * gradientFactor) };
@@ -579,8 +580,6 @@ void RS_ActionDefault::highlightEntity(RS_Entity* entity) {
         duplicatedPen.setAlpha(exponentialFactor);
 
         duplicatedEntity->setPen(duplicatedPen);
-        if (effectWidth > maxWidth)
-            break;
     }
 
     graphicView->redraw(RS2::RedrawOverlay);

--- a/librecad/src/lib/engine/lc_splinepoints.cpp
+++ b/librecad/src/lib/engine/lc_splinepoints.cpp
@@ -1902,45 +1902,13 @@ void LC_SplinePoints::drawSimple(RS_Painter* painter, RS_GraphicView* view)
 
 void LC_SplinePoints::draw(RS_Painter* painter, RS_GraphicView* view, double& patternOffset)
 {
-	if(painter == nullptr || view == nullptr)
-	{
-		return;
-	}
+    if(painter == nullptr || view == nullptr)
+        return;
 
-    RS_Pen penSaved = painter->getPen();
+    update();
+    patternOffset -= getLength();
 
-	// Pattern:
-	const RS_LineTypePattern* pat = nullptr;
-	if(isSelected() && !(view->isPrinting() || view->isPrintPreview()))
-	{
-//		styleFactor=1.;
-        pat = RS_LineTypePattern::getPattern(RS2::LineSelected);
-    }
-	else
-	{
-		pat = view->getPattern(getPen().getLineType());
-	}
-
-	bool bDrawPattern = false;
-	if(pat) bDrawPattern = pat->num > 0;
-	else
-	{
-		RS_DEBUG->print(RS_Debug::D_WARNING,
-			"RS_Line::draw: Invalid line pattern");
-	}
-
-	update();
-
-    // Pen to draw pattern is always solid:
-    RS_Pen pen = painter->getPen();
-    pen.setLineType(RS2::SolidLine);
-    painter->setPen(pen);
-
-	if(bDrawPattern)
-		drawPattern(painter, view, patternOffset, pat);
-	else drawSimple(painter, view);
-    painter->setPen(penSaved);
-
+    drawSimple(painter, view);
 }
 
 double LC_SplinePoints::getLength() const

--- a/librecad/src/lib/engine/lc_splinepoints.cpp
+++ b/librecad/src/lib/engine/lc_splinepoints.cpp
@@ -1914,8 +1914,8 @@ void LC_SplinePoints::draw(RS_Painter* painter, RS_GraphicView* view, double& pa
 	if(isSelected() && !(view->isPrinting() || view->isPrintPreview()))
 	{
 //		styleFactor=1.;
-        pat = &RS_LineTypePattern::patternSelected;
-	}
+        pat = RS_LineTypePattern::getPattern(RS2::LineSelected);
+    }
 	else
 	{
 		pat = view->getPattern(getPen().getLineType());

--- a/librecad/src/lib/engine/rs.h
+++ b/librecad/src/lib/engine/rs.h
@@ -698,7 +698,8 @@ namespace RS2 {
         BorderLine2 = 24,     /**< dash, dash, dot small. */
         BorderLineX2 = 25,    /**< dash, dash, dot large. */
 
-        LineTypeUnchanged=26      /**< Line type defined by block not entity */
+        LineTypeUnchanged=26,      /**< Line type defined by block not entity */
+        LineSelected=27      /**< Line type for selected */
     };
 
     /**

--- a/librecad/src/lib/engine/rs_arc.cpp
+++ b/librecad/src/lib/engine/rs_arc.cpp
@@ -943,113 +943,22 @@ void RS_Arc::draw(RS_Painter* painter, RS_GraphicView* view,
 void RS_Arc::drawVisible(RS_Painter* painter, RS_GraphicView* view,
                   double& patternOffset) {
 
-	if (!( painter && view)) return;
+    if (painter == nullptr || view == nullptr)
+        return;
     //visible in graphic view
-    if(isVisibleInWindow(view)==false) return;
+    if(!isVisibleInWindow(view))
+        return;
 
     RS_Vector cp=view->toGui(getCenter());
     double ra=getRadius()*view->getFactor().x;
     double length=getLength()*view->getFactor().x;
-    //double styleFactor = getStyleFactor();
+
     patternOffset -= length;
 
-    bool drawAsSelected = isSelected() && !(view->isPrinting() || view->isPrintPreview());
-
-    // simple style-less lines
-    {
-        painter->drawArc(cp,
-                         ra,
-                         getAngle1(), getAngle2(),
-                         isReversed());
-        return;
-    }
-//    double styleFactor = getStyleFactor(view);
-    //        if (styleFactor<0.0) {
-    //            painter->drawArc(cp,
-    //                             ra,
-    //                             getAngle1(), getAngle2(),
-    //                             isReversed());
-    //            return;
-    //        }
-
-    // Pattern:
-    const RS_LineTypePattern* pat;
-    if (drawAsSelected)
-    {
-        pat = RS_LineTypePattern::getPattern(RS2::LineSelected);
-    } else {
-        pat = view->getPattern(getPen().getLineType());
-    }
-
-	if (!pat || ra<0.5) {//avoid division by zero from small ra
-		RS_DEBUG->print("%s: Invalid line pattern or radius too small, drawing arc using solid line", __func__);
-        painter->drawArc(cp, ra,
-                         getAngle1(),getAngle2(),
-                         isReversed());
-        return;
-    }
-
-//    patternOffset=remainder(patternOffset - length -0.5*pat->totalLength,pat->totalLength)+0.5*pat->totalLength;
-
-    if (ra<RS_TOLERANCE_ANGLE){
-        return;
-    }
-
-    // Pen to draw pattern is always solid:
-    RS_Pen pen = painter->getPen();
-    pen.setLineType(RS2::SolidLine);
-    painter->setPen(pen);
-
-
-
-    // create scaled pattern:
-	if(pat->num<=0) { //invalid pattern
-		RS_DEBUG->print(RS_Debug::D_WARNING, "RS_Arc::draw(): invalid line pattern\n");
-		painter->drawArc(cp,
-						 ra,
-						 getAngle1(), getAngle2(),
-						 isReversed());
-		return;
-	}
-	std::vector<double> da(pat->num);
-    double patternSegmentLength(pat->totalLength);
-	double ira=1./ra;
-	double dpmm=static_cast<RS_PainterQt*>(painter)->getDpmm();
-	for (size_t i=0; i<pat->num; i++){
-		//        da[j] = pat->pattern[i++] * styleFactor;
-		//fixme, stylefactor needed
-		da[i] =dpmm*(isReversed() ? -fabs(pat->pattern[i]):fabs(pat->pattern[i]));
-		if ( fabs(da[i]) < 1.) da[i] = copysign(1., da[i]);
-		da[i] *= ira;
-	}
-
-    //    bool done = false;
-    double total=remainder(patternOffset-0.5*patternSegmentLength,patternSegmentLength)-0.5*patternSegmentLength;
-
-	double a1{RS_Math::correctAngle(getAngle1())};
-	double a2{RS_Math::correctAngle(getAngle2())};
-
-    if(isReversed()) {//always draw from a1 to a2, so, patternOffset is automatic
-        if(a1<a2+RS_TOLERANCE_ANGLE) a2 -= 2.*M_PI;
-        total = a1 - total*ira; //in angle
-    }else{
-        if(a2<a1+RS_TOLERANCE_ANGLE) a2 += 2.*M_PI;
-        total = a1 + total*ira; //in angle
-    }
-    double limit(fabs(a1-a2));
-    double t2;
-
-	for(int j=0; fabs(total-a1) < limit; j=(j+1)%pat->num) {
-		t2=total+da[j];
-
-		if(pat->pattern[j] > 0.0 && fabs(t2-a2) < limit) {
-			double a11=(fabs(total-a2) < limit)?total:a1;
-			double a21=(fabs(t2-a1) < limit)?t2:a2;
-			painter->drawArc(cp, ra, a11, a21, isReversed());
-		}
-
-		total=t2;
-	}
+    painter->drawArc(cp,
+                     ra,
+                     getAngle1(), getAngle2(),
+                     isReversed());
 }
 
 

--- a/librecad/src/lib/engine/rs_arc.cpp
+++ b/librecad/src/lib/engine/rs_arc.cpp
@@ -978,7 +978,7 @@ void RS_Arc::drawVisible(RS_Painter* painter, RS_GraphicView* view,
     const RS_LineTypePattern* pat;
     if (drawAsSelected)
     {
-        pat = &RS_LineTypePattern::patternSelected;
+        pat = RS_LineTypePattern::getPattern(RS2::LineSelected);
     } else {
         pat = view->getPattern(getPen().getLineType());
     }

--- a/librecad/src/lib/engine/rs_arc.cpp
+++ b/librecad/src/lib/engine/rs_arc.cpp
@@ -956,9 +956,7 @@ void RS_Arc::drawVisible(RS_Painter* painter, RS_GraphicView* view,
     bool drawAsSelected = isSelected() && !(view->isPrinting() || view->isPrintPreview());
 
     // simple style-less lines
-    if ( !drawAsSelected && (
-             getPen().getLineType()==RS2::SolidLine ||
-             view->getDrawingMode()==RS2::ModePreview)) {
+    {
         painter->drawArc(cp,
                          ra,
                          getAngle1(), getAngle2(),

--- a/librecad/src/lib/engine/rs_circle.cpp
+++ b/librecad/src/lib/engine/rs_circle.cpp
@@ -758,11 +758,12 @@ bool RS_Circle::isVisibleInWindow(RS_GraphicView* view) const
     return (vpMin-getCenter()).squared() > getRadius()*getRadius();
 }
 
-#include "rs_arc.h"
 void RS_Circle::draw(RS_Painter* painter, RS_GraphicView* view, double& /*patternOffset*/) {
+    if (!isVisibleInWindow(view))
+        return;
+
     painter->drawCircle(view->toGui(getCenter()), view->toGuiDX(getRadius()));
 }
-
 
 void RS_Circle::moveRef(const RS_Vector& ref, const RS_Vector& offset) {
 	if(ref.distanceTo(data.center)<1.0e-4){

--- a/librecad/src/lib/engine/rs_circle.cpp
+++ b/librecad/src/lib/engine/rs_circle.cpp
@@ -760,14 +760,7 @@ bool RS_Circle::isVisibleInWindow(RS_GraphicView* view) const
 
 #include "rs_arc.h"
 void RS_Circle::draw(RS_Painter* painter, RS_GraphicView* view, double& /*patternOffset*/) {
-    // draw circle as a 2 pi arc
-    RS_Arc arc{nullptr, RS_ArcData{getCenter(), getRadius(), 0., 2.*M_PI, false}};
-    arc.setSelected(isSelected());
-    arc.setPen(getPen());
-    double patternOffset=0.;
-    arc.draw(painter,view,patternOffset);
-
-    //painter->drawCircle(view->toGui(getCenter()), view->toGuiDX(getRadius()));
+    painter->drawCircle(view->toGui(getCenter()), view->toGuiDX(getRadius()));
 }
 
 

--- a/librecad/src/lib/engine/rs_circle.cpp
+++ b/librecad/src/lib/engine/rs_circle.cpp
@@ -758,15 +758,16 @@ bool RS_Circle::isVisibleInWindow(RS_GraphicView* view) const
     return (vpMin-getCenter()).squared() > getRadius()*getRadius();
 }
 
-
+#include "rs_arc.h"
 void RS_Circle::draw(RS_Painter* painter, RS_GraphicView* view, double& /*patternOffset*/) {
-//    // draw circle as a 2 pi arc
-//    RS_Arc arc(getParent(), RS_ArcData(getCenter(),getRadius(),0.,2.*M_PI, false));
-//    arc.setSelected(isSelected());
-//    arc.setPen(getPen());
-//    arc.draw(painter,view,patternOffset);
+    // draw circle as a 2 pi arc
+    RS_Arc arc{nullptr, RS_ArcData{getCenter(), getRadius(), 0., 2.*M_PI, false}};
+    arc.setSelected(isSelected());
+    arc.setPen(getPen());
+    double patternOffset=0.;
+    arc.draw(painter,view,patternOffset);
 
-    painter->drawCircle(view->toGui(getCenter()), view->toGuiDX(getRadius()));
+    //painter->drawCircle(view->toGui(getCenter()), view->toGuiDX(getRadius()));
 }
 
 

--- a/librecad/src/lib/engine/rs_ellipse.cpp
+++ b/librecad/src/lib/engine/rs_ellipse.cpp
@@ -1852,9 +1852,7 @@ void RS_Ellipse::drawVisible(RS_Painter* painter, RS_GraphicView* view, double& 
 
     double mAngle=getAngle();
     RS_Vector cp(view->toGui(getCenter()));
-	if (!drawAsSelected && (
-             getPen().getLineType()==RS2::SolidLine ||
-             view->getDrawingMode()==RS2::ModePreview)) {
+    {
         painter->drawEllipse(cp,
                              ra, rb,
                              mAngle,
@@ -1866,7 +1864,7 @@ void RS_Ellipse::drawVisible(RS_Painter* painter, RS_GraphicView* view, double& 
     // Pattern:
 	const RS_LineTypePattern* pat = nullptr;
 	if (drawAsSelected) {
-		pat = &RS_LineTypePattern::patternSelected;
+        pat = RS_LineTypePattern::getPattern(RS2::LineSelected);
 	}
 	else {
 		pat = view->getPattern(getPen().getLineType());

--- a/librecad/src/lib/engine/rs_ellipse.cpp
+++ b/librecad/src/lib/engine/rs_ellipse.cpp
@@ -1837,86 +1837,26 @@ void RS_Ellipse::draw(RS_Painter* painter, RS_GraphicView* view, double& pattern
 void RS_Ellipse::drawVisible(RS_Painter* painter, RS_GraphicView* view, double& /*patternOffset*/) {
 //    std::cout<<"RS_Ellipse::drawVisible(): begin\n";
 //    std::cout<<*this<<std::endl;
-	if (!(painter && view)) return;
+    if (painter == nullptr || view == nullptr)
+        return;
 
     //visible in graphic view
-	if(!isVisibleInWindow(view)) return;
-    double ra(getMajorRadius()*view->getFactor().x);
-    double rb(getRatio()*ra);
+    if(!isVisibleInWindow(view))
+        return;
+
+    double ra = getMajorRadius()*view->getFactor().x;
+    double rb = getRatio()*ra;
 	if(std::min(ra, rb) < RS_TOLERANCE) {//ellipse too small
         painter->drawLine(view->toGui(minV),view->toGui(maxV));
         return;
     }
 
-    bool drawAsSelected = isSelected() && !(view->isPrinting() || view->isPrintPreview());
-
-    double mAngle=getAngle();
-    RS_Vector cp(view->toGui(getCenter()));
-    {
-        painter->drawEllipse(cp,
-                             ra, rb,
-                             mAngle,
-                             getAngle1(), getAngle2(),
-                             isReversed());
-        return;
-    }
-
-    // Pattern:
-	const RS_LineTypePattern* pat = nullptr;
-	if (drawAsSelected) {
-        pat = RS_LineTypePattern::getPattern(RS2::LineSelected);
-	}
-	else {
-		pat = view->getPattern(getPen().getLineType());
-	}
-
-	if (!pat) {
-        RS_DEBUG->print(RS_Debug::D_WARNING, "Invalid pattern for Ellipse");
-        return;
-    }
-
-    // Pen to draw pattern is always solid:
-    RS_Pen pen = painter->getPen();
-    pen.setLineType(RS2::SolidLine);
-    double a1(RS_Math::correctAngle(getAngle1()));
-    double a2(RS_Math::correctAngle(getAngle2()));
-    if (isReversed()) std::swap(a1,a2);
-	if(a2 <a1+RS_TOLERANCE_ANGLE) a2 += 2.*M_PI;
-    painter->setPen(pen);
-	if(pat->num <= 0){
-		RS_DEBUG->print(RS_Debug::D_WARNING,"Invalid pattern when drawing ellipse");
-		painter->drawEllipse(cp, ra, rb, mAngle, a1, a2, false);
-		return;
-	}
-
-	std::vector<double> ds(pat->num, 0.);
-
-    double dpmm=painter->getDpmm();
-	for (size_t i = 0; i < pat->num; i++) {
-        ds[i]= dpmm * pat->pattern[i]; //pattern length
-        if(std::abs(ds[i]) < 1.)
-            ds[i] = std::copysign(1., ds[i]);
-	}
-
-    double curA(a1);
-    bool notDone(true);
-
-	//draw patterned ellipse
-	for (size_t i=0; notDone; i = (i + 1) % pat->num) {
-        double nextA = curA + std::abs(ds[i])/
-                                  RS_Vector(ra*std::sin(curA), rb*std::cos(curA)).magnitude();
-		if (nextA > a2){
-			nextA = a2;
-			notDone = false;
-        }
-		if (ds[i] > 0.)
-			painter->drawEllipse(cp, ra, rb, mAngle, curA, nextA, false);
-
-        curA=nextA;
-    }
-
+    painter->drawEllipse(view->toGui(getCenter()),
+                         ra, rb,
+                         getAngle(),
+                         getAngle1(), getAngle2(),
+                         isReversed());
 }
-
 
 
 /**

--- a/librecad/src/lib/engine/rs_line.cpp
+++ b/librecad/src/lib/engine/rs_line.cpp
@@ -688,9 +688,7 @@ void RS_Line::draw(RS_Painter* painter, RS_GraphicView* view, double& patternOff
 
     double  length=direction.magnitude();
     patternOffset -= length;
-    if (( !drawAsSelected && (
-              getPen().getLineType()==RS2::SolidLine ||
-              view->getDrawingMode()==RS2::ModePreview)) ) {
+    {
         //if length is too small, attempt to draw the line, could be a potential bug
         painter->drawLine(pStart,pEnd);
         return;

--- a/librecad/src/lib/engine/rs_line.cpp
+++ b/librecad/src/lib/engine/rs_line.cpp
@@ -702,7 +702,7 @@ void RS_Line::draw(RS_Painter* painter, RS_GraphicView* view, double& patternOff
     const RS_LineTypePattern* pat;
     if (drawAsSelected) {
 //        styleFactor=1.;
-        pat = &RS_LineTypePattern::patternSelected;
+        pat = RS_LineTypePattern::getPattern(RS2::LineSelected);
 
     } else {
         pat = view->getPattern(getPen().getLineType());

--- a/librecad/src/lib/engine/rs_line.cpp
+++ b/librecad/src/lib/engine/rs_line.cpp
@@ -606,36 +606,10 @@ void RS_Line::draw(RS_Painter* painter, RS_GraphicView* view, double& patternOff
     }
 
     auto viewportRect = view->getViewRect();
-    RS_VectorSolutions endPoints(0);
-    endPoints.push_back(getStartpoint());
-    endPoints.push_back(getEndpoint());
+    RS_VectorSolutions endPoints{{getStartpoint(), getEndpoint()}};
 
-    RS_EntityContainer ec(nullptr);
+    RS_EntityContainer ec = nullptr;
     ec.addRectangle(viewportRect.minP(), viewportRect.maxP());
-
-//    if (viewportRect.inArea(getStartpoint(), RS_TOLERANCE))
-//         endPoints.push_back(getStartpoint());
-//    if (viewportRect.inArea(getEndpoint(), RS_TOLERANCE))
-//         endPoints.push_back(getEndpoint());
-
-//    if (endPoints.size() < 2){
-//        RS_VectorSolutions vpIts;
-//        for(auto p: ec) {
-//            auto const sol=RS_Information::getIntersection(this, p, true);
-//            for (auto const& vp: sol) {
-//                if (vpIts.getClosestDistance(vp) <= RS_TOLERANCE * 10.)
-//                    continue;
-//                vpIts.push_back(vp);
-//            }
-//        }
-//        for (auto const& vp: vpIts) {
-//            if (endPoints.getClosestDistance(vp) <= RS_TOLERANCE * 10.)
-//                continue;
-//            endPoints.push_back(vp);
-//        }
-//    }
-
-//    if (endPoints.size()<2) return;
 
     if ((endPoints[0] - getStartpoint()).squared() >
             (endPoints[1] - getStartpoint()).squared() )
@@ -684,88 +658,11 @@ void RS_Line::draw(RS_Painter* painter, RS_GraphicView* view, double& patternOff
 		direction=pEnd-pStart;
     }
 
-    bool drawAsSelected = isSelected() && !(view->isPrinting() || view->isPrintPreview());
 
-    double  length=direction.magnitude();
+    double length=direction.magnitude();
     patternOffset -= length;
-    {
-        //if length is too small, attempt to draw the line, could be a potential bug
-        painter->drawLine(pStart,pEnd);
-        return;
-    }
-    //    double styleFactor = getStyleFactor(view);
 
-
-    // Pattern:
-    const RS_LineTypePattern* pat;
-    if (drawAsSelected) {
-//        styleFactor=1.;
-        pat = RS_LineTypePattern::getPattern(RS2::LineSelected);
-
-    } else {
-        pat = view->getPattern(getPen().getLineType());
-    }
-	if (!pat) {
-//        patternOffset -= length;
-        RS_DEBUG->print(RS_Debug::D_WARNING,
-                        "RS_Line::draw: Invalid line pattern");
-        painter->drawLine(pStart,pEnd);
-        return;
-    }
-//    patternOffset = remainder(patternOffset - length-0.5*pat->totalLength,pat->totalLength)+0.5*pat->totalLength;
-    if(length<=RS_TOLERANCE){
-        painter->drawLine(pStart,pEnd);
-        return; //avoid division by zero
-    }
-    direction/=length; //cos(angle), sin(angle)
-    // Pen to draw pattern is always solid:
-    RS_Pen pen = painter->getPen();
-
-    pen.setLineType(RS2::SolidLine);
-    painter->setPen(pen);
-
-	if (pat->num <= 0) {
-		RS_DEBUG->print(RS_Debug::D_WARNING,"invalid line pattern for line, draw solid line instead");
-		painter->drawLine(view->toGui(getStartpoint()),
-						  view->toGui(getEndpoint()));
-		return;
-	}
-
-	// pattern segment length:
-	double patternSegmentLength = pat->totalLength;
-
-	// create pattern:
-	std::vector<RS_Vector> dp(pat->num);
-	std::vector<double> ds(pat->num);
-	double dpmm=static_cast<RS_PainterQt*>(painter)->getDpmm();
-	for (size_t i=0; i < pat->num; ++i) {
-		//        ds[j]=pat->pattern[i] * styleFactor;
-		//fixme, styleFactor support needed
-
-		ds[i]=dpmm*pat->pattern[i];
-        if (std::abs(ds[i]) < 1. ) ds[i] = copysign(1., ds[i]);
-        dp[i] = direction*std::abs(ds[i]);
-	}
-	double total= remainder(patternOffset-0.5*patternSegmentLength,patternSegmentLength) -0.5*patternSegmentLength;
-    //    double total= patternOffset-patternSegmentLength;
-
-	RS_Vector curP{pStart+direction*total};
-	for (int j=0; total<length; j=(j+1)%pat->num) {
-
-        // line segment (otherwise space segment)
-        double const t2=total+std::abs(ds[j]);
-		RS_Vector const& p3=curP+dp[j];
-        if (ds[j]>0.0 && t2 > 0.0) {
-            // drop the whole pattern segment line, for ds[i]<0:
-            // trim end points of pattern segment line to line
-			RS_Vector const& p1 =(total > -0.5)?curP:pStart;
-			RS_Vector const& p2 =(t2 < length+0.5)?p3:pEnd;
-            painter->drawLine(p1,p2);
-        }
-        total=t2;
-        curP=p3;
-	}
-
+    painter->drawLine(pStart,pEnd);
 }
 
 /**

--- a/librecad/src/lib/engine/rs_line.cpp
+++ b/librecad/src/lib/engine/rs_line.cpp
@@ -446,7 +446,7 @@ bool RS_Line::offset(const RS_Vector& coord, const double& distance) {
 bool RS_Line::isTangent(const RS_CircleData&  circleData) const{
     double d;
 	getNearestPointOnEntity(circleData.center,false,&d);
-	if(fabs(d-circleData.radius)<20.*RS_TOLERANCE) return true;
+    if(std::abs(d-circleData.radius)<20.*RS_TOLERANCE) return true;
     return false;
 }
 
@@ -589,12 +589,12 @@ void RS_Line::stretch(const RS_Vector& firstCorner,
 
 
 void RS_Line::moveRef(const RS_Vector& ref, const RS_Vector& offset) {
-    if(  fabs(data.startpoint.x -ref.x)<1.0e-4 &&
-         fabs(data.startpoint.y -ref.y)<1.0e-4 ) {
+    if(  std::abs(data.startpoint.x -ref.x)<1.0e-4 &&
+         std::abs(data.startpoint.y -ref.y)<1.0e-4 ) {
         moveStartpoint(data.startpoint+offset);
     }
-    if(  fabs(data.endpoint.x -ref.x)<1.0e-4 &&
-         fabs(data.endpoint.y -ref.y)<1.0e-4 ) {
+    if(  std::abs(data.endpoint.x -ref.x)<1.0e-4 &&
+         std::abs(data.endpoint.y -ref.y)<1.0e-4 ) {
         moveEndpoint(data.endpoint+offset);
     }
 }
@@ -743,8 +743,8 @@ void RS_Line::draw(RS_Painter* painter, RS_GraphicView* view, double& patternOff
 		//fixme, styleFactor support needed
 
 		ds[i]=dpmm*pat->pattern[i];
-		if (fabs(ds[i]) < 1. ) ds[i] = copysign(1., ds[i]);
-		dp[i] = direction*fabs(ds[i]);
+        if (std::abs(ds[i]) < 1. ) ds[i] = copysign(1., ds[i]);
+        dp[i] = direction*std::abs(ds[i]);
 	}
 	double total= remainder(patternOffset-0.5*patternSegmentLength,patternSegmentLength) -0.5*patternSegmentLength;
     //    double total= patternOffset-patternSegmentLength;
@@ -753,7 +753,7 @@ void RS_Line::draw(RS_Painter* painter, RS_GraphicView* view, double& patternOff
 	for (int j=0; total<length; j=(j+1)%pat->num) {
 
         // line segment (otherwise space segment)
-		double const t2=total+fabs(ds[j]);
+        double const t2=total+std::abs(ds[j]);
 		RS_Vector const& p3=curP+dp[j];
         if (ds[j]>0.0 && t2 > 0.0) {
             // drop the whole pattern segment line, for ds[i]<0:

--- a/librecad/src/lib/gui/rs_linetypepattern.cpp
+++ b/librecad/src/lib/gui/rs_linetypepattern.cpp
@@ -32,6 +32,44 @@
 
 #include "rs.h"
 
+namespace {
+//define all line patterns in pixels
+const RS_LineTypePattern patternSolidLine={10.0};
+
+const RS_LineTypePattern patternDotLineTiny{{0.15, -1.}};
+const RS_LineTypePattern patternDotLine{{0.2, -6.2}};
+const RS_LineTypePattern patternDotLine2{{0.2, -3.1}};
+const RS_LineTypePattern patternDotLineX2{{0.2, -12.4}};
+
+const RS_LineTypePattern patternDashLineTiny{{2., -1.}};
+const RS_LineTypePattern patternDashLine{{12.0, -6.0}};
+const RS_LineTypePattern patternDashLine2{{6.0, -3.0}};
+const RS_LineTypePattern patternDashLineX2{{24.0, -12.0}};
+
+const RS_LineTypePattern patternDashDotLineTiny{{2., -2., 0.15, -2.}};
+const RS_LineTypePattern patternDashDotLine{{12.0, -5., 0.2, -5.}};
+const RS_LineTypePattern patternDashDotLine2{{6.0, -2.5, 0.2, -2.5}};
+const RS_LineTypePattern patternDashDotLineX2{{24.0, -8., 0.2, -8.}};
+
+const RS_LineTypePattern patternDivideLineTiny{{2., -0.7, 0.15, -0.7, 0.15, -0.7}};
+const RS_LineTypePattern patternDivideLine{{12.0, -4.9, 0.2, -4.9, 0.2, -4.9}};
+const RS_LineTypePattern patternDivideLine2{{6.0, -1.9, 0.2, -1.9, 0.2, -1.9}};
+const RS_LineTypePattern patternDivideLineX2{{24.0, -8., 0.2, -8., 0.2, -8.}};
+
+const RS_LineTypePattern patternCenterLineTiny{{5., -1., 1., -1.}};
+const RS_LineTypePattern patternCenterLine{{32.0, -6.0, 6.0, -6.0}};
+const RS_LineTypePattern patternCenterLine2{{16.0, -3.0, 3.0, -3.0}};
+const RS_LineTypePattern patternCenterLineX2{{64.0, -12.0, 12.0, -12.0}};
+
+const RS_LineTypePattern patternBorderLineTiny{{2., -1., 2., -1., 0.15, -1.}};
+const RS_LineTypePattern patternBorderLine{{12.0, -4.0, 12.0, -4., 0.2, -4.}};
+const RS_LineTypePattern patternBorderLine2{{6.0, -3.0, 6.0, -3., 0.2, -3.}};
+const RS_LineTypePattern patternBorderLineX2{{24.0, -8.0, 24.0, -8., 0.2, -8.}};
+
+const RS_LineTypePattern patternBlockLine{{0.5, -0.5}};
+const RS_LineTypePattern patternSelected{{1.0, -3.0}};
+}
+
 RS_LineTypePattern::RS_LineTypePattern(std::initializer_list<double> const& pattern):
 	pattern(pattern)
     , num { pattern.size()}
@@ -71,45 +109,11 @@ const RS_LineTypePattern* RS_LineTypePattern::getPattern(RS2::LineType lineType)
             {RS2::BorderLine2, &patternBorderLine2},
             {RS2::BorderLineX2, &patternBorderLineX2},
             {RS2::LineByLayer, &patternBlockLine},
-            {RS2::LineByBlock, &patternBlockLine}
+            {RS2::LineByBlock, &patternBlockLine},
+            {RS2::LineSelected, &patternSelected}
             };
     if (lineTypeToPattern.count(lineType) == 0)
         return nullptr;
     return lineTypeToPattern[lineType];
 }
 
-//define all line patterns in pixels
-const RS_LineTypePattern RS_LineTypePattern::patternSolidLine={10.0};
-
-const RS_LineTypePattern RS_LineTypePattern::patternDotLineTiny{{0.15, -1.}};
-const RS_LineTypePattern RS_LineTypePattern::patternDotLine{{0.2, -6.2}};
-const RS_LineTypePattern RS_LineTypePattern::patternDotLine2{{0.2, -3.1}};
-const RS_LineTypePattern RS_LineTypePattern::patternDotLineX2{{0.2, -12.4}};
-
-const RS_LineTypePattern RS_LineTypePattern::patternDashLineTiny{{2., -1.}};
-const RS_LineTypePattern RS_LineTypePattern::patternDashLine{{12.0, -6.0}};
-const RS_LineTypePattern RS_LineTypePattern::patternDashLine2{{6.0, -3.0}};
-const RS_LineTypePattern RS_LineTypePattern::patternDashLineX2{{24.0, -12.0}};
-
-const RS_LineTypePattern RS_LineTypePattern::patternDashDotLineTiny{{2., -0.7, 0.15, -2.}};
-const RS_LineTypePattern RS_LineTypePattern::patternDashDotLine{{12.0, -5., 0.2, -5.95}};
-const RS_LineTypePattern RS_LineTypePattern::patternDashDotLine2{{6.0, -2., 0.2, -2.}};
-const RS_LineTypePattern RS_LineTypePattern::patternDashDotLineX2{{24.0, -8., 0.2, -8.}};
-
-const RS_LineTypePattern RS_LineTypePattern::patternDivideLineTiny{{2., -0.7, 0.15, -0.7, 0.15, -0.7}};
-const RS_LineTypePattern RS_LineTypePattern::patternDivideLine{{12.0, -4.9, 0.2, -4.9, 0.2, -4.9}};
-const RS_LineTypePattern RS_LineTypePattern::patternDivideLine2{{6.0, -1.9, 0.2, -1.9, 0.2, -1.9}};
-const RS_LineTypePattern RS_LineTypePattern::patternDivideLineX2{{24.0, -8., 0.2, -8., 0.2, -8.}};
-
-const RS_LineTypePattern RS_LineTypePattern::patternCenterLineTiny{{5., -1., 1., -1.}};
-const RS_LineTypePattern RS_LineTypePattern::patternCenterLine{{32.0, -6.0, 6.0, -6.0}};
-const RS_LineTypePattern RS_LineTypePattern::patternCenterLine2{{16.0, -3.0, 3.0, -3.0}};
-const RS_LineTypePattern RS_LineTypePattern::patternCenterLineX2{{64.0, -12.0, 12.0, -12.0}};
-
-const RS_LineTypePattern RS_LineTypePattern::patternBorderLineTiny{{2., -1., 2., -1., 0.15, -1.}};
-const RS_LineTypePattern RS_LineTypePattern::patternBorderLine{{12.0, -4.0, 12.0, -4., 0.2, -4.}};
-const RS_LineTypePattern RS_LineTypePattern::patternBorderLine2{{6.0, -3.0, 6.0, -3., 0.2, -3.}};
-const RS_LineTypePattern RS_LineTypePattern::patternBorderLineX2{{24.0, -8.0, 24.0, -8., 0.2, -8.}};
-
-const RS_LineTypePattern RS_LineTypePattern::patternBlockLine{{0.5, -0.5}};
-const RS_LineTypePattern RS_LineTypePattern::patternSelected{{1.0, -3.0}};

--- a/librecad/src/lib/gui/rs_linetypepattern.h
+++ b/librecad/src/lib/gui/rs_linetypepattern.h
@@ -48,42 +48,6 @@ struct RS_LineTypePattern {
 
     // line type to line pattern conversion
     static const RS_LineTypePattern* getPattern(RS2::LineType entityType);
-
-    //define all line patterns in pixels
-    static const RS_LineTypePattern patternSolidLine;
-
-    static const RS_LineTypePattern patternDotLineTiny;
-    static const RS_LineTypePattern patternDotLine;
-    static const RS_LineTypePattern patternDotLine2;
-    static const RS_LineTypePattern patternDotLineX2;
-
-    static const RS_LineTypePattern patternDashLineTiny;
-    static const RS_LineTypePattern patternDashLine;
-    static const RS_LineTypePattern patternDashLine2;
-    static const RS_LineTypePattern patternDashLineX2;
-
-    static const RS_LineTypePattern patternDashDotLineTiny;
-    static const RS_LineTypePattern patternDashDotLine;
-    static const RS_LineTypePattern patternDashDotLine2;
-    static const RS_LineTypePattern patternDashDotLineX2;
-
-    static const RS_LineTypePattern patternDivideLineTiny;
-    static const RS_LineTypePattern patternDivideLine;
-    static const RS_LineTypePattern patternDivideLine2;
-    static const RS_LineTypePattern patternDivideLineX2;
-
-    static const RS_LineTypePattern patternCenterLineTiny;
-    static const RS_LineTypePattern patternCenterLine;
-    static const RS_LineTypePattern patternCenterLine2;
-    static const RS_LineTypePattern patternCenterLineX2;
-
-    static const RS_LineTypePattern patternBorderLineTiny;
-    static const RS_LineTypePattern patternBorderLine;
-    static const RS_LineTypePattern patternBorderLine2;
-    static const RS_LineTypePattern patternBorderLineX2;
-
-    static const RS_LineTypePattern patternBlockLine;
-    static const RS_LineTypePattern patternSelected;
 };
 
 #endif

--- a/librecad/src/lib/gui/rs_painterqt.cpp
+++ b/librecad/src/lib/gui/rs_painterqt.cpp
@@ -497,12 +497,14 @@ void RS_PainterQt::drawEllipse(const RS_Vector& cp,
     // shift a2 - a1 to the range of 0 to 2 pi
     a2 = a1+ M_PI + std::remainder(a2 - a1 - M_PI, 2. * M_PI);
 
+    QPointF center = {toScreenX(cp.x), toScreenY(cp.y)};
+
     if (std::abs(std::remainder(a2 - a1, 2. * M_PI)) > RS_TOLERANCE_ANGLE)
     {
         // arc
-        auto getP = [center = RS_Vector{toScreenX(cp.x), toScreenY(cp.y)}, &radius1, &radius2, &angle](double a) {
-            RS_Vector point = center + RS_Vector{a}.scale({radius1, radius2});
-            point.rotate(center, angle);
+        auto getP = [origin = RS_Vector{center.x(), center.y()}, &radius1, &radius2, &angle](double a) {
+            auto point = origin + RS_Vector{a}.scale({radius1, radius2});
+            point.rotate(origin, angle);
             return point;
         };
         setClipping(true);
@@ -523,14 +525,12 @@ void RS_PainterQt::drawEllipse(const RS_Vector& cp,
         path.lineTo(p2.x, p2.y);
         path.lineTo(p1.x, p1.y);
         setClipPath(path);
-    setClipping(false);
     } else {
 
     }
     this->rotate(-angle * 180.0/M_PI);
     QTransform t0 = transform();
     QTransform t1;
-    QPointF center = {toScreenX(cp.x), toScreenY(cp.y)};
     t1.translate(center.x(), center.y());
     t1.rotate(-angle*180./M_PI);
     t1.translate(-center.x(), -center.y());

--- a/librecad/src/lib/gui/rs_painterqt.cpp
+++ b/librecad/src/lib/gui/rs_painterqt.cpp
@@ -497,7 +497,7 @@ void RS_PainterQt::drawEllipse(const RS_Vector& cp,
     // shift a2 - a1 to the range of 0 to 2 pi
     a2 = a1+ M_PI + std::remainder(a2 - a1 - M_PI, 2. * M_PI);
 
-    QPointF center = {toScreenX(cp.x), toScreenY(cp.y)};
+    QPointF center = {double(toScreenX(cp.x)), double(toScreenY(cp.y))};
 
     if (std::abs(std::remainder(a2 - a1, 2. * M_PI)) > RS_TOLERANCE_ANGLE)
     {
@@ -528,8 +528,6 @@ void RS_PainterQt::drawEllipse(const RS_Vector& cp,
         path.lineTo(p1.x, p1.y);
         setClipping(true);
         setClipPath(path);
-    } else {
-
     }
     QTransform t0 = transform();
     QTransform t1;

--- a/librecad/src/lib/gui/rs_painterqt.h
+++ b/librecad/src/lib/gui/rs_painterqt.h
@@ -108,6 +108,15 @@ public:
     void setClipRect(int x, int y, int w, int h) override;
     void resetClipping() override;
 
+    //RAII style QPen dash pattern
+    struct PenDashPattern {
+        PenDashPattern(const QPen& pen, RS2::LineType t, double screenWidth);
+        ~PenDashPattern();
+        QPen& m_pen;
+        RS2::LineType m_lineType;
+    };
+
+
 protected:
     RS_Pen lpen;
     long rememberX = 0; // Used for the moment because QPainter doesn't support moveTo anymore, thus we need to remember ourselves the moveTo positions


### PR DESCRIPTION
To avoid dash pattern and anti-aliasing issues (#778, #1657, #1658), use Qt native methods to handle line dash patterns.

Modified draw() methods for: RS_Line, RS_Arc, RS_Circle, RS_Ellipse.

Since QPainter doesn't support drawing elliptic arc natively, elliptic arcs are drawn as clipped complete ellipses.

This commit is expected to be experimental, and may be reverted in the future due to potential regressions.