### PR TITLE
feat: Extend one-character coordinate shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [2.2.1-alpha] - unreleased
 
 ### Added
-- shortcut "." to specify the current point coordinates on command line
+- shortcut "0" to specify coordinates "0,0" on command line
+- shortcut "." or "," to specify the current point coordinates on command line
 
 ### Removed
 - importshp plugin, see issue #1481

--- a/librecad/src/lib/gui/rs_eventhandler.cpp
+++ b/librecad/src/lib/gui/rs_eventhandler.cpp
@@ -241,14 +241,17 @@ void RS_EventHandler::commandEvent(RS_CommandEvent* e) {
                     switch (cmd[0].toLatin1()) {
                         case '0':
                             at.set(0,0);
-                            /* FALL THROUGH */
-                        case '.': case ',': {
+                            /* FALL THROUGH, to be replaced with c++17 [[fallthrough]] */
+                        case '.':
+                        case ',':
+                        {
                             RS_CoordinateEvent ce(at);
                             currentActions.last()->coordinateEvent(&ce);
                             e->accept();
                         }
+                            /* FALL THROUGH */
                         default: /* NO OP */
-                            ;
+                            break;
                     }
                 }
 

--- a/librecad/src/lib/gui/rs_eventhandler.cpp
+++ b/librecad/src/lib/gui/rs_eventhandler.cpp
@@ -235,9 +235,25 @@ void RS_EventHandler::commandEvent(RS_CommandEvent* e) {
         if (!e->isAccepted()) {
 
             if(hasAction()){
-                // handle absolute cartesian coordinate input:
-                if (cmd.contains(',') && cmd.at(0)!='@') {
+                // handle quick shortcuts for absolute/current origins:
+                if (cmd.length() == 1) {
+                    RS_Vector at = relative_zero;
+                    switch (cmd[0].toLatin1()) {
+                        case '0':
+                            at.set(0,0);
+                            /* FALL THROUGH */
+                        case '.': case ',': {
+                            RS_CoordinateEvent ce(at);
+                            currentActions.last()->coordinateEvent(&ce);
+                            e->accept();
+                        }
+                        default: /* NO OP */
+                            ;
+                    }
+                }
 
+                // handle absolute cartesian coordinate input:
+                if (!e->isAccepted() && cmd.contains(',') && cmd.at(0)!='@') {
                     int commaPos = cmd.indexOf(',');
                     RS_DEBUG->print("RS_EventHandler::commandEvent: 001");
                     bool ok1, ok2;
@@ -275,15 +291,6 @@ void RS_EventHandler::commandEvent(RS_CommandEvent* e) {
 							RS_DIALOGFACTORY->commandMessage(
 										"Expression Syntax Error");
 						e->accept();
-                    }
-                }
-
-                // handle quick shortcut for current point:
-                if (!e->isAccepted()) {
-                    if (cmd == ".") {
-                        RS_CoordinateEvent ce(relative_zero);
-                        currentActions.last()->coordinateEvent(&ce);
-                        e->accept();
                     }
                 }
 


### PR DESCRIPTION
  This commit adds a shortcut of `,` to specify the current point
  (relative origin) when coordinates are expected on the command line,
  on top of the recently-added `.` shortcut with the same meaning. (This
  addition means that all number pads have a key which can be used for
  the current point.) In addition, it adds a shortcut of `0` to mean
  `0,0` so that there is a parallel one-character way of specifying
  the absolute origin.

(As agreed upon in the discussion re PR #1673.)