### PR TITLE
Issue #1572: fixed single loop area

### DIFF
--- a/librecad/src/lib/engine/lc_looputils.cpp
+++ b/librecad/src/lib/engine/lc_looputils.cpp
@@ -23,9 +23,6 @@ constexpr double contourGapTolerance = 1E-7;
 // a random angle between 0 and 2 pi
 double getRandomAngle();
 
-// a random number in [0, 1]
-double getRandom();
-
 // Create a random ray: starting from an internal point of the loop
 std::unique_ptr<RS_Line> getRandomRay(RS_EntityContainer* loop);
 
@@ -292,7 +289,7 @@ std::vector<std::unique_ptr<RS_EntityContainer>> LoopExtractor::extract() {
     bool success = true;
     while(success && !m_data->edges.isEmpty()) {
         findFirst();
-        while(m_data->vertex.squaredTo(m_data->vertexTarget) > RS_TOLERANCE) {
+        while(success && m_data->vertex.squaredTo(m_data->vertexTarget) > RS_TOLERANCE) {
             LC_LOG<<m_data->vertex.x<<", "<< m_data->vertex.y<<" : "<<" : ds2 = "
                  <<m_data->vertex.squaredTo(m_data->vertexTarget);
             LC_LOG<<"id = "<<m_data->current->getId();

--- a/librecad/src/lib/engine/lc_looputils.cpp
+++ b/librecad/src/lib/engine/lc_looputils.cpp
@@ -204,11 +204,14 @@ RS_Vector LoopExtractor::getInternalPoint() const
 // To find the next connected edge, keep going by left turning or right turning only.
 RS_Entity* LoopExtractor::findFirst() const
 {
+
     // draw a line crossing the first edge
     RS_Entity* first = m_edges.firstEntity();
     RS_Vector p0 = m_edges.firstEntity()->getMiddlePoint();
-    RS_Vector t0 = first->getTangentDirection(p0);
-    RS_Vector dP0 = t0.rotate((getRandomAngle() - M_PI)*0.06)*m_edges.getSize().magnitude();
+    RS_Vector t0 = first->getTangentDirection(p0).normalize();
+
+    RS_Vector dP0 = t0.rotate(M_PI/2 + getRandomAngle()*0.06)* m_size * 1.1;
+
     std::array<RS_Vector, 2> linePoints = {{p0 - dP0, p0 + dP0}};
     std::sort(std::begin(linePoints), std::end(linePoints), ComparePoints{});
     RS_Line line0{linePoints.front(), linePoints.back()};

--- a/librecad/src/lib/engine/lc_looputils.cpp
+++ b/librecad/src/lib/engine/lc_looputils.cpp
@@ -204,14 +204,11 @@ RS_Vector LoopExtractor::getInternalPoint() const
 // To find the next connected edge, keep going by left turning or right turning only.
 RS_Entity* LoopExtractor::findFirst() const
 {
-
     // draw a line crossing the first edge
     RS_Entity* first = m_edges.firstEntity();
     RS_Vector p0 = m_edges.firstEntity()->getMiddlePoint();
-    RS_Vector t0 = first->getTangentDirection(p0).normalize();
-
-    RS_Vector dP0 = t0.rotate(M_PI/2 + getRandomAngle()*0.06)* m_size * 1.1;
-
+    RS_Vector t0 = first->getTangentDirection(p0);
+    RS_Vector dP0 = t0.rotate((getRandomAngle() - M_PI)*0.06)*m_edges.getSize().magnitude();
     std::array<RS_Vector, 2> linePoints = {{p0 - dP0, p0 + dP0}};
     std::sort(std::begin(linePoints), std::end(linePoints), ComparePoints{});
     RS_Line line0{linePoints.front(), linePoints.back()};

--- a/librecad/src/lib/engine/lc_looputils.cpp
+++ b/librecad/src/lib/engine/lc_looputils.cpp
@@ -53,11 +53,6 @@ double getRandomAngle() {
     return uniformDistribution(randomEngine);
 }
 
-double getRandom() {
-    static std::uniform_real_distribution<double> uniformDistribution(0.0, 1.);
-    return uniformDistribution(randomEngine);
-}
-
 RS_Vector getInternalPoint(const RS_EntityContainer& loop)
 {
     RS_Vector p0 = loop.firstEntity()->getNearestPointOnEntity(loop.getMin(), true);

--- a/librecad/src/lib/engine/lc_looputils.h
+++ b/librecad/src/lib/engine/lc_looputils.h
@@ -72,12 +72,8 @@ private:
     RS_Entity* findOutermost(std::vector<RS_Entity*> edges) const;
     mutable std::unique_ptr<RS_EntityContainer> m_loop;
     mutable std::vector<std::unique_ptr<RS_EntityContainer>> m_loops;
-    RS_Vector getInternalPoint() const;
     struct LoopData;
     std::unique_ptr<LoopData> m_data;
-
-    RS_EntityContainer& m_edges;
-    double m_size;
 };
 
 


### PR DESCRIPTION
The contour area calcuation by Green's theorem requires consistent integration direction.

The issue before this PR: The integration direction is determined by finding whether the start/end point is connected to the current vertex location. For the first entity, it's direction is also needed to know: whether the start point or the end point is connected to the next edge.

In this PR, the direction of the first edge is also evaluated by finding the nearest end points to the start point or the end point of the current entity.