### PR TITLE
feat: Shortcut "." to specify current point coordinates on command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2.2.1-alpha] - unreleased
 
 ### Added
+- shortcut "." to specify the current point coordinates on command line
 
 ### Removed
 - importshp plugin, see issue #1481

--- a/librecad/src/lib/gui/rs_eventhandler.cpp
+++ b/librecad/src/lib/gui/rs_eventhandler.cpp
@@ -278,6 +278,15 @@ void RS_EventHandler::commandEvent(RS_CommandEvent* e) {
                     }
                 }
 
+                // handle quick shortcut for current point:
+                if (!e->isAccepted()) {
+                    if (cmd == ".") {
+                        RS_CoordinateEvent ce(relative_zero);
+                        currentActions.last()->coordinateEvent(&ce);
+                        e->accept();
+                    }
+                }
+
                 // handle absolute polar coordinate input:
                 if (!e->isAccepted()) {
                     if (cmd.contains('<') && cmd.at(0)!='@') {


### PR DESCRIPTION
In using the LibreCAD command line, I find that far and away the most common point that needs to be entered is simply the current point (the origin for relative coordinates). I am aware that "0..0" specifies this, but that is four fairly awkward keystrokes. Hence, I suggest that a single-character shortcut is well worth it. This commit implements "." to mean the current point (i.e. same as "0..0") when coordinates are expected on the command line. The shortcut was chosen because a bare "." has no other meaning, and it could be read "point" anyway, as a convenient mnemonic. Happy to revise in favor of any other single character if desired. Another possibility that came to mind was a bare "@", chose "." mostly because it's easier to type and because of the cute mnemonic.

Note that as documentation is (currently?) separate from the source repository, I was sure whether you preferred a parallel PR to the docs repository, or just want me to do a PR there if this is merged. Happy to do either as you prefer, just let me know.