### PR TITLE
Icons

### DIFF
--- a/librecad/res/icons/angle_line_to_line.svg
+++ b/librecad/res/icons/angle_line_to_line.svg
@@ -144,6 +144,6 @@
        sodipodi:cx="60"
        sodipodi:type="arc"
        id="path5091"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#130000;stroke-width:7.99999857;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:8;stroke-opacity:1" />
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:7.99999857;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:8;stroke-opacity:1" />
   </g>
 </svg>

--- a/librecad/res/icons/arc_concentric.svg
+++ b/librecad/res/icons/arc_concentric.svg
@@ -72,7 +72,7 @@
        sodipodi:cx="9.0311108"
        sodipodi:type="arc"
        id="path4394"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#130000;stroke-width:2.25777793;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.25777793;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        sodipodi:open="true"
        d="M 9.0311116,19.191109 A 44.026672,44.026672 0 0 1 53.057783,63.217781"
@@ -83,7 +83,7 @@
        sodipodi:cy="63.217781"
        sodipodi:cx="9.0311108"
        sodipodi:type="arc"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#130000;stroke-width:2.25777793;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:9.03111172, 4.51555586;stroke-dashoffset:3.38666677;stroke-opacity:1"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.25777793;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:9.03111172, 4.51555586;stroke-dashoffset:3.38666677;stroke-opacity:1"
        id="circle4396" />
     <path
        sodipodi:open="true"
@@ -96,6 +96,6 @@
        sodipodi:cx="9.0311108"
        sodipodi:type="arc"
        id="circle4398"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#130000;stroke-width:2.25777793;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.25777793;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   </g>
 </svg>

--- a/librecad/res/icons/fillet.svg
+++ b/librecad/res/icons/fillet.svg
@@ -69,7 +69,7 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccc" />
       <path
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#130000;stroke-width:8;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9;stroke-opacity:1"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:8;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9;stroke-opacity:1"
          id="path4141"
          sodipodi:type="arc"
          sodipodi:cx="96.00016"

--- a/librecad/res/icons/offset.svg
+++ b/librecad/res/icons/offset.svg
@@ -72,7 +72,7 @@
        sodipodi:cx="9.0311108"
        sodipodi:type="arc"
        id="path4394"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#130000;stroke-width:2.25777793;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.25777793;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        sodipodi:open="true"
        d="M 9.0311116,19.191109 A 44.026672,44.026672 0 0 1 53.057783,63.217781"
@@ -83,7 +83,7 @@
        sodipodi:cy="63.217781"
        sodipodi:cx="9.0311108"
        sodipodi:type="arc"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#130000;stroke-width:2.25777793;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:9.03111172, 4.51555586;stroke-dashoffset:3.38666677;stroke-opacity:1"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.25777793;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:9.03111172, 4.51555586;stroke-dashoffset:3.38666677;stroke-opacity:1"
        id="circle4396" />
     <path
        sodipodi:open="true"
@@ -96,6 +96,6 @@
        sodipodi:cx="9.0311108"
        sodipodi:type="arc"
        id="circle4398"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#130000;stroke-width:2.25777793;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.25777793;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   </g>
 </svg>

--- a/librecad/res/icons/snap_center.svg
+++ b/librecad/res/icons/snap_center.svg
@@ -72,7 +72,7 @@
        sodipodi:cx="9.0311098"
        sodipodi:type="arc"
        id="path4394"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#130000;stroke-width:2.25777769;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.25777769;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"

--- a/librecad/res/icons/snap_distance.svg
+++ b/librecad/res/icons/snap_distance.svg
@@ -72,7 +72,7 @@
        sodipodi:cx="6.7733316"
        sodipodi:type="arc"
        id="path4394"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#130000;stroke-width:2.25777769;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.25777769;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"

--- a/librecad/res/icons/snap_endpoints.svg
+++ b/librecad/res/icons/snap_endpoints.svg
@@ -78,7 +78,7 @@
        sodipodi:cx="15.804445"
        sodipodi:type="arc"
        id="path4394"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#130000;stroke-width:2.25777793;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.25777793;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <circle
        r="5.6444449"
        style="opacity:1;fill:#00ff7f;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.25777793;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1"

--- a/librecad/res/icons/snap_entity.svg
+++ b/librecad/res/icons/snap_entity.svg
@@ -72,7 +72,7 @@
        sodipodi:cx="13.546667"
        sodipodi:type="arc"
        id="path4394"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#130000;stroke-width:2.25777793;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.25777793;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"

--- a/librecad/res/icons/snap_middle.svg
+++ b/librecad/res/icons/snap_middle.svg
@@ -72,7 +72,7 @@
        sodipodi:cx="9.0311098"
        sodipodi:type="arc"
        id="path4394"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#130000;stroke-width:2.25777769;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.25777769;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"

--- a/librecad/res/icons/unlocked.svg
+++ b/librecad/res/icons/unlocked.svg
@@ -25,7 +25,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -41,16 +41,16 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1000"
+     inkscape:window-height="1176"
      id="namedview4321"
      showgrid="true"
      units="px"
      inkscape:snap-grids="true"
-     inkscape:zoom="4.0249896"
-     inkscape:cx="87.254553"
-     inkscape:cy="131.50336"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:zoom="3.7226562"
+     inkscape:cx="128"
+     inkscape:cy="128"
+     inkscape:window-x="-4"
+     inkscape:window-y="-4"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg4295"
      inkscape:object-nodes="true"
@@ -67,7 +67,7 @@
        inkscape:connector-curvature="0"
        id="path6592"
        d="m 14.675557,62.088893 0,-33.866669 42.89778,0 0,33.866669 z"
-       style="fill:#c8c8c8;fill-rule:evenodd;stroke:#c8c8c8;stroke-width:2.25777793;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1" />
+       style="fill:#cccccc;fill-rule:evenodd;stroke:#cccccc;stroke-width:2.25777793;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1" />
     <path
        sodipodi:open="true"
        d="M 20.319998,24.83541 A 15.804445,15.804445 0 0 1 36.124443,9.0309658 15.804445,15.804445 0 0 1 51.928888,24.835411"
@@ -79,6 +79,6 @@
        sodipodi:cx="36.124443"
        sodipodi:type="arc"
        id="path6594"
-       style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#c8c8c8;stroke-width:4.51555634;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:4.51555634;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>


### PR DESCRIPTION
Three icon issues are:
1. some icons contain #130000 (Diesel) color which is generally perceived as #000000 (Black)
2. the zoom in/out icons have long been reversed
3. icons were created with 90 DPI rather than the css standard of 96 DPI

This change fixes the first two issues by changing Diesel to Black, and swapping the contents of the zoom icons. The third issue has never been considered and is discussed in https://inkscape.org/release/inkscape-0.92/:

> Release Notes
Inkscape 0.92
-=  Released 2017-01-01  =-
>
> • The default resolution was changed from 90dpi to 96dpi, to match the
CSS standard. For more background information, please see the Wiki
article about handling of units in Inkscape. Inkscape 0.92 will
attempt to identify 'legacy' Inkscape files that need to be
converted. If such a file is detected, the user will be offered
three options:
    1. Set 'viewBox'. Inkscape will add an appropriate 'viewBox' which
will do a global scaling of the document. It will also adjust
the document width and height if necessary.
    2. Scale elements. Inkscape will scale each internal element.
    3. Ignore. Do nothing. This is an appropriate choice for documents
meant for screen display.

I suggest trying option 2. Scale elements. I don't expect any significant difference to svg files.

Can anyone provide comments in terms of the programming and OS environments?