### PR TITLE
Exiting print preview displays wrong drawing #1207

### DIFF
--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -547,8 +547,15 @@ void QC_ApplicationWindow::doClose(QC_MDIWindow * w, bool activateNext)
 	actionHandler->set_view(nullptr);
 	actionHandler->set_document(nullptr);
 
-	if (activateNext && window_list.count() > 0)
+    if (!parentWindow && activateNext && window_list.count() > 0)
+    {
 		doActivate(window_list.front());
+    }
+    else
+    {
+        RS_DEBUG->print("QC_ApplicationWindow::active parent window");
+        doActivate(parentWindow);
+    }
 	RS_DEBUG->print("QC_ApplicationWindow::doClose end");
 }
 

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -547,16 +547,16 @@ void QC_ApplicationWindow::doClose(QC_MDIWindow * w, bool activateNext)
 	actionHandler->set_view(nullptr);
 	actionHandler->set_document(nullptr);
 
-    if (!parentWindow && activateNext && window_list.count() > 0)
-    {
-		doActivate(window_list.front());
+    if (activateNext && window_list.count() > 0) {
+        if (nullptr != parentWindow) {
+            doActivate(parentWindow);
+        }
+        else {
+            doActivate(window_list.front());
+        }
     }
-    else
-    {
-        RS_DEBUG->print("QC_ApplicationWindow::active parent window");
-        doActivate(parentWindow);
-    }
-	RS_DEBUG->print("QC_ApplicationWindow::doClose end");
+
+    RS_DEBUG->print("QC_ApplicationWindow::doClose end");
 }
 
 /**


### PR DESCRIPTION
Hello,

This is my first PR, so I picked up a simple issue to start with. As described in Issue #1207, after performing certain actions, LibreCAD always reverts to the first window. I tested this on the 2.2 branch, and the issue persists.

Upon inspecting the code, I noticed that even though there is access to parentWindow, the active window always defaults to the first one in the window list. Since parentWindow is used to determine whether the current window is printPreview or a Block, I utilized this variable to set the focus when closing the current window.

I use LibreCAD for woodworking drawings as a hobby, and while I may not have experience with C++ or QT, I was eager to contribute.
