### PR TITLE
Issue #1572: fix hatching area calculation

### DIFF
--- a/librecad/src/lib/engine/lc_looputils.cpp
+++ b/librecad/src/lib/engine/lc_looputils.cpp
@@ -112,7 +112,8 @@ RS_Vector LoopExtractor::getInternalPoint() const
             continue;
         std::sort(results.begin(), results.end(), CompareDistance{p0});
         // find an internal point
-        return (results.at(0) + results.at(1)) * 0.5;
+        const double mixFactor = 0.1 + 0.8 * getRandom();
+        return results.at(0) * mixFactor + results.at(1) * (1.0 - mixFactor);
     }
     LC_LOG << __func__
            << "(): failed: "<<__func__<<"(): failed";
@@ -190,7 +191,7 @@ bool LoopExtractor::findNext() const
     std::vector<RS_Entity*> connected = getConnected();
     switch (connected.size()) {
     case 0:
-        LC_LOG << __func__
+        LC_ERR << __func__
                << "(): disconnected at point: ("<<m_data->vertex.x<<", "<<m_data->vertex.y<<")";
         return false;
     case 1:
@@ -210,22 +211,22 @@ bool LoopExtractor::findNext() const
 
 std::vector<std::unique_ptr<RS_EntityContainer>> LoopExtractor::extract() {
     std::vector<std::unique_ptr<RS_EntityContainer>> loops;
-    LC_ERR<<__func__<<"(): begin";
+    LC_LOG<<__func__<<"(): begin";
 
     bool success = true;
     while(success && !m_edges.isEmpty()) {
         LC_ERR<<"0: size="<<m_edges.count();
         findFirst();
         while(m_data->vertex.squaredTo(m_data->vertexTarget) > RS_TOLERANCE) {
-            LC_ERR<<m_data->vertex.x<<", "<< m_data->vertex.y<<" : "<<" : ds2 = "
+            LC_LOG<<m_data->vertex.x<<", "<< m_data->vertex.y<<" : "<<" : ds2 = "
                  <<m_data->vertex.squaredTo(m_data->vertexTarget);
-            LC_ERR<<"id = "<<m_data->current->getId();
+            LC_LOG<<"id = "<<m_data->current->getId();
             success = findNext();
         }
-        LC_ERR<<"1: loop.size() = "<<m_loop->count()<<": size="<<m_edges.count();
+        LC_LOG<<"1: loop.size() = "<<m_loop->count()<<": size="<<m_edges.count();
         loops.push_back(std::move(m_loop));
     }
-    LC_ERR<<__func__<<"(): loops.size() = "<<loops.size();
+    LC_LOG<<__func__<<"(): loops.size() = "<<loops.size();
     //if (loops.size() == 2)
      //   loops.pop_back();
     return loops;

--- a/librecad/src/lib/engine/lc_looputils.cpp
+++ b/librecad/src/lib/engine/lc_looputils.cpp
@@ -1,0 +1,130 @@
+#include <algorithm>
+#include <array>
+#include <random>
+#include <vector>
+
+#include "lc_looputils.h"
+#include "rs_debug.h"
+#include "rs_entity.h"
+#include "rs_entitycontainer.h"
+#include "rs_information.h"
+#include "rs_line.h"
+#include "rs_vector.h"
+
+namespace {
+std::default_random_engine randomEngine;
+
+std::vector<RS_Entity *> getConnected(RS_EntityContainer &ec,
+                                      const RS_Vector &point) {
+  std::vector<RS_Entity *> connected;
+  std::copy_if(ec.begin(), ec.end(), std::back_inserter(connected),
+               [&point](const RS_Entity *e) {
+                 double dist = RS_MAXDOUBLE;
+                 e->getNearestEndpoint(point, &dist);
+                 return dist < 1E-7;
+               });
+  return connected;
+}
+
+} // namespace
+
+namespace LC_LoopUtils {
+
+// a random angle between 0 and 2 pi
+double getRandomAngle() {
+  static std::uniform_real_distribution<double> uniformDistribution(0.0,
+                                                                    2. * M_PI);
+  return uniformDistribution(randomEngine);
+}
+
+struct ComparePoints {
+  bool operator()(const RS_Vector &p0, const RS_Vector &p1) const {
+    if (p0.x + RS_TOLERANCE < p1.x)
+      return true;
+    else if (p0.x > p1.x + RS_TOLERANCE)
+      return false;
+    return p0.y + RS_TOLERANCE < p1.y;
+  }
+};
+
+RS_VectorSolutions getIntersection(RS_AtomicEntity *line,
+                                   const RS_EntityContainer &loop) {
+  RS_VectorSolutions ret;
+  for (RS_Entity *entity : loop) {
+    if (entity && entity->isEdge()) {
+      auto intersections = RS_Information::getIntersection(line, entity, true);
+      ret.push_back(intersections);
+    }
+  }
+  return ret;
+}
+
+RS_Vector getInternalPoint(RS_EntityContainer &loop) {
+  RS_Vector p0 =
+      loop.firstEntity()->getNearestPointOnEntity(loop.getMin(), true);
+  double size = loop.count();
+  for (short i = 0; i < 16; i++) {
+    RS_Vector offset = RS_Vector(getRandomAngle()) * size;
+    auto line = std::make_unique<RS_Line>(nullptr, p0 - offset, p0 + offset);
+    auto results = getIntersection(line.get(), loop);
+    // need even number of intersections
+    if (results.empty() || results.size() % 2 == 1)
+      continue;
+    std::sort(results.begin(), results.end(), ComparePoints{});
+    // find an internal point
+    return (results.at(0) + results.at(1)) * 0.5;
+  }
+  LC_LOG << __func__
+         << "(): failed to find a line passing the loop: " << loop.getId();
+  return RS_Vector{false};
+}
+
+bool isEnclosed(RS_EntityContainer &loop, RS_Entity &entity) {
+  RS_Vector internal = getInternalPoint(loop);
+
+  static std::uniform_int_distribution<> uniformDistribution(1, 100);
+  int i = uniformDistribution(randomEngine);
+  RS_Vector point = entity.getNearestMiddle(internal, nullptr, i);
+  auto line = std::make_unique<RS_Line>(nullptr, internal, point);
+  auto results = getIntersection(line.get(), loop);
+  return results.size() % 2 == 0;
+}
+
+std::unique_ptr<RS_Line> getRandomRay(RS_EntityContainer &loop) {
+  RS_Vector p0 = getInternalPoint(loop);
+  double size = loop.count();
+  return std::make_unique<RS_Line>(nullptr, p0,
+                                   p0 + RS_Vector{getRandomAngle()} * size);
+}
+
+LoopExtractor::LoopExtractor(RS_EntityContainer &edges) : m_edges{edges} {}
+
+std::unique_ptr<RS_EntityContainer> LoopExtractor::extract() {
+
+  auto loop = std::make_unique<RS_EntityContainer>(nullptr, false);
+  while (!m_edges.isEmpty()) {
+    RS_Entity *e = m_edges.firstEntity();
+    m_edges.removeEntity(e);
+    RS_Vector target = e->getStartpoint();
+    loop->addEntity(e);
+    RS_Vector endPoint = e->getEndpoint();
+    while (endPoint.squaredTo(target) > RS_TOLERANCE && !m_edges.isEmpty()) {
+      double distance = 0.;
+      RS_Entity *next = nullptr;
+      RS_Vector startPoint =
+          m_edges.getNearestEndpoint(endPoint, &distance, &next);
+      std::array<RS_Vector, 2> points{next->getStartpoint(),
+                                      next->getEndpoint()};
+      if (startPoint.squaredTo(points[1]) < RS_TOLERANCE15)
+        std::swap(points[0], points[1]);
+      loop->addEntity(next);
+      m_edges.removeEntity(next);
+      endPoint = points[1];
+    }
+    if (endPoint.squaredTo(target) < RS_TOLERANCE)
+      return loop;
+  }
+  return loop;
+}
+
+} // namespace LC_LoopUtils

--- a/librecad/src/lib/engine/lc_looputils.cpp
+++ b/librecad/src/lib/engine/lc_looputils.cpp
@@ -14,16 +14,16 @@
 namespace {
 std::default_random_engine randomEngine;
 
-std::vector<RS_Entity *> getConnected(RS_EntityContainer &ec,
-                                      const RS_Vector &point) {
-  std::vector<RS_Entity *> connected;
-  std::copy_if(ec.begin(), ec.end(), std::back_inserter(connected),
-               [&point](const RS_Entity *e) {
-                 double dist = RS_MAXDOUBLE;
-                 e->getNearestEndpoint(point, &dist);
-                 return dist < 1E-7;
-               });
-  return connected;
+
+double endDistance(const RS_Entity& entity)
+{
+    return entity.getStartpoint().squaredTo(entity.getEndpoint());
+}
+
+// compare entities by start-end distance
+bool compareEndDistance(const RS_Entity* lhs, const RS_Entity* rhs)
+{
+    return endDistance(*lhs) < endDistance(*rhs);
 }
 
 } // namespace
@@ -32,99 +32,171 @@ namespace LC_LoopUtils {
 
 // a random angle between 0 and 2 pi
 double getRandomAngle() {
-  static std::uniform_real_distribution<double> uniformDistribution(0.0,
-                                                                    2. * M_PI);
-  return uniformDistribution(randomEngine);
+    static std::uniform_real_distribution<double> uniformDistribution(0.0,
+                                                                      2. * M_PI);
+    return uniformDistribution(randomEngine);
+}
+
+
+double getRandom() {
+    static std::uniform_real_distribution<double> uniformDistribution(0.0, 1.);
+    return uniformDistribution(randomEngine);
 }
 
 struct ComparePoints {
-  bool operator()(const RS_Vector &p0, const RS_Vector &p1) const {
-    if (p0.x + RS_TOLERANCE < p1.x)
-      return true;
-    else if (p0.x > p1.x + RS_TOLERANCE)
-      return false;
-    return p0.y + RS_TOLERANCE < p1.y;
-  }
+    bool operator()(const RS_Vector &p0, const RS_Vector &p1) const {
+        if (p0.x + RS_TOLERANCE < p1.x)
+            return true;
+        else if (p0.x > p1.x + RS_TOLERANCE)
+            return false;
+        return p0.y + RS_TOLERANCE < p1.y;
+    }
+    bool operator()(const std::pair<RS_Vector, RS_Entity*> &p0, const std::pair<RS_Vector, RS_Entity*> &p1) const {
+        return (*this)(p0.first, p1.first);
+    }
+};
+struct CompareDistance {
+    CompareDistance(const RS_Vector& point):
+        m_point{point}
+    {}
+
+    bool operator() (const RS_Vector &p0, const RS_Vector &p1) const {
+        return p0.squaredTo(m_point) < p1.squaredTo(m_point);
+    }
+
+    const RS_Vector& m_point;
 };
 
 RS_VectorSolutions getIntersection(RS_AtomicEntity *line,
                                    const RS_EntityContainer &loop) {
-  RS_VectorSolutions ret;
-  for (RS_Entity *entity : loop) {
-    if (entity && entity->isEdge()) {
-      auto intersections = RS_Information::getIntersection(line, entity, true);
-      ret.push_back(intersections);
+    RS_VectorSolutions ret;
+    for (RS_Entity *entity : loop) {
+        if (entity != nullptr && entity->isEdge()) {
+            auto intersections = RS_Information::getIntersection(line, entity, true);
+            ret.push_back(intersections);
+        }
     }
-  }
-  return ret;
+    return ret;
 }
 
-RS_Vector getInternalPoint(RS_EntityContainer &loop) {
-  RS_Vector p0 =
-      loop.firstEntity()->getNearestPointOnEntity(loop.getMin(), true);
-  double size = loop.count();
-  for (short i = 0; i < 16; i++) {
-    RS_Vector offset = RS_Vector(getRandomAngle()) * size;
-    auto line = std::make_unique<RS_Line>(nullptr, p0 - offset, p0 + offset);
-    auto results = getIntersection(line.get(), loop);
-    // need even number of intersections
-    if (results.empty() || results.size() % 2 == 1)
-      continue;
-    std::sort(results.begin(), results.end(), ComparePoints{});
-    // find an internal point
-    return (results.at(0) + results.at(1)) * 0.5;
-  }
-  LC_LOG << __func__
-         << "(): failed to find a line passing the loop: " << loop.getId();
-  return RS_Vector{false};
+struct LoopExtractor::LoopData {
+    RS_Vector vertex;
+    RS_Vector vertexTarget;
+    RS_Entity* current = nullptr;
+};
+
+LoopExtractor::LoopExtractor(RS_EntityContainer &edges) :
+    m_data{std::make_unique<LoopData>()}
+    , m_edges{edges}
+{}
+
+std::vector<RS_Entity*> LoopExtractor::getConnected() const
+{
+    std::vector<RS_Entity *> connected;
+    std::copy_if(m_edges.begin(), m_edges.end(), std::back_inserter(connected),
+                 [vertex = m_data->vertex, current = m_data->current](const RS_Entity *e) {
+        if (e == current)
+            return false;
+        double dist = RS_MAXDOUBLE;
+        e->getNearestEndpoint(vertex, &dist);
+        return dist < 1E-7;
+    });
+    return connected;
 }
 
-bool isEnclosed(RS_EntityContainer &loop, RS_Entity &entity) {
-  RS_Vector internal = getInternalPoint(loop);
+LoopExtractor::~LoopExtractor() = default;
 
-  static std::uniform_int_distribution<> uniformDistribution(1, 100);
-  int i = uniformDistribution(randomEngine);
-  RS_Vector point = entity.getNearestMiddle(internal, nullptr, i);
-  auto line = std::make_unique<RS_Line>(nullptr, internal, point);
-  auto results = getIntersection(line.get(), loop);
-  return results.size() % 2 == 0;
-}
-
-std::unique_ptr<RS_Line> getRandomRay(RS_EntityContainer &loop) {
-  RS_Vector p0 = getInternalPoint(loop);
-  double size = loop.count();
-  return std::make_unique<RS_Line>(nullptr, p0,
-                                   p0 + RS_Vector{getRandomAngle()} * size);
-}
-
-LoopExtractor::LoopExtractor(RS_EntityContainer &edges) : m_edges{edges} {}
-
-std::unique_ptr<RS_EntityContainer> LoopExtractor::extract() {
-
-  auto loop = std::make_unique<RS_EntityContainer>(nullptr, false);
-  while (!m_edges.isEmpty()) {
-    RS_Entity *e = m_edges.firstEntity();
-    m_edges.removeEntity(e);
-    RS_Vector target = e->getStartpoint();
-    loop->addEntity(e);
-    RS_Vector endPoint = e->getEndpoint();
-    while (endPoint.squaredTo(target) > RS_TOLERANCE && !m_edges.isEmpty()) {
-      double distance = 0.;
-      RS_Entity *next = nullptr;
-      RS_Vector startPoint =
-          m_edges.getNearestEndpoint(endPoint, &distance, &next);
-      std::array<RS_Vector, 2> points{next->getStartpoint(),
-                                      next->getEndpoint()};
-      if (startPoint.squaredTo(points[1]) < RS_TOLERANCE15)
-        std::swap(points[0], points[1]);
-      loop->addEntity(next);
-      m_edges.removeEntity(next);
-      endPoint = points[1];
+RS_Vector LoopExtractor::getInternalPoint() const
+{
+    RS_Vector p0 =m_data->current->getMiddlePoint();
+    for(short i = 0; i < 16; ++i) {
+        RS_Vector offset = m_data->current->getTangentDirection(p0).rotate(M_PI/4 +getRandomAngle()/8.);
+        offset *= m_edges.getSize().magnitude()/offset.magnitude();
+        auto line = std::make_unique<RS_Line>(nullptr, p0 - offset, p0 + offset);
+        auto results = getIntersection(line.get(), m_edges);
+        // need even number of intersections
+        if (results.empty() || results.size() % 2 == 1)
+            continue;
+        std::sort(results.begin(), results.end(), CompareDistance{p0});
+        // find an internal point
+        return (results.at(0) + results.at(1)) * 0.5;
     }
-    if (endPoint.squaredTo(target) < RS_TOLERANCE)
-      return loop;
-  }
-  return loop;
+    LC_LOG << __func__
+           << "(): failed: "<<__func__<<"(): failed";
+    return RS_Vector{false};
+}
+
+
+RS_Entity* LoopExtractor::findFirst() const
+{
+    RS_Entity* first = nullptr;
+    m_edges.getNearestPointOnEntity(m_edges.getMin(), true, nullptr, &first);
+    m_data->vertex = first->getEndpoint();
+    m_data->vertexTarget = first->getStartpoint();
+    m_data->current = first;
+    m_loop = std::make_unique<RS_EntityContainer>(nullptr, false);
+    m_loop->addEntity(m_data->current);
+    return first;
+}
+
+bool LoopExtractor::isOutermost(RS_Entity* edge, const RS_Vector& innerPoint) const
+{
+    assert(edge != nullptr);
+    RS_Vector middle = edge->getMiddlePoint();
+    RS_Vector direction = (middle - innerPoint).normalize();
+    auto line = std::make_unique<RS_Line>(middle, middle + direction * m_edges.getSize().magnitude());
+    auto hasIntersection = [l=line.get(), edge](RS_Entity* e) {
+        return e != edge && !RS_Information::getIntersection(l, e, true).empty();
+    };
+    return std::none_of(m_edges.begin(), m_edges.end(), hasIntersection);
+}
+
+
+RS_Entity* LoopExtractor::findOutermost(std::vector<RS_Entity*> edges) const
+{
+    assert(edges.size() >= 2);
+    RS_Vector innerPoint = getInternalPoint();
+    for (RS_Entity* edge: edges)
+        if (isOutermost(edge, innerPoint))
+            return edge;
+
+    return edges.front();
+}
+
+void LoopExtractor::findNext() const
+{
+    std::vector<RS_Entity*> connected = getConnected();
+    switch (connected.size()) {
+    case 0:
+        LC_LOG << __func__
+               << "(): disconnected at point: ("<<m_data->vertex.x<<", "<<m_data->vertex.y<<")";
+        return;
+    case 1:
+        m_data->current = connected.front();
+        break;
+    default:
+    {
+        m_data->current = findOutermost(connected);
+    }
+    }
+    m_data->vertex = (m_data->vertex.squaredTo(m_data->current->getStartpoint()) > RS_TOLERANCE) ? m_data->current->getStartpoint() : m_data->current->getEndpoint();
+    m_loop->addEntity(m_data->current);
+}
+
+
+std::vector<std::unique_ptr<RS_EntityContainer>> LoopExtractor::extract() {
+    std::vector<std::unique_ptr<RS_EntityContainer>> loops;
+
+    m_loops.clear();
+    while(!m_edges.isEmpty()) {
+        findFirst();
+        while(m_data->vertex.squaredTo(m_data->vertexTarget) > RS_TOLERANCE)
+            findNext();
+        for(RS_Entity* edge: *m_loop)
+            m_edges.removeEntity(edge);
+        loops.push_back(std::move(m_loop));
+    }
+    return loops;
 }
 
 } // namespace LC_LoopUtils

--- a/librecad/src/lib/engine/lc_looputils.cpp
+++ b/librecad/src/lib/engine/lc_looputils.cpp
@@ -166,7 +166,7 @@ RS_Entity* LoopExtractor::findOutermost(std::vector<RS_Entity*> edges) const
     for(RS_Entity* edge: edges)
         edgeLength = std::min({edgeLength, edge->getLength(), edge->getStartpoint().distanceTo(edge->getEndpoint())});
 
-    RS_Circle circle{nullptr, {m_data->vertex, edgeLength * 0.1}};
+    RS_Circle circle{nullptr, {m_data->vertex, edgeLength * 0.01}};
     auto getCut = [&circle, p0 = m_data->vertex](RS_Entity* edge){
         RS_VectorSolutions sol = RS_Information::getIntersection(&circle, edge, true);
         assert(!sol.empty());

--- a/librecad/src/lib/engine/lc_looputils.h
+++ b/librecad/src/lib/engine/lc_looputils.h
@@ -1,0 +1,50 @@
+#ifndef LC_LOOPUTILS_H
+#define LC_LOOPUTILS_H
+
+#include <memory>
+
+class RS_Entity;
+class RS_EntityContainer;
+class RS_Line;
+class RS_Vector;
+class RS_VectorSolutions;
+
+namespace LC_LoopUtils {
+
+// a random angle between 0 and 2 pi
+double getRandomAngle();
+
+// find a point inside a given loop
+RS_Vector  getInternalPoint(RS_EntityContainer& loop);
+
+// Create a random ray: starting from an internal point of the loop
+std::unique_ptr<RS_Line> getRandomRay(RS_EntityContainer* loop);
+
+// Find intersection between a line and a loop
+RS_VectorSolutions getIntersection(RS_Entity* line, const RS_EntityContainer& loop);
+
+/**
+ * @brief isEnclosed - whether the entity is enclosed in the loop. It's assumed the entity shouldn't intersect
+ * with the loop.
+ * @param loop - a simple closed contour
+ * @param entity - an entity
+ * @return bool - true, an entity
+ */
+bool isEnclosed(RS_EntityContainer& loop, RS_Entity& entity);
+
+double getSize(const RS_EntityContainer& loop);
+
+
+class LoopExtractor {
+public:
+    LoopExtractor(RS_EntityContainer& edges);
+
+    std::unique_ptr<RS_EntityContainer> extract();
+private:
+    RS_EntityContainer& m_edges;
+};
+
+
+}
+
+#endif // LC_LOOPUTILS_H

--- a/librecad/src/lib/engine/lc_looputils.h
+++ b/librecad/src/lib/engine/lc_looputils.h
@@ -11,6 +11,12 @@ class RS_Line;
 class RS_Vector;
 class RS_VectorSolutions;
 
+/**
+ * @brief the name space contains utils to analyze contour topology.
+ * The initial motivation is to allow proper calculation of hatched areas. For example, the hatched areas
+ * contain holes(say, denoted as lakes), and the lakes may further contain islands of their own. The hatched
+ * area calculation should find the total area of all land including any islands in lakes.
+ */
 namespace LC_LoopUtils {
 
 /**
@@ -21,8 +27,6 @@ namespace LC_LoopUtils {
  * @return bool - true, an entity
  */
 bool isEnclosed(RS_EntityContainer& loop, RS_AtomicEntity& entity);
-
-double getSize(const RS_EntityContainer& loop);
 
 /**
  * @brief The LoopExtractor class, to extract closed loops from edges.

--- a/librecad/src/lib/engine/lc_looputils.h
+++ b/librecad/src/lib/engine/lc_looputils.h
@@ -44,9 +44,9 @@ public:
     std::vector<std::unique_ptr<RS_EntityContainer>> extract();
 private:
     RS_Entity* findFirst() const;
-    void findNext() const;
+    bool findNext() const;
     std::vector<RS_Entity*> getConnected() const;
-    bool isOutermost(RS_Entity* edge, const RS_Vector& innerPoint) const;
+    bool isOutermost(RS_Entity* edge) const;
     RS_Entity* findOutermost(std::vector<RS_Entity*> edges) const;
     mutable std::unique_ptr<RS_EntityContainer> m_loop;
     mutable std::vector<std::unique_ptr<RS_EntityContainer>> m_loops;

--- a/librecad/src/lib/engine/lc_looputils.h
+++ b/librecad/src/lib/engine/lc_looputils.h
@@ -2,6 +2,7 @@
 #define LC_LOOPUTILS_H
 
 #include <memory>
+#include <vector>
 
 class RS_Entity;
 class RS_EntityContainer;
@@ -15,7 +16,7 @@ namespace LC_LoopUtils {
 double getRandomAngle();
 
 // find a point inside a given loop
-RS_Vector  getInternalPoint(RS_EntityContainer& loop);
+RS_Vector  getInternalPoint(RS_EntityContainer& loop, RS_Entity* edge);
 
 // Create a random ray: starting from an internal point of the loop
 std::unique_ptr<RS_Line> getRandomRay(RS_EntityContainer* loop);
@@ -38,9 +39,21 @@ double getSize(const RS_EntityContainer& loop);
 class LoopExtractor {
 public:
     LoopExtractor(RS_EntityContainer& edges);
+    ~LoopExtractor();
 
-    std::unique_ptr<RS_EntityContainer> extract();
+    std::vector<std::unique_ptr<RS_EntityContainer>> extract();
 private:
+    RS_Entity* findFirst() const;
+    void findNext() const;
+    std::vector<RS_Entity*> getConnected() const;
+    bool isOutermost(RS_Entity* edge, const RS_Vector& innerPoint) const;
+    RS_Entity* findOutermost(std::vector<RS_Entity*> edges) const;
+    mutable std::unique_ptr<RS_EntityContainer> m_loop;
+    mutable std::vector<std::unique_ptr<RS_EntityContainer>> m_loops;
+    RS_Vector getInternalPoint() const;
+    struct LoopData;
+    std::unique_ptr<LoopData> m_data;
+
     RS_EntityContainer& m_edges;
 };
 

--- a/librecad/src/lib/engine/lc_looputils.h
+++ b/librecad/src/lib/engine/lc_looputils.h
@@ -35,12 +35,40 @@ bool isEnclosed(RS_EntityContainer& loop, RS_Entity& entity);
 
 double getSize(const RS_EntityContainer& loop);
 
+/**
+ * @brief The LoopExtractor class, to extract closed loops from edges.
+ * The algorithm：
+ * 0. Move label all edges as unprocessed
+ * 1. Find an edge closest to the bounding box of all edges;
+ * 2. Set the start point of the edge as the target point;
+ * 3. Label the edge as processed;
+ * 4. Find internal point of the edge;
+ * 5. From the end point of the current edge, find all unprocessed edges connected to this point;
+ * 6. From the end point draw a small circle, find intersections between the circle and edges(the current, and connected);
+ * 7. Find the direction angle from the circle center to the intersections. Add another angle from the end point to the
+ * internal point from Step 4.;
+ * 8. Sort the angles, find the direction right next to the direction of the current edge;
+ * 9. Choose the edge which has an angle right next to the current edge's angle;
+ * 10. Repeat steps 2- 19, until the target point set in Step 2.
+ * The algorithm has the following assumptions:
 
+ * 1. Contours are closed loops, so each edge has its start/end points connected to other edges;
+ * 2. Each loop is simply closed with number of edges equals the number of vertices (Shared endpoints),
+ * i.e. Euler characteristic 0;
+ * 3. Full circles/ellipses are accepted as individual closed contours;
+ * 4. No self-intersection among contours; i.e. no edge crosses another edge;
+ * 5. Multiple edges are allowed to be connected at a single point;
+ * 6. Closed contours may share edge endpoints, but no edge is shared by more than one contours.
+ */
 class LoopExtractor {
 public:
     LoopExtractor(RS_EntityContainer& edges);
     ~LoopExtractor();
 
+    /**
+     * @brief extract - extract loops from connected edges
+     * @return std::vector<std::unique_ptr<RS_EntityContainer>> - loops. each element is simply closed
+     */
     std::vector<std::unique_ptr<RS_EntityContainer>> extract();
 private:
     RS_Entity* findFirst() const;

--- a/librecad/src/lib/engine/lc_looputils.h
+++ b/librecad/src/lib/engine/lc_looputils.h
@@ -49,7 +49,9 @@ double getSize(const RS_EntityContainer& loop);
  * internal point from Step 4.;
  * 8. Sort the angles, find the direction right next to the direction of the current edge;
  * 9. Choose the edge which has an angle right next to the current edge's angle;
- * 10. Repeat steps 2- 19, until the target point set in Step 2.
+ * 10. Repeat steps 2- 19, until the target point set in Step 2 to find a closed loop;
+ * 11. Repeat Steps 1-10, untill all edges are processed.
+ *
  * The algorithm has the following assumptions:
 
  * 1. Contours are closed loops, so each edge has its start/end points connected to other edges;

--- a/librecad/src/lib/engine/rs_arc.cpp
+++ b/librecad/src/lib/engine/rs_arc.cpp
@@ -1051,7 +1051,11 @@ double RS_Arc::areaLineIntegral() const
     const double r2=0.25*r*r;
     const double fStart=data.center.x*r*sin(a0)+r2*sin(a0+a0);
     const double fEnd=data.center.x*r*sin(a1)+r2*sin(a1+a1);
-    return (isReversed()?fStart-fEnd:fEnd-fStart) + 2.*r2*getAngleLength();
+    if (isReversed()) {
+        return fEnd-fStart - 2.*r2*getAngleLength();
+    } else {
+        return fEnd-fStart + 2.*r2*getAngleLength();
+    }
 }
 
 /**

--- a/librecad/src/lib/engine/rs_ellipse.cpp
+++ b/librecad/src/lib/engine/rs_ellipse.cpp
@@ -1678,7 +1678,11 @@ double RS_Ellipse::areaLineIntegral() const
     const double& a1=data.angle2;
     const double fStart=cx*getStartpoint().y+0.25*r2*sin(2.*aE)*cos(a0)*cos(a0)-0.25*ab*(2.*sin(aE)*sin(aE)*sin(2.*a0)-sin(2.*a0));
     const double fEnd=cx*getEndpoint().y+0.25*r2*sin(2.*aE)*cos(a1)*cos(a1)-0.25*ab*(2.*sin(aE)*sin(aE)*sin(2.*a1)-sin(2.*a1));
-    return (isReversed()?fStart-fEnd:fEnd-fStart) + 0.5*ab*getAngleLength();
+    if (isReversed()) {
+        return fEnd-fStart - 0.5 * a * b * getAngleLength();
+    } else {
+        return fEnd-fStart + 0.5 * a * b * getAngleLength();
+    }
 }
 
 bool RS_Ellipse::isReversed() const {

--- a/librecad/src/lib/engine/rs_entitycontainer.cpp
+++ b/librecad/src/lib/engine/rs_entitycontainer.cpp
@@ -30,6 +30,8 @@
 
 #include <QtGlobal>
 
+#include "lc_looputils.h"
+
 #include "qg_dialogfactory.h"
 
 #include "rs_arc.h"
@@ -2107,7 +2109,8 @@ std::vector<std::unique_ptr<RS_EntityContainer>> RS_EntityContainer::getLoops() 
     //find loops
     while (!edges.isEmpty())
     {
-        auto subLoops = findLoop(edges);
+        LC_LoopUtils::LoopExtractor extractor{edges};
+        auto subLoops = extractor.extract();
         for (auto& loop: subLoops)
             loops.push_back(std::move(loop));
     }

--- a/librecad/src/lib/engine/rs_entitycontainer.cpp
+++ b/librecad/src/lib/engine/rs_entitycontainer.cpp
@@ -1873,7 +1873,7 @@ double RS_EntityContainer::areaLineIntegral() const
 
     // edges:
 
-    RS_Vector previousPoint;
+    RS_Vector previousPoint(false);
     for(auto* e: entities){
         if (isClosedLoop(*e))
         {
@@ -1887,11 +1887,10 @@ double RS_EntityContainer::areaLineIntegral() const
         double lineIntegral = e->areaLineIntegral();
         RS_Vector startPoint = e->getStartpoint();
         RS_Vector endPoint = e->getEndpoint();
+        LC_ERR<<e->getId()<<": int = "<<lineIntegral<<": "<<startPoint.x<<" - "<<endPoint.x;
 
         // the line integral is always by the direction: from the start point to the end point
-        if (isReversed(e))
-            std::swap(startPoint, endPoint);
-        RS_Vector nearest;
+        RS_Vector nearest(false);
         if (previousPoint.valid) {
             double distance = RS_MAXDOUBLE;
             nearest = e->getNearestEndpoint(previousPoint, &distance);
@@ -1900,7 +1899,7 @@ double RS_EntityContainer::areaLineIntegral() const
                                 __func__, distance, previousPoint.x, previousPoint.y);
         }
         // assume the contour is a simple connected loop
-        if (previousPoint.valid && endPoint.squaredTo(nearest) <= RS_TOLERANCE15)
+        if (previousPoint.valid && endPoint.squaredTo(previousPoint) <= RS_TOLERANCE15)
         {
             contourArea -= lineIntegral;
             previousPoint = startPoint;

--- a/librecad/src/lib/engine/rs_entitycontainer.cpp
+++ b/librecad/src/lib/engine/rs_entitycontainer.cpp
@@ -2034,6 +2034,7 @@ const QList<RS_Entity*>& RS_EntityContainer::getEntityList()
 }
 
 namespace {
+
 std::vector<std::unique_ptr<RS_EntityContainer>> findLoop(RS_EntityContainer& container)
 {
 

--- a/librecad/src/lib/engine/rs_hatch.cpp
+++ b/librecad/src/lib/engine/rs_hatch.cpp
@@ -23,13 +23,8 @@
 ** This copyright notice MUST APPEAR in all copies of the script!
 **
 **********************************************************************/
-#include <iostream>
 #include <cmath>
-#include <memory>
-#include <set>
-#include <map>
-#include <random>
-#include <unordered_map>
+#include <iostream>
 
 #include <QPainterPath>
 #include <QBrush>
@@ -50,152 +45,6 @@
 #include "rs_patternlist.h"
 #include "rs_math.h"
 #include "rs_debug.h"
-
-namespace
-{
-
-// a random angle between 0 and 2 pi
-double getRandomAngle();
-
-// find a point inside a given loop
-RS_Vector  getInternalPoint(RS_EntityContainer* loop);
-
-// Create a random ray: starting from an internal point of the loop
-std::unique_ptr<RS_Line> getRandomRay(RS_EntityContainer* loop);
-
-// Find intersection between a line and a loop
-RS_VectorSolutions getIntersection(RS_AtomicEntity* line, const RS_EntityContainer& loop);
-
-double getSize(const RS_EntityContainer* loop) {
-    return (loop->getMax() - loop->getMin()).magnitude();
-}
-
-std::unordered_map<const RS_EntityContainer*, double> findAreas(const std::vector<std::unique_ptr<RS_EntityContainer>>& loops )
-{
-    std::unordered_map<const RS_EntityContainer*, double> ret;
-    for(const std::unique_ptr<RS_EntityContainer>& loop: loops)
-        ret.emplace(loop.get(), std::abs(loop->areaLineIntegral()));
-    return ret;
-}
-
-/**
- * @brief The LoopSorter class - find topologic relations of loops
- * The input loops must not cross each other; no edge is shared among loops.
- * Tangential edges are allowed.
- */
-class LoopSorter {
-public:
-    /**
-     * Each input loop is assumed to be a simple closed loop, and contains only edges.
-     * The input loops should not contain sub-loops
-     * Ownership of the input loops is transferred to this LoopSorter
-     * @param std::vector<std::unique_ptr<RS_EntityContainer>> loops input loops
-     */
-    LoopSorter(std::vector<std::unique_ptr<RS_EntityContainer>> loops);
-    struct AreaPredicate {
-        AreaPredicate(const LoopSorter& sorter);
-        bool operator () (const RS_EntityContainer* lhs, const RS_EntityContainer* rhs) const;
-        const LoopSorter& m_sorter;
-    };
-
-    /**
-     * @brief getResults - the sorting results
-     * @return std::vector<RS_EntityContainer*> - the top level loops, i.e. outermost loops, after sorting
-     * each inner loop is added as a child of its immediate parent loop.
-     */
-    std::vector<RS_EntityContainer*> getResults() const
-    {
-        std::set<RS_EntityContainer*> roots;
-        for (const auto& loop: m_loops)
-            if (m_parents.count(loop.get()) == 0)
-                roots.insert(loop.get());
-        return {roots.begin(), roots.end()};
-    }
-
-private:
-    void init();
-    // find all ancestor loops of a given loop
-    void findAncestors(RS_EntityContainer* loop);
-
-    // hold input loops
-    std::vector<std::unique_ptr<RS_EntityContainer>> m_loops;
-    // lookup table to find enclosed area of each loop
-    std::unordered_map<const RS_EntityContainer*, double> m_area;
-    // compare loops by their enclosed areas
-    // The area of any ancestor loop is larger than the child loop.
-    // Always find ancestors using the loop with the smallest unprocessed loop.
-    // For each loop, only need to find its parent once.
-    AreaPredicate m_areaComparison{*this};
-    // Candidate loops, sorted by their enclosed areas
-    std::multiset<RS_EntityContainer*, AreaPredicate> m_toProcess{m_areaComparison};
-    // lookup table for parent loops
-    std::unordered_map<RS_EntityContainer*, RS_EntityContainer*> m_parents;
-};
-
-LoopSorter::LoopSorter(std::vector<std::unique_ptr<RS_EntityContainer>> loops):
-    m_loops{std::move(loops)}
-  , m_area{findAreas(m_loops)}
-{
-    init();
-}
-
-void LoopSorter::init()
-{
-    for(const auto& loop: m_loops)
-        m_toProcess.insert(loop.get());
-    std::vector<RS_EntityContainer*> loops{m_toProcess.begin(), m_toProcess.end()};
-    for (RS_EntityContainer* loop : loops)
-        findAncestors(loop);
-}
-
-void LoopSorter::findAncestors(RS_EntityContainer* loop)
-{
-    if (m_toProcess.erase(loop) == 0)
-        return;
-
-    // use a random direction to avoid passing tangential directions
-    // TODO, to complete avoid tangential
-    auto ray = getRandomRay(loop);
-    using namespace std;
-    // sorting by floating points is okay, the loops shouldn't be close to each other, with exception
-    // of touching points
-    map<double, RS_EntityContainer*> ancestors;
-    for(RS_EntityContainer* candidate: m_toProcess) {
-        if (candidate == loop)
-            continue;
-        RS_VectorSolutions intersections = getIntersection(ray.get(), *candidate);
-        if (intersections.size()%2 == 0)
-            continue;
-        // a parent loop has odd intersections for a ray starting from an inner point
-        double distance = intersections.getClosestDistance(ray->getStartpoint());
-        ancestors.emplace(distance, candidate);
-    }
-    // ancestors found: from innermost to outermost
-    RS_EntityContainer* current = loop;
-    for (const auto& entry: ancestors)
-    {
-        RS_EntityContainer* parent = entry.second;
-        m_toProcess.erase(parent);
-        if (m_parents.count(current) == 1)
-            break;
-        m_parents[current] = parent;
-        parent->addEntity(current);
-        current = parent;
-    }
-}
-
-
-LoopSorter::AreaPredicate::AreaPredicate(const LoopSorter &sorter):
-    m_sorter{sorter}
-{}
-
-bool LoopSorter::AreaPredicate::operator ()(const RS_EntityContainer* lhs, const RS_EntityContainer* rhs) const
-{
-    return m_sorter.m_area.at(lhs) + RS_TOLERANCE < m_sorter.m_area.at(rhs);
-}
-
-}
-
 
 RS_HatchData::RS_HatchData(bool _solid,
 						   double _scale,
@@ -957,69 +806,6 @@ void RS_Hatch::stretch(const RS_Vector& firstCorner,
     update();
 }
 
-namespace {
-
-// a random angle between 0 and 2 pi
-double getRandomAngle()
-{
-    static std::default_random_engine randomEngine;
-    static std::uniform_real_distribution<double> uniformDistribution(0.0, 2. * M_PI);
-    return uniformDistribution(randomEngine);
-}
-
-struct ComparePoints {
-    bool operator () (const RS_Vector& p0, const RS_Vector& p1) const
-    {
-        if (p0.x + RS_TOLERANCE < p1.x)
-            return true;
-        else if (p0.x > p1.x + RS_TOLERANCE)
-            return false;
-        return p0.y + RS_TOLERANCE < p1.y;
-    }
-};
-
-RS_VectorSolutions getIntersection(RS_AtomicEntity* line, const RS_EntityContainer& loop)
-{
-    RS_VectorSolutions ret;
-    for(RS_Entity* entity: loop) {
-        if (entity && entity->isEdge()) {
-            auto intersections = RS_Information::getIntersection(line, entity, true);
-            ret.push_back(intersections);
-        }
-    }
-    return ret;
-}
-
-RS_Vector getInternalPoint(RS_EntityContainer* loop)
-{
-    RS_Vector p0 = loop->firstEntity()->getNearestPointOnEntity(loop->getMin(), true);
-    double size = getSize(loop);
-    for(short i=0;i<16; i++)
-    {
-        RS_Vector offset =  RS_Vector(getRandomAngle())*size;
-        auto line = std::make_unique<RS_Line>(nullptr, p0 - offset, p0 + offset);
-        auto results = getIntersection(line.get(), *loop);
-        // need even number of intersections
-        if (results.empty() || results.size() % 2 == 1)
-            continue;
-        std::sort(results.begin(), results.end(), ComparePoints{});
-        // find an internal point
-        return (results.at(0) + results.at(1)) * 0.5;
-    }
-    LC_LOG(RS_Debug::D_ERROR)<<__func__<<"(): failed to find a line passing the loop: "<<loop->getId();
-    return RS_Vector{false};
-}
-
-std::unique_ptr<RS_Line> getRandomRay(RS_EntityContainer* loop)
-{
-    RS_Vector p0 = getInternalPoint(loop);
-    double size = getSize(loop);
-    return std::make_unique<RS_Line>(nullptr, p0, p0 + RS_Vector{getRandomAngle()}*size);
-}
-}
-
-
-
 /**
  * Dumps the point's data to stdout.
  */
@@ -1027,5 +813,3 @@ std::ostream& operator << (std::ostream& os, const RS_Hatch& p) {
     os << " Hatch: " << p.getData() << "\n";
     return os;
 }
-
-

--- a/librecad/src/lib/engine/rs_hatch.cpp
+++ b/librecad/src/lib/engine/rs_hatch.cpp
@@ -34,14 +34,16 @@
 #include <QPainterPath>
 #include <QBrush>
 #include <QString>
+
 #include "rs_hatch.h"
+
+#include "lc_looputils.h"
 
 #include "rs_arc.h"
 #include "rs_circle.h"
 #include "rs_ellipse.h"
 #include "rs_line.h"
 #include "rs_graphicview.h"
-
 #include "rs_information.h"
 #include "rs_painter.h"
 #include "rs_pattern.h"
@@ -870,7 +872,7 @@ double RS_Hatch::getTotalArea() {
     }
     std::cout<<"loops: done"<<std::endl;
 
-    LoopSorter loopSorter(std::move(loops));
+    LC_LoopUtils::LoopSorter loopSorter(std::move(loops));
     auto sorted = loopSorter.getResults();
 
     double totalArea=0.;

--- a/librecad/src/lib/engine/rs_vector.cpp
+++ b/librecad/src/lib/engine/rs_vector.cpp
@@ -170,6 +170,28 @@ double RS_Vector::squaredTo(const RS_Vector& v1) const
     return RS_MAXDOUBLE;
 }
 
+
+RS_Vector RS_Vector::normalized() const
+{
+    if (valid) {
+        double length = magnitude();
+        if (length > RS_TOLERANCE)
+            return (*this) * (1. / length);
+    }
+    return *this;
+}
+
+
+RS_Vector& RS_Vector::normalize()
+{
+    if (valid) {
+        double length = magnitude();
+        if (length > RS_TOLERANCE)
+            *this *= 1./length;
+    }
+    return *this;
+}
+
 /**
  *
  */

--- a/librecad/src/lib/engine/rs_vector.h
+++ b/librecad/src/lib/engine/rs_vector.h
@@ -83,6 +83,8 @@ public:
 	RS_Vector scale(const RS_Vector& center, const RS_Vector& factor);
     RS_Vector mirror(const RS_Vector& axisPoint1, const RS_Vector& axisPoint2);
 	double dotP(const RS_Vector& v1) const;
+    RS_Vector normalized() const;
+    RS_Vector& normalize();
 
     RS_Vector operator + (const RS_Vector& v) const;
 	RS_Vector operator + (double d) const;

--- a/librecad/src/src.pro
+++ b/librecad/src/src.pro
@@ -131,6 +131,7 @@ HEADERS += \
     lib/actions/rs_snapper.h \
     lib/creation/rs_creation.h \
     lib/debug/rs_debug.h \
+    lib/engine/lc_looputils.h \
     lib/engine/rs.h \
     lib/engine/rs_arc.h \
     lib/engine/rs_atomicentity.h \
@@ -235,6 +236,7 @@ SOURCES += \
     lib/actions/rs_snapper.cpp \
     lib/creation/rs_creation.cpp \
     lib/debug/rs_debug.cpp \
+    lib/engine/lc_looputils.cpp \
     lib/engine/rs_arc.cpp \
     lib/engine/rs_block.cpp \
     lib/engine/rs_blocklist.cpp \

--- a/librecad/src/ui/forms/qg_dlgarc.cpp
+++ b/librecad/src/ui/forms/qg_dlgarc.cpp
@@ -77,6 +77,7 @@ void QG_DlgArc::setArc(RS_Arc& a) {
     s.setNum(RS_Math::rad2deg(arc->getAngle2()));
     leAngle2->setText(s);
     cbReversed->setChecked(arc->isReversed());
+    lId->setText(QString("ID: %1").arg(arc->getId()));
 }
 
 void QG_DlgArc::updateArc() {

--- a/librecad/src/ui/forms/qg_dlgarc.ui
+++ b/librecad/src/ui/forms/qg_dlgarc.ui
@@ -27,6 +27,13 @@
   </property>
   <layout class="QVBoxLayout" name="gfdgf">
    <item>
+    <widget class="QLabel" name="lId">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout">
      <item>
       <layout class="QVBoxLayout">

--- a/librecad/src/ui/forms/qg_dlgellipse.cpp
+++ b/librecad/src/ui/forms/qg_dlgellipse.cpp
@@ -89,6 +89,7 @@ void QG_DlgEllipse::setEllipse(RS_Ellipse& e) {
     s.setNum(RS_Math::rad2deg(ellipse->getAngle2()));
     leAngle2->setText(s);
     cbReversed->setChecked(ellipse->isReversed());
+    lId->setText(QString("ID: %1").arg(ellipse->getId()));
 }
 
 void QG_DlgEllipse::updateEllipse() {

--- a/librecad/src/ui/forms/qg_dlgellipse.ui
+++ b/librecad/src/ui/forms/qg_dlgellipse.ui
@@ -27,6 +27,13 @@
   </property>
   <layout class="QVBoxLayout">
    <item>
+    <widget class="QLabel" name="lId">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout">
      <item>
       <layout class="QVBoxLayout">

--- a/librecad/src/ui/forms/qg_dlgline.cpp
+++ b/librecad/src/ui/forms/qg_dlgline.cpp
@@ -45,14 +45,6 @@ QG_DlgLine::QG_DlgLine(QWidget* parent, bool modal, Qt::WindowFlags fl)
 }
 
 /*
- *  Destroys the object and frees any allocated resources
- */
-QG_DlgLine::~QG_DlgLine()
-{
-    // no need to delete child widgets, Qt does it all for us
-}
-
-/*
  *  Sets the strings of the subwidgets using the current
  *  language.
  */
@@ -82,6 +74,7 @@ void QG_DlgLine::setLine(RS_Line& l) {
     leEndX->setText(s);
     s.setNum(line->getEndpoint().y);
     leEndY->setText(s);
+    lId->setText(QString("ID: %1").arg(line->getId()));
 }
 
 void QG_DlgLine::updateLine() {

--- a/librecad/src/ui/forms/qg_dlgline.h
+++ b/librecad/src/ui/forms/qg_dlgline.h
@@ -35,8 +35,7 @@ class QG_DlgLine : public QDialog, public Ui::QG_DlgLine
     Q_OBJECT
 
 public:
-    QG_DlgLine(QWidget* parent = 0, bool modal = false, Qt::WindowFlags fl = {});
-    ~QG_DlgLine();
+    QG_DlgLine(QWidget* parent = nullptr, bool modal = false, Qt::WindowFlags fl = {});
 
 public slots:
     virtual void setLine( RS_Line & l );

--- a/librecad/src/ui/forms/qg_dlgline.ui
+++ b/librecad/src/ui/forms/qg_dlgline.ui
@@ -30,6 +30,13 @@
   </property>
   <layout class="QVBoxLayout">
    <item>
+    <widget class="QLabel" name="lId">
+     <property name="text">
+      <string>ID: </string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout">
      <item>
       <layout class="QVBoxLayout">

--- a/librecad/src/ui/forms/qg_dlgspline.cpp
+++ b/librecad/src/ui/forms/qg_dlgspline.cpp
@@ -48,14 +48,6 @@ QG_DlgSpline::QG_DlgSpline(QWidget* parent, bool modal, Qt::WindowFlags fl)
 }
 
 /*
- *  Destroys the object and frees any allocated resources
- */
-QG_DlgSpline::~QG_DlgSpline()
-{
-    // no need to delete child widgets, Qt does it all for us
-}
-
-/*
  *  Sets the strings of the subwidgets using the current
  *  language.
  */
@@ -82,6 +74,7 @@ void QG_DlgSpline::setSpline(RS_Spline& e) {
     cbDegree->setCurrentIndex( cbDegree->findText(s) );
 
     cbClosed->setChecked(spline->isClosed());
+    lId->setText(QString("ID: %1").arg(spline->getId()));
 }
 
 

--- a/librecad/src/ui/forms/qg_dlgspline.h
+++ b/librecad/src/ui/forms/qg_dlgspline.h
@@ -36,7 +36,6 @@ class QG_DlgSpline : public QDialog, public Ui::QG_DlgSpline
 
 public:
     QG_DlgSpline(QWidget* parent = nullptr, bool modal = false, Qt::WindowFlags fl = {});
-    ~QG_DlgSpline();
 
 public slots:
     virtual void setSpline( RS_Spline & e );

--- a/librecad/src/ui/forms/qg_dlgspline.ui
+++ b/librecad/src/ui/forms/qg_dlgspline.ui
@@ -27,6 +27,13 @@
   </property>
   <layout class="QVBoxLayout">
    <item>
+    <widget class="QLabel" name="lId">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout">
      <item>
       <layout class="QVBoxLayout">


### PR DESCRIPTION
LibreCAD v3 calculates enclosed area within a contour by an approximate algorithm.

In v2, the area is found by line integration along the contour edges. To support complex contours requires some topology analysis of the contour.

This PR allows support for contours with inner contours (_i.e._ islands within a lake, and lakes on an island within another lake, scenarios).

The algorithm has the following assumptions:

1. Contours are closed loops, so each edge has its start/end points connected to other edges; each loop is simply closed with number of edges equals the number of vertices (Shared endpoints), _i.e._ Euler characteristic 0;
2. Full circles/ellipses are accepted as individual closed contours;
3. No self-intersection among contours; _i.e._ no edge crosses another edge;
4. Multiple edges are allowed to be connected at a single point;
5. Closed contours may share edge endpoints, but no edge is shared by more than one contours. 