### PR TITLE
Fix loading of splines that falsely defined by closed

### DIFF
--- a/librecad/src/lib/filters/rs_filterdxfrw.cpp
+++ b/librecad/src/lib/filters/rs_filterdxfrw.cpp
@@ -666,6 +666,9 @@ void RS_FilterDXFRW::addSpline(const DRW_Spline* data) {
         for (auto const& vert: data->fitlist)
             spline->addControlPoint({vert->x, vert->y});
     }
+    // ensure that the spline is really closed
+    if (spline->data.closed and !spline->hasWrappedControlPoints())
+        spline->data.closed = 0;
 
     spline->update();
 }


### PR DESCRIPTION
Fixes #863.

[Closed splines](https://pages.mtu.edu/~shene/COURSES/cs3621/NOTES/spline/B-spline/bspline-curve-closed.html) have the `p` identical control points in the beginning and at the end of the control points list (where `p` is the degree of the spline).
Some DXF-files contains splines that are defined as closed but actually are open (an example is attached) that causes the incorrect rendering by the LibreCAD. We should verify the closure of the spline by checking the conrol points.

![screenshot](https://github.com/LibreCAD/LibreCAD/assets/3592925/5a6bfadd-1250-4779-9304-72efb9459a85)

[open-circle-spline-defined-as-closed.dxf.zip](https://github.com/LibreCAD/LibreCAD/files/13403914/open-circle-spline-defined-as-closed.dxf.zip)
