### PR TITLE
Parabola support common tangent

### DIFF
--- a/librecad/src/actions/lc_actiondrawparabola4points.cpp
+++ b/librecad/src/actions/lc_actiondrawparabola4points.cpp
@@ -75,6 +75,7 @@ void LC_ActionDrawParabola4Points::trigger() {
         }
     }
     RS_Vector rz = graphicView->getRelativeZero();
+       // graphicView->SignVerbor(container) : graphicView->
     graphicView->redraw(RS2::RedrawDrawing);
     graphicView->moveRelativeZero(rz);
     drawSnapper();

--- a/librecad/src/actions/rs_actiondrawlinetangent2.cpp
+++ b/librecad/src/actions/rs_actiondrawlinetangent2.cpp
@@ -108,9 +108,9 @@ void RS_ActionDrawLineTangent2::mouseMoveEvent(QMouseEvent* e) {
 	RS_Creation creation(nullptr, nullptr);
     RS_Vector mouse(graphicView->toGraphX(e->x()),
                     graphicView->toGraphY(e->y()));
-    tangent.reset(creation.createTangent2(mouse,
+    tangent = creation.createTangent2(mouse,
                                           circle1,
-                                          circle2));
+                                          circle2);
 	if(!tangent.get()){
         valid=false;
         return;

--- a/librecad/src/actions/rs_actiondrawlinetangent2.cpp
+++ b/librecad/src/actions/rs_actiondrawlinetangent2.cpp
@@ -35,15 +35,22 @@
 #include "rs_preview.h"
 #include "rs_debug.h"
 
-RS_ActionDrawLineTangent2::RS_ActionDrawLineTangent2(
-    RS_EntityContainer& container,
-    RS_GraphicView& graphicView)
-	:RS_PreviewActionInterface("Draw Tangents 2", container, graphicView)
-	,circle1(nullptr)
-	,circle2(nullptr)
-	,valid(false)
+namespace {
+double linePointDist(const RS_Line& line, const RS_Vector& point)
 {
-	actionType=RS2::ActionDrawLineTangent2;
+    return point.distanceTo(line.getNearestPointOnEntity(point));
+}
+}
+RS_ActionDrawLineTangent2::RS_ActionDrawLineTangent2(
+        RS_EntityContainer& container,
+        RS_GraphicView& graphicView)
+    :RS_PreviewActionInterface("Draw Tangents 2", container, graphicView)
+    ,circle1(nullptr)
+    ,circle2(nullptr)
+    ,valid(false)
+{
+    m_tangents.clear();
+    actionType=RS2::ActionDrawLineTangent2;
     setStatus(SetCircle1);
 }
 
@@ -53,15 +60,21 @@ RS_ActionDrawLineTangent2::~RS_ActionDrawLineTangent2() = default;
 void RS_ActionDrawLineTangent2::finish(bool updateTB){
     if(circle1){
         circle1->setHighlighted(false);
-		graphicView->drawEntity(circle1);
+        graphicView->drawEntity(circle1);
+    }
+    if(circle2){
+        circle1->setHighlighted(false);
+        graphicView->drawEntity(circle1);
     }
     RS_PreviewActionInterface::finish(updateTB);
 }
 
 void RS_ActionDrawLineTangent2::trigger() {
     RS_PreviewActionInterface::trigger();
+    if (m_tangents.empty() || m_tangents.front() == nullptr)
+        return;
 
-	RS_Entity* newEntity = new RS_Line(container, *lineData);
+    RS_Entity* newEntity = new RS_Line(container, m_tangents.front()->getData());
 
     if (newEntity) {
         newEntity->setLayerToActive();
@@ -73,8 +86,8 @@ void RS_ActionDrawLineTangent2::trigger() {
             document->startUndoCycle();
             document->addUndoable(newEntity);
             document->endUndoCycle();
-		}
-		clearHighlighted();
+        }
+        clearHighlighted();
 
         setStatus(SetCircle1);
     }
@@ -83,53 +96,53 @@ void RS_ActionDrawLineTangent2::trigger() {
 
 void RS_ActionDrawLineTangent2::clearHighlighted()
 {
-	for(RS_Entity** p: {&circle1, &circle2}){
-		if(*p){
-			(*p)->setHighlighted(false);
-			graphicView->drawEntity(*p);
-			*p=nullptr;
-		}
-	}
+    for(RS_Entity** p: {&circle1, &circle2}){
+        if(*p){
+            (*p)->setHighlighted(false);
+            graphicView->drawEntity(*p);
+            *p=nullptr;
+        }
+    }
 }
 
 void RS_ActionDrawLineTangent2::mouseMoveEvent(QMouseEvent* e) {
-//    RS_DEBUG->print("RS_ActionDrawLineTangent2::mouseMoveEvent begin");
-	e->accept();
-    if(getStatus() != SetCircle2) return;
-	RS_Entity* en= catchEntity(e, circleType, RS2::ResolveAll);
-	if(!en || en==circle1) return;
-	if(circle2){
-		circle2->setHighlighted(false);
-		graphicView->drawEntity(circle2);
-	}
-	circle2=en;
-	circle2->setHighlighted(true);
-	graphicView->drawEntity(circle2);
-	RS_Creation creation(nullptr, nullptr);
-    RS_Vector mouse(graphicView->toGraphX(e->x()),
-                    graphicView->toGraphY(e->y()));
-    tangent = creation.createTangent2(mouse,
-                                          circle1,
-                                          circle2);
-	if(!tangent.get()){
-        valid=false;
-        return;
-    }
-    valid=true;
-	lineData.reset(new RS_LineData(tangent->getData()));
-
+    //    RS_DEBUG->print("RS_ActionDrawLineTangent2::mouseMoveEvent begin");
+    e->accept();
     deletePreview();
-	preview->addEntity(new RS_Line(preview.get(), *lineData));
-    drawPreview();
+
+    switch(getStatus())
+    {
+    case SetCircle1:
+        return;
+    case SetCircle2:
+    {
+        RS_Entity* en= catchEntity(e, circleType, RS2::ResolveAll);
+        if(en == nullptr || en==circle1)
+            return;
+        circle2=en;
+        circle2->setHighlighted(true);
+        graphicView->drawEntity(circle2);
+        m_tangents = RS_Creation{preview.get()}.createTangent2(circle1, circle2);
+        if (m_tangents.empty()) {
+            circle2->setHighlighted(false);
+            graphicView->drawEntity(circle2);
+        } else {
+            preparePreivew(e);
+        }
+    }
+        break;
+    case SelectLine:
+        preparePreivew(e);
+    }
 }
 
 void RS_ActionDrawLineTangent2::mouseReleaseEvent(QMouseEvent* e) {
 
     if (e->button()==Qt::RightButton) {
         deletePreview();
-		init(getStatus()-1);
-		if(getStatus()>=0){
-			clearHighlighted();
+        init(getStatus()-1);
+        if(getStatus()>=0){
+            clearHighlighted();
         }
         return;
     }
@@ -137,33 +150,72 @@ void RS_ActionDrawLineTangent2::mouseReleaseEvent(QMouseEvent* e) {
     case SetCircle1:
     {
         circle1 = catchEntity(e, circleType, RS2::ResolveAll);
-		if(!circle1) return;
+        if(!circle1) return;
         circle1->setHighlighted(true);
-		graphicView->drawEntity(circle1);
+        graphicView->drawEntity(circle1);
         setStatus(getStatus()+1);
     }
         break;
 
     case SetCircle2:
-        if(valid) trigger();
+    {
+        m_tangents = RS_Creation{preview.get()}.createTangent2(circle1, circle2);
+        if (!m_tangents.empty())
+            setStatus(getStatus()+1);
+    }
+        break;
+    case SelectLine:
+    {
+        RS_Vector mouse = snapFree(e);
+        std::sort(m_tangents.begin(), m_tangents.end(), [&mouse](const std::unique_ptr<RS_Line>& lhs,
+                  const std::unique_ptr<RS_Line>& rhs){
+            return linePointDist(*lhs.get(), mouse) < linePointDist(*rhs.get(), mouse);
+        });
+        if (!m_tangents.empty())
+            trigger();
+    }
+        break;
+    default:
         break;
     }
 }
 
+void RS_ActionDrawLineTangent2::preparePreivew(QMouseEvent* e)
+{
+    switch(getStatus()) {
+    case SetCircle2:
+    case SelectLine:
+    {
+        RS_Vector mouse = snapFree(e);
+        deletePreview();
+        for (const auto& line: m_tangents) {
+            auto newLine = std::make_unique<RS_Line>(preview.get(), line->getData());
+            preview->addEntity(newLine.get());
+            newLine.release();
+        }
+        drawPreview();
+    }
+        break;
+    default:
+        break;
+    }
+}
+
+
 void RS_ActionDrawLineTangent2::updateMouseButtonHints() {
-	switch (getStatus()) {
-	case SetCircle1:
-		RS_DIALOGFACTORY->updateMouseWidget(tr("Select first circle or ellipse"),
-											tr("Cancel"));
-		break;
-	case SetCircle2:
-		RS_DIALOGFACTORY->updateMouseWidget(tr("Select second circle or ellipse"),
-											tr("Back"));
-		break;
-	default:
-		RS_DIALOGFACTORY->updateMouseWidget();
-		break;
-	}
+    switch (getStatus()) {
+    case SetCircle1:
+        RS_DIALOGFACTORY->updateMouseWidget(tr("Select first circle or ellipse"),
+                                            tr("Cancel"));
+        break;
+    case SetCircle2:
+        RS_DIALOGFACTORY->updateMouseWidget(tr("Select second circle or ellipse"),
+                                            tr("Back"));
+        break;
+    default:
+        RS_DIALOGFACTORY->updateMouseWidget();
+        break;
+    }
 }
 
 void RS_ActionDrawLineTangent2::updateMouseCursor() {

--- a/librecad/src/actions/rs_actiondrawlinetangent2.cpp
+++ b/librecad/src/actions/rs_actiondrawlinetangent2.cpp
@@ -63,8 +63,8 @@ void RS_ActionDrawLineTangent2::finish(bool updateTB){
         graphicView->drawEntity(circle1);
     }
     if(circle2){
-        circle1->setHighlighted(false);
-        graphicView->drawEntity(circle1);
+        circle2->setHighlighted(false);
+        graphicView->drawEntity(circle2);
     }
     RS_PreviewActionInterface::finish(updateTB);
 }

--- a/librecad/src/actions/rs_actiondrawlinetangent2.cpp
+++ b/librecad/src/actions/rs_actiondrawlinetangent2.cpp
@@ -32,6 +32,7 @@
 #include "rs_graphicview.h"
 #include "rs_creation.h"
 #include "rs_line.h"
+#include "rs_point.h"
 #include "rs_preview.h"
 #include "rs_debug.h"
 
@@ -51,21 +52,18 @@ RS_ActionDrawLineTangent2::RS_ActionDrawLineTangent2(
 {
     m_tangents.clear();
     actionType=RS2::ActionDrawLineTangent2;
-    setStatus(SetCircle1);
+    init(SetCircle1);
 }
 
-RS_ActionDrawLineTangent2::~RS_ActionDrawLineTangent2() = default;
+RS_ActionDrawLineTangent2::~RS_ActionDrawLineTangent2()
+{
+    init(SetCircle1);
+    clearHighlighted();
+}
 
 
 void RS_ActionDrawLineTangent2::finish(bool updateTB){
-    if(circle1){
-        circle1->setHighlighted(false);
-        graphicView->drawEntity(circle1);
-    }
-    if(circle2){
-        circle2->setHighlighted(false);
-        graphicView->drawEntity(circle2);
-    }
+    clearHighlighted();
     RS_PreviewActionInterface::finish(updateTB);
 }
 
@@ -74,9 +72,9 @@ void RS_ActionDrawLineTangent2::trigger() {
     if (m_tangents.empty() || m_tangents.front() == nullptr)
         return;
 
-    RS_Entity* newEntity = new RS_Line(container, m_tangents.front()->getData());
+    RS_Entity* newEntity = new RS_Line{container, m_tangents.front()->getData()};
 
-    if (newEntity) {
+    if (newEntity != nullptr) {
         newEntity->setLayerToActive();
         newEntity->setPenToActive();
         container->addEntity(newEntity);
@@ -87,27 +85,37 @@ void RS_ActionDrawLineTangent2::trigger() {
             document->addUndoable(newEntity);
             document->endUndoCycle();
         }
+        init(SetCircle1);
         clearHighlighted();
-
-        setStatus(SetCircle1);
     }
-    tangent.reset();
 }
 
 void RS_ActionDrawLineTangent2::clearHighlighted()
 {
-    for(RS_Entity** p: {&circle1, &circle2}){
-        if(*p){
-            (*p)->setHighlighted(false);
-            graphicView->drawEntity(*p);
-            *p=nullptr;
+    auto clearHighlight = [this](RS_Entity** pCircle) {
+        if (*pCircle != nullptr) {
+            (*pCircle)->setHighlighted(false);
+            graphicView->drawEntity(*pCircle);
+            *pCircle = nullptr;
         }
+    };
+    switch(getStatus()) {
+    case SetCircle1:
+        if (circle2 == nullptr)
+            clearHighlight(&circle1);
+        [[fallthrough]];
+    case SetCircle2:
+        clearHighlight(&circle2);
+        break;
+    default:
+        break;
     }
 }
 
 void RS_ActionDrawLineTangent2::mouseMoveEvent(QMouseEvent* e) {
     //    RS_DEBUG->print("RS_ActionDrawLineTangent2::mouseMoveEvent begin");
     e->accept();
+    deleteSnapper();
     deletePreview();
 
     switch(getStatus())
@@ -119,6 +127,7 @@ void RS_ActionDrawLineTangent2::mouseMoveEvent(QMouseEvent* e) {
         RS_Entity* en= catchEntity(e, circleType, RS2::ResolveAll);
         if(en == nullptr || en==circle1)
             return;
+        clearHighlighted();
         circle2=en;
         circle2->setHighlighted(true);
         graphicView->drawEntity(circle2);
@@ -140,10 +149,9 @@ void RS_ActionDrawLineTangent2::mouseReleaseEvent(QMouseEvent* e) {
 
     if (e->button()==Qt::RightButton) {
         deletePreview();
-        init(getStatus()-1);
-        if(getStatus()>=0){
-            clearHighlighted();
-        }
+        if (getStatus() != SetCircle1)
+            init(getStatus()-1);
+        clearHighlighted();
         return;
     }
     switch (getStatus()) {
@@ -160,17 +168,18 @@ void RS_ActionDrawLineTangent2::mouseReleaseEvent(QMouseEvent* e) {
     case SetCircle2:
     {
         m_tangents = RS_Creation{preview.get()}.createTangent2(circle1, circle2);
-        if (!m_tangents.empty())
-            setStatus(getStatus()+1);
+        if (!m_tangents.empty()) {
+            if (m_tangents.size() == 1) {
+                trigger();
+            } else {
+                init(getStatus()+1);
+                preparePreivew(e);
+            }
+        }
     }
         break;
     case SelectLine:
     {
-        RS_Vector mouse = snapFree(e);
-        std::sort(m_tangents.begin(), m_tangents.end(), [&mouse](const std::unique_ptr<RS_Line>& lhs,
-                  const std::unique_ptr<RS_Line>& rhs){
-            return linePointDist(*lhs.get(), mouse) < linePointDist(*rhs.get(), mouse);
-        });
         if (!m_tangents.empty())
             trigger();
     }
@@ -187,29 +196,43 @@ void RS_ActionDrawLineTangent2::preparePreivew(QMouseEvent* e)
     case SelectLine:
     {
         RS_Vector mouse = snapFree(e);
+        deleteSnapper();
         deletePreview();
-        for (const auto& line: m_tangents) {
-            auto newLine = std::make_unique<RS_Line>(preview.get(), line->getData());
-            preview->addEntity(newLine.get());
-            newLine.release();
+        std::sort(m_tangents.begin(), m_tangents.end(), [&mouse](
+                  const std::unique_ptr<RS_Line>& lhs,
+                  const std::unique_ptr<RS_Line>& rhs) {
+            return linePointDist(*lhs, mouse) < linePointDist(*rhs, mouse);
+        });
+        for(const auto& line: m_tangents){
+            auto newEndpoint = new RS_Point{preview.get(), line->getData().startpoint};
+            preview->addEntity(newEndpoint);
+            newEndpoint = new RS_Point{preview.get(), line->getData().endpoint};
+            preview->addEntity(newEndpoint);
         }
+        auto newLine = new RS_Line{preview.get(), m_tangents.front()->getData()};
+        preview->addEntity(newLine);
         drawPreview();
     }
         break;
     default:
         break;
     }
+    deleteSnapper();
 }
 
 
 void RS_ActionDrawLineTangent2::updateMouseButtonHints() {
     switch (getStatus()) {
     case SetCircle1:
-        RS_DIALOGFACTORY->updateMouseWidget(tr("Select first circle or ellipse"),
+        RS_DIALOGFACTORY->updateMouseWidget(tr("Select first circle/ellipse/parabola"),
                                             tr("Cancel"));
         break;
     case SetCircle2:
-        RS_DIALOGFACTORY->updateMouseWidget(tr("Select second circle or ellipse"),
+        RS_DIALOGFACTORY->updateMouseWidget(tr("Select second circle/ellipse/parabola"),
+                                            tr("Back"));
+        break;
+    case SelectLine:
+        RS_DIALOGFACTORY->updateMouseWidget(tr("Select the tangent line closest to cursor"),
                                             tr("Back"));
         break;
     default:

--- a/librecad/src/actions/rs_actiondrawlinetangent2.h
+++ b/librecad/src/actions/rs_actiondrawlinetangent2.h
@@ -70,7 +70,7 @@ private:
     bool valid = false;
 
     //list of entity types supported by current action
-    const EntityTypeList circleType = EntityTypeList{RS2::EntityArc, RS2::EntityCircle, RS2::EntityEllipse};
+    const EntityTypeList circleType = EntityTypeList{RS2::EntityArc, RS2::EntityCircle, RS2::EntityEllipse, RS2::EntityParabola};
 };
 
 #endif

--- a/librecad/src/actions/rs_actiondrawlinetangent2.h
+++ b/librecad/src/actions/rs_actiondrawlinetangent2.h
@@ -42,7 +42,8 @@ class RS_ActionDrawLineTangent2 : public RS_PreviewActionInterface {
 private:
     enum Status {
         SetCircle1,     /**< Choose the startpoint. */
-        SetCircle2      /**< Choose the circle / arc. */
+        SetCircle2,     /**< Choose the circle / arc. */
+        SelectLine      /**<Choose the tangent*/
     };
 
 public:
@@ -51,18 +52,20 @@ public:
 	~RS_ActionDrawLineTangent2() override;
 
 	void trigger() override;
-	void mouseMoveEvent(QMouseEvent* e) override;
+    void mouseMoveEvent(QMouseEvent* e) override;
 	void mouseReleaseEvent(QMouseEvent* e) override;
 	void updateMouseButtonHints() override;
 	void finish(bool updateTB) override;
 
-	void updateMouseCursor() override;
+    void updateMouseCursor();
 
 private:
+    void preparePreivew(QMouseEvent* e);
 	void clearHighlighted();
     /** Closest tangent. */
     std::unique_ptr<RS_Line> tangent;
-	std::unique_ptr<RS_LineData> lineData;
+    std::vector<std::unique_ptr<RS_Line>> m_tangents;
+    std::unique_ptr<RS_LineData> lineData;
 	/** 1st chosen entity */
     RS_Entity* circle1 = nullptr;
     /** 2nd chosen entity */

--- a/librecad/src/actions/rs_actiondrawlinetangent2.h
+++ b/librecad/src/actions/rs_actiondrawlinetangent2.h
@@ -63,9 +63,7 @@ private:
     void preparePreivew(QMouseEvent* e);
 	void clearHighlighted();
     /** Closest tangent. */
-    std::unique_ptr<RS_Line> tangent;
     std::vector<std::unique_ptr<RS_Line>> m_tangents;
-    std::unique_ptr<RS_LineData> lineData;
 	/** 1st chosen entity */
     RS_Entity* circle1 = nullptr;
     /** 2nd chosen entity */

--- a/librecad/src/actions/rs_actiondrawlinetangent2.h
+++ b/librecad/src/actions/rs_actiondrawlinetangent2.h
@@ -57,7 +57,7 @@ public:
 	void updateMouseButtonHints() override;
 	void finish(bool updateTB) override;
 
-    void updateMouseCursor();
+    void updateMouseCursor() override;
 
 private:
     void preparePreivew(QMouseEvent* e);

--- a/librecad/src/actions/rs_actionselectwindow.cpp
+++ b/librecad/src/actions/rs_actionselectwindow.cpp
@@ -36,8 +36,8 @@
 #include "rs_debug.h"
 
 struct RS_ActionSelectWindow::Points {
-	RS_Vector v1;
-	RS_Vector v2;
+    RS_Vector v1;
+    RS_Vector v2;
 };
 
 
@@ -47,28 +47,28 @@ struct RS_ActionSelectWindow::Points {
  * @param select true: select window. false: deselect window
  */
 RS_ActionSelectWindow::RS_ActionSelectWindow(RS_EntityContainer& container,
-        RS_GraphicView& graphicView,
-        bool select)
-        : RS_PreviewActionInterface("Select Window",
-							container, graphicView)
+                                             RS_GraphicView& graphicView,
+                                             bool select)
+    : RS_PreviewActionInterface("Select Window",
+                                container, graphicView)
     , pPoints(std::make_unique<Points>())
     , select(select)
 {
-	actionType=RS2::ActionSelectWindow;
+    actionType=RS2::ActionSelectWindow;
 }
 
 RS_ActionSelectWindow::RS_ActionSelectWindow(
-    enum RS2::EntityType typeToSelect,
-    RS_EntityContainer& container,
+        enum RS2::EntityType typeToSelect,
+        RS_EntityContainer& container,
         RS_GraphicView& graphicView,
         bool select)
-        : RS_PreviewActionInterface("Select Window",
-							container, graphicView)
-        , select(select),
-    typeToSelect(typeToSelect)
+    : RS_PreviewActionInterface("Select Window",
+                                container, graphicView)
     , pPoints(std::make_unique<Points>())
+    , typeToSelect(typeToSelect)
+    , select(select)
 {
-	actionType=RS2::ActionSelectWindow;
+    actionType=RS2::ActionSelectWindow;
 }
 
 RS_ActionSelectWindow::~RS_ActionSelectWindow() = default;
@@ -86,13 +86,13 @@ void RS_ActionSelectWindow::init(int status) {
 void RS_ActionSelectWindow::trigger() {
     RS_PreviewActionInterface::trigger();
 
-	if (pPoints->v1.valid && pPoints->v2.valid) {
-		if (graphicView->toGuiDX(pPoints->v1.distanceTo(pPoints->v2))>10) {
+    if (pPoints->v1.valid && pPoints->v2.valid) {
+        if (graphicView->toGuiDX(pPoints->v1.distanceTo(pPoints->v2))>10) {
 
-			bool cross = (pPoints->v1.x>pPoints->v2.x);
+            bool cross = (pPoints->v1.x>pPoints->v2.x);
 
             RS_Selection s(*container, graphicView);
-			s.selectWindow(typeToSelect, pPoints->v1, pPoints->v2, select, cross);
+            s.selectWindow(typeToSelect, pPoints->v1, pPoints->v2, select, cross);
 
             RS_DIALOGFACTORY->updateSelectionWidget(container->countSelected(),container->totalSelectedLength());
 
@@ -106,29 +106,29 @@ void RS_ActionSelectWindow::trigger() {
 void RS_ActionSelectWindow::mouseMoveEvent(QMouseEvent* e) {
     snapFree(e);
     drawSnapper();
-	if (getStatus()==SetCorner2 && pPoints->v1.valid) {
-		pPoints->v2 = snapFree(e);
+    if (getStatus()==SetCorner2 && pPoints->v1.valid) {
+        pPoints->v2 = snapFree(e);
         deletePreview();
-		RS_OverlayBox* ob=new RS_OverlayBox(preview.get(), RS_OverlayBoxData(pPoints->v1, pPoints->v2));
+        RS_OverlayBox* ob=new RS_OverlayBox(preview.get(), RS_OverlayBoxData(pPoints->v1, pPoints->v2));
         preview->addEntity(ob);
 
         //RLZ: not needed overlay have contour
         /*                RS_Pen pen(RS_Color(218,105,24), RS2::Width00, RS2::SolidLine);
 
                 // TODO change to a rs_box sort of entity
-				RS_Line* e=new RS_Line(preview, RS_LineData(RS_Vector(v1->x, v1->y),  RS_Vector(v2->x, v1->y)));
+                RS_Line* e=new RS_Line(preview, RS_LineData(RS_Vector(v1->x, v1->y),  RS_Vector(v2->x, v1->y)));
                 e->setPen(pen);
         preview->addEntity(e);
 
-				e=new RS_Line(preview, RS_LineData(RS_Vector(v2->x, v1->y),  RS_Vector(v2->x, v2->y)));
+                e=new RS_Line(preview, RS_LineData(RS_Vector(v2->x, v1->y),  RS_Vector(v2->x, v2->y)));
                 e->setPen(pen);
         preview->addEntity(e);
 
-				e=new RS_Line(preview, RS_LineData(RS_Vector(v2->x, v2->y),  RS_Vector(v1->x, v2->y)));
+                e=new RS_Line(preview, RS_LineData(RS_Vector(v2->x, v2->y),  RS_Vector(v1->x, v2->y)));
                 e->setPen(pen);
         preview->addEntity(e);
 
-				e=new RS_Line(preview, RS_LineData(RS_Vector(v1->x, v2->y),  RS_Vector(v1->x, v1->y)));
+                e=new RS_Line(preview, RS_LineData(RS_Vector(v1->x, v2->y),  RS_Vector(v1->x, v1->y)));
                 e->setPen(pen);
         preview->addEntity(e);*/
 
@@ -142,7 +142,7 @@ void RS_ActionSelectWindow::mousePressEvent(QMouseEvent* e) {
     if (e->button()==Qt::LeftButton) {
         switch (getStatus()) {
         case SetCorner1:
-			pPoints->v1 = snapFree(e);
+            pPoints->v1 = snapFree(e);
             setStatus(SetCorner2);
             break;
 
@@ -152,7 +152,7 @@ void RS_ActionSelectWindow::mousePressEvent(QMouseEvent* e) {
     }
 
     RS_DEBUG->print("RS_ActionSelectWindow::mousePressEvent(): %f %f",
-					pPoints->v1.x, pPoints->v1.y);
+                    pPoints->v1.x, pPoints->v1.y);
 }
 
 
@@ -162,7 +162,7 @@ void RS_ActionSelectWindow::mouseReleaseEvent(QMouseEvent* e) {
 
     if (e->button()==Qt::LeftButton) {
         if (getStatus()==SetCorner2) {
-			pPoints->v2 = snapFree(e);
+            pPoints->v2 = snapFree(e);
             trigger();
         }
     } else if (e->button()==Qt::RightButton) {

--- a/librecad/src/lib/creation/rs_creation.cpp
+++ b/librecad/src/lib/creation/rs_creation.cpp
@@ -29,6 +29,8 @@
 #include <QString>
 #include <QFileInfo>
 
+#include "lc_parabola.h"
+#include "lc_quadratic.h"
 #include "rs_arc.h"
 #include "rs_block.h"
 #include "rs_constructionline.h"
@@ -50,6 +52,43 @@
 #include "lc_undosection.h"
 #include "lc_splinepoints.h"
 
+namespace {
+
+/**
+ * @brief isArc whether the entity supports tangent
+ * @param entity
+ * @return  true if the entity can have tangent (RS_Line is not considered as an arc here).
+ */
+bool isArc(const RS_Entity& entity){
+    if (entity.isArc())
+        return true;
+    switch (entity.rtti()){
+    case RS2::EntityParabola:
+        return true;
+    default:
+        return false;
+    }
+}
+
+/**
+     * @brief fromLineCoordinate create a line from line coordinates (x, y, 1)
+     * @param line the line coordinates, (x, y, 1), the last coordinate is always one, and the z-component of the input
+     * vector is not used
+     * @return the same line in RS_LineData
+     */
+RS_LineData fromLineCoordinate(const RS_Vector& line)
+{
+    RS_Vector start = RS_Vector{line}.rotate(-M_PI/4.);
+    RS_Vector stop = RS_Vector{line}.rotate(M_PI/4.);
+    return {start/(-start.dotP(line)), stop/(-stop.dotP(line))};
+}
+
+// point to a line distance
+double getPointLineDist(const RS_Vector& point, const RS_Line& line) {
+    return point.distanceTo(line.getNearestPointOnEntity(point));
+}
+}
+
 /**
  * Default constructor.
  *
@@ -58,9 +97,9 @@
  *        it can also be a polyline, text, ...
  */
 RS_Creation::RS_Creation(RS_EntityContainer* container,
-						 RS_GraphicView* graphicView,
-						 bool handleUndo):
-	container(container)
+                         RS_GraphicView* graphicView,
+                         bool handleUndo):
+    container(container)
   ,graphic(container?container->getGraphic():nullptr)
   ,document(container?container->getDocument():nullptr)
   ,graphicView(graphicView)
@@ -83,15 +122,15 @@ RS_Creation::RS_Creation(RS_EntityContainer* container,
 RS_Entity* RS_Creation::createParallelThrough(const RS_Vector& coord,
                                               int number,
                                               RS_Entity* e) {
-	if (!e) {
-		return nullptr;
+    if (!e) {
+        return nullptr;
     }
 
     double dist;
 
     if (e->rtti()==RS2::EntityLine) {
         RS_Line* l = (RS_Line*)e;
-		RS_ConstructionLine cl(nullptr,
+        RS_ConstructionLine cl(nullptr,
                                RS_ConstructionLineData(l->getStartpoint(),
                                                        l->getEndpoint()));
         dist = cl.getDistanceToPoint(coord);
@@ -102,7 +141,7 @@ RS_Entity* RS_Creation::createParallelThrough(const RS_Vector& coord,
     if (dist<RS_MAXDOUBLE) {
         return createParallel(coord, dist, number, e);
     } else {
-		return nullptr;
+        return nullptr;
     }
 }
 
@@ -126,8 +165,8 @@ RS_Entity* RS_Creation::createParallelThrough(const RS_Vector& coord,
 RS_Entity* RS_Creation::createParallel(const RS_Vector& coord,
                                        double distance, int number,
                                        RS_Entity* e) {
-	if (!e) {
-		return nullptr;
+    if (!e) {
+        return nullptr;
     }
 
     switch (e->rtti()) {
@@ -151,7 +190,7 @@ RS_Entity* RS_Creation::createParallel(const RS_Vector& coord,
         break;
     }
 
-	return nullptr;
+    return nullptr;
 }
 
 /**
@@ -172,30 +211,30 @@ RS_Line* RS_Creation::createParallelLine(const RS_Vector& coord,
                                          double distance, int number,
                                          RS_Line* e) {
 
-	if (!e) {
-		return nullptr;
+    if (!e) {
+        return nullptr;
     }
 
-	double ang = e->getAngle1() + M_PI_2;
+    double ang = e->getAngle1() + M_PI_2;
     RS_LineData parallelData;
-	RS_Line* ret = nullptr;
+    RS_Line* ret = nullptr;
 
     LC_UndoSection undo( document, handleUndo);
     for (int num=1; num<=number; ++num) {
 
         // calculate 1st parallel:
-		RS_Vector p1 = RS_Vector::polar(distance*num, ang);
+        RS_Vector p1 = RS_Vector::polar(distance*num, ang);
         p1 += e->getStartpoint();
-		RS_Vector p2 = RS_Vector::polar(distance*num, ang);
+        RS_Vector p2 = RS_Vector::polar(distance*num, ang);
         p2 += e->getEndpoint();
-		RS_Line parallel1{p1, p2};
+        RS_Line parallel1{p1, p2};
 
         // calculate 2nd parallel:
         p1.setPolar(distance*num, ang+M_PI);
         p1 += e->getStartpoint();
         p2.setPolar(distance*num, ang+M_PI);
         p2 += e->getEndpoint();
-		RS_Line parallel2{p1, p2};
+        RS_Line parallel2{p1, p2};
 
         double dist1 = parallel1.getDistanceToPoint(coord);
         double dist2 = parallel2.getDistanceToPoint(coord);
@@ -208,11 +247,11 @@ RS_Line* RS_Creation::createParallelLine(const RS_Vector& coord,
                 parallelData = parallel2.getData();
             }
 
-			RS_Line* newLine = new RS_Line{container, parallelData};
-			if (!ret) {
-				ret = newLine;
-			}
-			setEntity(newLine);
+            RS_Line* newLine = new RS_Line{container, parallelData};
+            if (!ret) {
+                ret = newLine;
+            }
+            setEntity(newLine);
         }
     }
 
@@ -239,12 +278,12 @@ RS_Arc* RS_Creation::createParallelArc(const RS_Vector& coord,
                                        double distance, int number,
                                        RS_Arc* e) {
 
-	if (!e) {
-		return nullptr;
+    if (!e) {
+        return nullptr;
     }
 
     RS_ArcData parallelData;
-	RS_Arc* ret = nullptr;
+    RS_Arc* ret = nullptr;
 
     bool inside = (e->getCenter().distanceTo(coord) < e->getRadius());
 
@@ -256,7 +295,7 @@ RS_Arc* RS_Creation::createParallelArc(const RS_Vector& coord,
 
         // calculate parallel:
         bool ok = true;
-		RS_Arc parallel1(nullptr, e->getData());
+        RS_Arc parallel1(nullptr, e->getData());
         parallel1.setRadius(e->getRadius() + distance*num);
         if (parallel1.getRadius()<0.0) {
             parallel1.setRadius(RS_MAXDOUBLE);
@@ -264,7 +303,7 @@ RS_Arc* RS_Creation::createParallelArc(const RS_Vector& coord,
         }
 
         // calculate 2nd parallel:
-		//RS_Arc parallel2(nullptr, e->getData());
+        //RS_Arc parallel2(nullptr, e->getData());
         //parallel2.setRadius(e->getRadius()+distance*num);
 
         //double dist1 = parallel1.getDistanceToPoint(coord);
@@ -272,7 +311,7 @@ RS_Arc* RS_Creation::createParallelArc(const RS_Vector& coord,
         //double minDist = min(dist1, dist2);
 
         //if (minDist<RS_MAXDOUBLE) {
-		if (ok) {
+        if (ok) {
             //if (dist1<dist2) {
             parallelData = parallel1.getData();
             //} else {
@@ -281,10 +320,10 @@ RS_Arc* RS_Creation::createParallelArc(const RS_Vector& coord,
 
             LC_UndoSection undo( document, handleUndo);
             RS_Arc* newArc = new RS_Arc(container, parallelData);
-			if (!ret) {
-				ret = newArc;
-			}
-			setEntity(newArc);
+            if (!ret) {
+                ret = newArc;
+            }
+            setEntity(newArc);
         }
     }
 
@@ -311,12 +350,12 @@ RS_Circle* RS_Creation::createParallelCircle(const RS_Vector& coord,
                                              double distance, int number,
                                              RS_Circle* e) {
 
-	if (!e) {
-		return nullptr;
+    if (!e) {
+        return nullptr;
     }
 
     RS_CircleData parallelData;
-	RS_Circle* ret = nullptr;
+    RS_Circle* ret = nullptr;
 
     bool inside = (e->getCenter().distanceTo(coord) < e->getRadius());
 
@@ -328,7 +367,7 @@ RS_Circle* RS_Creation::createParallelCircle(const RS_Vector& coord,
 
         // calculate parallel:
         bool ok = true;
-		RS_Circle parallel1(nullptr, e->getData());
+        RS_Circle parallel1(nullptr, e->getData());
         parallel1.setRadius(e->getRadius() + distance*num);
         if (parallel1.getRadius()<0.0) {
             parallel1.setRadius(RS_MAXDOUBLE);
@@ -336,7 +375,7 @@ RS_Circle* RS_Creation::createParallelCircle(const RS_Vector& coord,
         }
 
         // calculate 2nd parallel:
-		//RS_Circle parallel2(nullptr, e->getData());
+        //RS_Circle parallel2(nullptr, e->getData());
         //parallel2.setRadius(e->getRadius()+distance*num);
 
         //double dist1 = parallel1.getDistanceToPoint(coord);
@@ -344,7 +383,7 @@ RS_Circle* RS_Creation::createParallelCircle(const RS_Vector& coord,
         //double minDist = min(dist1, dist2);
 
         //if (minDist<RS_MAXDOUBLE) {
-		if (ok) {
+        if (ok) {
             //if (dist1<dist2) {
             parallelData = parallel1.getData();
             //} else {
@@ -353,10 +392,10 @@ RS_Circle* RS_Creation::createParallelCircle(const RS_Vector& coord,
 
             LC_UndoSection undo( document, handleUndo);
             RS_Circle* newCircle = new RS_Circle(container, parallelData);
-			if (!ret) {
-				ret = newCircle;
-			}
-			setEntity(newCircle);
+            if (!ret) {
+                ret = newCircle;
+            }
+            setEntity(newCircle);
         }
     }
     return ret;
@@ -377,24 +416,24 @@ RS_Circle* RS_Creation::createParallelCircle(const RS_Vector& coord,
  *    parallel has been created.
  */
 LC_SplinePoints* RS_Creation::createParallelSplinePoints(const RS_Vector& coord,
-	double distance, int number, LC_SplinePoints* e)
+                                                         double distance, int number, LC_SplinePoints* e)
 {
-	if(!e) return nullptr;
+    if(!e) return nullptr;
 
-	LC_SplinePoints *psp, *ret = nullptr;
+    LC_SplinePoints *psp, *ret = nullptr;
 
     LC_UndoSection undo( document, handleUndo);
     for(int i = 1; i <= number; ++i)
-	{
-		psp = (LC_SplinePoints*)e->clone();
-		psp->offset(coord, i*distance);
+    {
+        psp = (LC_SplinePoints*)e->clone();
+        psp->offset(coord, i*distance);
 
-		psp->setParent(container);
-		if(!ret) ret = psp;
-		setEntity(psp);
-	}
+        psp->setParent(container);
+        if(!ret) ret = psp;
+        setEntity(psp);
+    }
 
-	return ret;
+    return ret;
 }
 
 
@@ -421,26 +460,26 @@ RS_Line* RS_Creation::createBisector(const RS_Vector& coord1,
                                      RS_Line* l2) {
 
     // check given entities:
-	if (!(l1 && l2))
-		return nullptr;
-	if (!(l1->rtti()==RS2::EntityLine && l2->rtti()==RS2::EntityLine))
-		return nullptr;
+    if (!(l1 && l2))
+        return nullptr;
+    if (!(l1->rtti()==RS2::EntityLine && l2->rtti()==RS2::EntityLine))
+        return nullptr;
 
     // intersection between entities:
-	RS_VectorSolutions const& sol =
-			RS_Information::getIntersection(l1, l2, false);
+    RS_VectorSolutions const& sol =
+            RS_Information::getIntersection(l1, l2, false);
     RS_Vector inters = sol.get(0);
-	if (!inters.valid) {
-		return nullptr;
+    if (!inters.valid) {
+        return nullptr;
     }
 
     double angle1 = inters.angleTo(l1->getNearestPointOnEntity(coord1));
     double angle2 = inters.angleTo(l2->getNearestPointOnEntity(coord2));
     double angleDiff = RS_Math::getAngleDifference(angle1, angle2);
-	if (angleDiff > M_PI) {
-		angleDiff = angleDiff - 2.*M_PI;
+    if (angleDiff > M_PI) {
+        angleDiff = angleDiff - 2.*M_PI;
     }
-	RS_Line* ret = nullptr;
+    RS_Line* ret = nullptr;
 
     LC_UndoSection undo( document, handleUndo);
     for (int n=1; n <= num; ++n) {
@@ -448,11 +487,11 @@ RS_Line* RS_Creation::createBisector(const RS_Vector& coord1,
         double angle = angle1 +
                 (angleDiff / (num+1) * n);
 
-		RS_Vector const& v = RS_Vector::polar(length, angle);
+        RS_Vector const& v = RS_Vector::polar(length, angle);
 
-		RS_Line* newLine = new RS_Line{container, inters, inters + v};
-		if (!ret) ret = newLine;
-		setEntity(newLine);
+        RS_Line* newLine = new RS_Line{container, inters, inters + v};
+        if (!ret) ret = newLine;
+        setEntity(newLine);
     }
 
     return ret;
@@ -469,17 +508,17 @@ RS_Line* RS_Creation::createBisector(const RS_Vector& coord1,
 RS_Line* RS_Creation::createLineOrthTan(const RS_Vector& coord,
                                         RS_Line* normal,
                                         RS_Entity* circle) {
-	RS_Line* ret = nullptr;
+    RS_Line* ret = nullptr;
 
     // check given entities:
-	if (!(circle && normal))
-		return ret;
+    if (!(circle && normal))
+        return ret;
     if (!(circle->isArc() || circle->rtti() == RS2::EntityParabola))
-		return ret;
+        return ret;
     //if( normal->getLength()<RS_TOLERANCE) return ret;//line too short
-	RS_Vector const& t0 = circle->getNearestOrthTan(coord,*normal,false);
+    RS_Vector const& t0 = circle->getNearestOrthTan(coord,*normal,false);
     if(!t0.valid) return ret;
-	RS_Vector const& vp=normal->getNearestPointOnEntity(t0, false);
+    RS_Vector const& vp=normal->getNearestPointOnEntity(t0, false);
     LC_UndoSection undo( document, handleUndo);
     ret = new RS_Line{container, vp, t0};
     ret->setLayerToActive();
@@ -500,33 +539,33 @@ RS_Line* RS_Creation::createLineOrthTan(const RS_Vector& coord,
 RS_Line* RS_Creation::createTangent1(const RS_Vector& coord,
                                      const RS_Vector& point,
                                      RS_Entity* circle) {
-	RS_Line* ret = nullptr;
+    RS_Line* ret = nullptr;
     //RS_Vector circleCenter;
 
     // check given entities:
-	if (!(circle && point.valid)) return nullptr;
- //    if (!(circle->isArc() || circle->rtti()==RS2::EntitySplinePoints || circle->rtti() == RS2::EntityParabola)){
+    if (!(circle && point.valid)) return nullptr;
+    //    if (!(circle->isArc() || circle->rtti()==RS2::EntitySplinePoints || circle->rtti() == RS2::EntityParabola)){
     // 	return nullptr;
     // }
 
     // the two tangent points:
     RS_VectorSolutions sol=circle->getTangentPoint(point);
 
-	if (!sol.getNumber())
-		return nullptr;
-	RS_Vector const vp2{sol.getClosest(coord)};
+    if (!sol.getNumber())
+        return nullptr;
+    RS_Vector const vp2{sol.getClosest(coord)};
     RS_LineData d;
     if( (vp2-point).squared() > RS_TOLERANCE2 ) {
-		d={vp2, point};
+        d={vp2, point};
     }else{//the given point is a tangential point
-		d={point+circle->getTangentDirection(point), point};
+        d={point+circle->getTangentDirection(point), point};
     }
 
 
     // create the closest tangent:
     LC_UndoSection undo( document, handleUndo);
     ret = new RS_Line{container, d};
-	setEntity(ret);
+    setEntity(ret);
 
     return ret;
 }
@@ -542,175 +581,66 @@ RS_Line* RS_Creation::createTangent1(const RS_Vector& coord,
 * @param circle2 2nd circle or arc entity.
 */
 std::unique_ptr<RS_Line> RS_Creation::createTangent2(const RS_Vector& coord,
-                                     RS_Entity* circle1,
-                                     RS_Entity* circle2) {
-    std::unique_ptr<RS_Line> ret;
-    RS_Vector circleCenter1;
-    RS_Vector circleCenter2;
-    double circleRadius1 = 0.0;
-    double circleRadius2 = 0.0;
-
+                                                     RS_Entity* circle1,
+                                                     RS_Entity* circle2) {
     // check given entities:
-	if(! (circle1 && circle2))
-        return {};
-	if( !(circle1->isArc() && circle2->isArc()))
+    if(! (circle1 && circle2))
         return {};
 
-    std::vector<std::unique_ptr<RS_Line>> poss;
-    RS_LineData d;
-    if( circle1->rtti() == RS2::EntityEllipse) {
-        std::swap(circle1,circle2);//move Ellipse to the second place
-    }
-    circleCenter1=circle1->getCenter();
-    circleRadius1=circle1->getRadius();
-    circleCenter2=circle2->getCenter();
-    circleRadius2=circle2->getRadius();
-    if(circle2->rtti() != RS2::EntityEllipse) {
-        //no ellipse
+    if( !(isArc(*circle1) && isArc(*circle2)))
+        return {};
 
-        // create all possible tangents:
-
-        double angle1 = circleCenter1.angleTo(circleCenter2);
-        double dist1 = circleCenter1.distanceTo(circleCenter2);
-
-        if (dist1>1.0e-6) {
-            // outer tangents:
-            double dist2 = circleRadius2 - circleRadius1;
-            if (dist1>dist2) {
-                double angle2 = asin(dist2/dist1);
-				double angt1 = angle1 + angle2 + M_PI_2;
-				double angt2 = angle1 - angle2 - M_PI_2;
-				RS_Vector offs1 = RS_Vector::polar(circleRadius1, angt1);
-				RS_Vector offs2 = RS_Vector::polar(circleRadius2, angt1);
-
-                poss.emplace_back(std::make_unique<RS_Line>(circleCenter1 + offs1,
-                                                      circleCenter2 + offs2));
-
-                offs1.setPolar(circleRadius1, angt2);
-                offs2.setPolar(circleRadius2, angt2);
-
-                poss.emplace_back(std::make_unique<RS_Line>(circleCenter1 + offs1,
-                                                      circleCenter2 + offs2));
-            }
-
-            // inner tangents:
-            double dist3 = circleRadius2 + circleRadius1;
-            if (dist1>dist3) {
-                double angle3 = asin(dist3/dist1);
-				double angt3 = angle1 + angle3 + M_PI_2;
-				double angt4 = angle1 - angle3 - M_PI_2;
-                RS_Vector offs1;
-                RS_Vector offs2;
-
-                offs1.setPolar(circleRadius1, angt3);
-                offs2.setPolar(circleRadius2, angt3);
-                poss.emplace_back(std::make_unique<RS_Line>(circleCenter1 - offs1,
-                                                      circleCenter2 + offs2));
-
-
-                offs1.setPolar(circleRadius1, angt4);
-                offs2.setPolar(circleRadius2, angt4);
-
-                poss.emplace_back(std::make_unique<RS_Line>(circleCenter1 - offs1,
-                                                      circleCenter2 + offs2));
-            }
-
-        }
-    }else{
-        //circle2 is Ellipse
-		std::unique_ptr<RS_Ellipse> e2((RS_Ellipse*)circle2->clone());
-//        RS_Ellipse* e2=new RS_Ellipse(nullptr,RS_EllipseData(RS_Vector(4.,1.),RS_Vector(2.,0.),0.5,0.,0.,false));
-//        RS_Ellipse  e3(nullptr,RS_EllipseData(RS_Vector(4.,1.),RS_Vector(2.,0.),0.5,0.,0.,false));
-//        RS_Ellipse* circle1=new RS_Ellipse(nullptr,RS_EllipseData(RS_Vector(0.,0.),RS_Vector(1.,0.),1.,0.,0.,false));
-        RS_Vector m0(circle1->getCenter());
-//        std::cout<<"translation: "<<-m0<<std::endl;
-        e2->move(-m0); //circle1 centered at origin
-
-        double a,b;
-        double a0(0.);
-        if(circle1->rtti() != RS2::EntityEllipse){//circle1 is either arc or circle
-            a=fabs(circle1->getRadius());
-            b=a;
-			if(fabs(a)<RS_TOLERANCE) return nullptr;
-        }else{//circle1 is ellipse
-            RS_Ellipse* e1=static_cast<RS_Ellipse*>(circle1);
-            a0=e1->getAngle();
-//            std::cout<<"rotation: "<<-a0<<std::endl;
-            e2->rotate(-a0);//e1 major axis along x-axis
-            a=e1->getMajorRadius();
-            b=e1->getRatio()*a;
-			if(fabs(a)<RS_TOLERANCE || fabs(b)<RS_TOLERANCE) return nullptr;
-        }
-        RS_Vector factor1(1./a,1./b);
-//        std::cout<<"scaling: factor1="<<factor1<<std::endl;
-        e2->scale(RS_Vector(0.,0.),factor1);//circle1 is a unit circle
-        factor1.set(a,b);
-        double a2(e2->getAngle());
-//        std::cout<<"rotation: a2="<<-a2<<std::endl;
-        e2->rotate(-a2); //ellipse2 with major axis in x-axis direction
-        a=e2->getMajorP().x;
-        b=a*e2->getRatio();
-        RS_Vector v(e2->getCenter());
-//        std::cout<<"Center: (x,y)="<<v<<std::endl;
-
-
-        std::vector<double> m(0,0.);
-        m.push_back(1./(a*a)); //ma000
-        m.push_back(1./(b*b)); //ma000
-        m.push_back(v.y*v.y-1.); //ma100
-        m.push_back(v.x*v.y); //ma101
-        m.push_back(v.x*v.x-1.); //ma111
-        m.push_back(2.*a*b*v.y); //mb10
-        m.push_back(2.*a*b*v.x); //mb11
-        m.push_back(a*a*b*b); //mc1
-
-		auto vs0=RS_Math::simultaneousQuadraticSolver(m); //to hold solutions
-		if (vs0.getNumber()<1) return nullptr;
-//        for(size_t i=0;i<vs0.getNumber();i++){
-		for(RS_Vector vpec: vs0){
-			RS_Vector vpe2(e2->getCenter()+
-						   RS_Vector(vpec.y/e2->getRatio(),vpec.x*e2->getRatio()));
-            vpec.x *= -1.;//direction vector of tangent
-            RS_Vector vpe1(vpe2 - vpec*(RS_Vector::dotP(vpec,vpe2)/vpec.squared()));
-//            std::cout<<"vpe1.squared()="<<vpe1.squared()<<std::endl;
-            auto l=std::make_unique<RS_Line>(vpe1, vpe2);
-            l->rotate(a2);
-            l->scale(factor1);
-            l->rotate(a0);
-            l->move(m0);
-            poss.push_back(std::move(l));
-
-        }
-        //debugging
-
-    }
-    // find closest tangent:
-	if(poss.size()<1) return nullptr;
-    double minDist = RS_MAXDOUBLE;
-    double dist;
-    int idx = -1;
-	for (size_t i=0; i<poss.size(); ++i) {
-		if (poss[i]) {
-            poss[i]->getNearestPointOnEntity(coord,false,&dist);
-//        std::cout<<poss.size()<<": i="<<i<<" dist="<<dist<<"\n";
-            if (dist<minDist) {
-                minDist = dist;
-                idx = i;
-            }
-        }
-    }
-//idx=static_cast<int>(poss.size()*(random()/(double(1.0)+RAND_MAX)));
-    if (idx!=-1) {
-        RS_LineData d = poss[idx]->getData();
-
-        LC_UndoSection undo( document, handleUndo);
-        ret = std::make_unique<RS_Line>(container, d);
-        setEntity(ret.get());
-    } else {
-        ret.reset();
-    }
-
-    return ret;
+    // Find common tangent lines in line coordinates, i.e. using dual curves
+    // A common tangent line is an intersection of the dual curves
+    auto sol = LC_Quadratic::getIntersection(circle1->getQuadratic().getDualCurve(),
+                                             circle2->getQuadratic().getDualCurve());
+    if (sol.empty())
+        return {};
+    // find the tangent point for a line in line coordinates
+    auto getTangentPoint = [](const RS_Entity& circle, const RS_Vector& line) -> RS_Vector {
+        auto rsLine = std::make_unique<RS_Line>(nullptr, fromLineCoordinate(line));
+        auto tangentPs = circle.getTangentPoint(rsLine->getStartpoint());
+        if (tangentPs.empty())
+            return {};
+        RS_Vector vp = *std::min_element(tangentPs.begin(), tangentPs.end(), [&rsLine](const RS_Vector& lhs, const RS_Vector& rhs)
+        {
+            double dist0 = getPointLineDist(lhs, *rsLine);
+            double dist1 = getPointLineDist(rhs, *rsLine);
+            return dist0 < dist1;
+        });
+        if (getPointLineDist(vp, *rsLine) > RS_TOLERANCE)
+            return {};
+        return vp;
+    };
+    // verify the tangent lines
+    std::vector<std::unique_ptr<RS_Line>> tangents;
+    std::transform(sol.begin(), sol.end(), std::back_inserter(tangents),
+                   [&getTangentPoint, circle1, circle2](const RS_Vector& line) -> std::unique_ptr<RS_Line> {
+        RS_Vector tangentP = getTangentPoint(*circle1, line);
+        if (!tangentP.valid)
+            return {};
+        auto rsLine = std::make_unique<RS_Line>(nullptr, fromLineCoordinate(line));
+        if (std::abs(std::remainder(tangentP.angleTo(rsLine->getStartpoint()) - tangentP.angleTo(rsLine->getEndpoint()),
+                                    M_PI/2)) > RS_TOLERANCE_ANGLE)
+            return {};
+        rsLine->setStartpoint(tangentP);
+        rsLine->setEndpoint(getTangentPoint(*circle2, line));
+        return std::unique_ptr<RS_Line>(std::move(rsLine));
+    });
+    // cleanup invalid lines
+    tangents.erase(remove_if(tangents.begin(), tangents.end(), [](const std::unique_ptr<RS_Line>& line) {
+        return line == nullptr;
+    }), tangents.end());
+    if (tangents.empty())
+        return {};
+    // the nearest to the mouse cursor
+    auto& nearest = *std::min_element(tangents.begin(),
+                                          tangents.end(), [&coord](const std::unique_ptr<RS_Line>& lhs, const std::unique_ptr<RS_Line>& rhs) {
+        double dist0 = coord.distanceTo(lhs->getNearestPointOnEntity(coord));
+        double dist1 = coord.distanceTo(rhs->getNearestPointOnEntity(coord));
+        return dist0 < dist1;
+    });
+    return std::move(nearest);
 }
 
 /**
@@ -718,40 +648,40 @@ std::unique_ptr<RS_Line> RS_Creation::createTangent2(const RS_Vector& coord,
   *@ return nullptr, if failed
   *@ at success return either an ellipse or hyperbola
   */
- std::vector<RS_Entity*> RS_Creation::createCircleTangent2( RS_Entity* circle1,RS_Entity* circle2)
- {
-	std::vector<RS_Entity*> ret(0, nullptr);
-	if (!(circle1 && circle2)) return ret;
-	RS_Entity* e1=circle1;
-	RS_Entity* e2=circle2;
+std::vector<RS_Entity*> RS_Creation::createCircleTangent2( RS_Entity* circle1,RS_Entity* circle2)
+{
+    std::vector<RS_Entity*> ret(0, nullptr);
+    if (!(circle1 && circle2)) return ret;
+    RS_Entity* e1=circle1;
+    RS_Entity* e2=circle2;
 
-	if (e1->getRadius() < e2->getRadius()) std::swap(e1,e2);
+    if (e1->getRadius() < e2->getRadius()) std::swap(e1,e2);
 
-	RS_Vector center1=e1->getCenter();
-	RS_Vector center2=e2->getCenter();
-	RS_Vector cp=(center1+center2)*0.5;
+    RS_Vector center1=e1->getCenter();
+    RS_Vector center2=e2->getCenter();
+    RS_Vector cp=(center1+center2)*0.5;
     double dist=center1.distanceTo(center2);
     if(dist<RS_TOLERANCE) return ret;
-	RS_Vector vp= center1 - cp;
-     double c=dist/(e1->getRadius()+e2->getRadius());
-	 if( c < 1. - RS_TOLERANCE) {
-		 //two circles intersection or one circle in the other, there's an ellipse path
-		 ret.push_back(
-					 new RS_Ellipse(nullptr,
-									{cp, vp, sqrt(1. - c*c), 0., 0., false}
-					 ));
-	 }
+    RS_Vector vp= center1 - cp;
+    double c=dist/(e1->getRadius()+e2->getRadius());
+    if( c < 1. - RS_TOLERANCE) {
+        //two circles intersection or one circle in the other, there's an ellipse path
+        ret.push_back(
+                    new RS_Ellipse(nullptr,
+                                   {cp, vp, sqrt(1. - c*c), 0., 0., false}
+                                   ));
+    }
     if( dist + e2 ->getRadius() < e1->getRadius() +RS_TOLERANCE ) {
         //one circle inside of another, the path is an ellipse
         return ret;
     }
     if(c > 1. + RS_TOLERANCE) {
         //not circle in circle, there's a hyperbola path
-    c= (e1->getRadius()  - e2->getRadius())/dist;
-	ret.push_back(new LC_Hyperbola(nullptr, LC_HyperbolaData(cp,vp*c,sqrt(1. - c*c),0.,0.,false)));
-    return ret;
-}
-	ret.push_back(new RS_Line{cp, {cp.x - vp.y, cp.y+vp.x}});
+        c= (e1->getRadius()  - e2->getRadius())/dist;
+        ret.push_back(new LC_Hyperbola(nullptr, LC_HyperbolaData(cp,vp*c,sqrt(1. - c*c),0.,0.,false)));
+        return ret;
+    }
+    ret.push_back(new RS_Line{cp, {cp.x - vp.y, cp.y+vp.x}});
     return ret;
 }
 
@@ -771,22 +701,22 @@ RS_Line* RS_Creation::createLineRelAngle(const RS_Vector& coord,
                                          double length) {
 
     // check given entity / coord:
-	if (!(entity && coord))
-		return nullptr;
+    if (!(entity && coord))
+        return nullptr;
 
-	switch(entity->rtti()){
-	default:
-		return nullptr;
-	case RS2::EntityArc:
-	case RS2::EntityCircle:
-	case RS2::EntityLine:
-	case RS2::EntityEllipse:
-		break;
-	}
+    switch(entity->rtti()){
+    default:
+        return nullptr;
+    case RS2::EntityArc:
+    case RS2::EntityCircle:
+    case RS2::EntityLine:
+    case RS2::EntityEllipse:
+        break;
+    }
 
-	auto const vp = entity->getNearestPointOnEntity(coord, false);
+    auto const vp = entity->getNearestPointOnEntity(coord, false);
 
-	double const a1 = angle + entity->getTangentDirection(vp).angle();
+    double const a1 = angle + entity->getTangentDirection(vp).angle();
 
     RS_Vector const v1 = RS_Vector::polar(length, a1);
 
@@ -809,32 +739,32 @@ RS_Line* RS_Creation::createPolygon(const RS_Vector& center,
                                     int number) {
     // check given coords / number:
     if (!center.valid || !corner.valid || number<3) {
-		return nullptr;
+        return nullptr;
     }
 
-	RS_Line* ret = nullptr;
+    RS_Line* ret = nullptr;
 
-	double const r = center.distanceTo(corner);
-	double const angle0 = center.angleTo(corner);
-	double const da = 2.*M_PI/number;
+    double const r = center.distanceTo(corner);
+    double const angle0 = center.angleTo(corner);
+    double const da = 2.*M_PI/number;
     LC_UndoSection undo( document, handleUndo);
     for (int i=0; i < number; ++i) {
-		RS_Vector const& c0 = center +
-				RS_Vector::polar(r, angle0 + i*da);
-		RS_Vector const& c1 = center +
-				RS_Vector::polar(r, angle0 + ((i+1)%number)*da);
+        RS_Vector const& c0 = center +
+                RS_Vector::polar(r, angle0 + i*da);
+        RS_Vector const& c1 = center +
+                RS_Vector::polar(r, angle0 + ((i+1)%number)*da);
 
-		RS_Line* line = new RS_Line{container, c0, c1};
+        RS_Line* line = new RS_Line{container, c0, c1};
         line->setLayerToActive();
         line->setPenToActive();
 
-		if (!ret) ret = line;
+        if (!ret) ret = line;
 
-		if (container) {
+        if (container) {
             container->addEntity(line);
         }
         undo.addUndoable(line);
-		if (graphicView) {
+        if (graphicView) {
             graphicView->drawEntity(line);
         }
     }
@@ -856,41 +786,41 @@ RS_Line* RS_Creation::createPolygon2(const RS_Vector& corner1,
                                      int number) {
     // check given coords / number:
     if (!corner1.valid || !corner2.valid || number<3) {
-		return nullptr;
+        return nullptr;
     }
 
-	RS_Line* ret = nullptr;
+    RS_Line* ret = nullptr;
 
     LC_UndoSection undo( document, handleUndo);
     double const len = corner1.distanceTo(corner2);
-	double const da = 2.*M_PI/number;
-	double const r = 0.5*len/sin(0.5*da);
-	double const angle1 = corner1.angleTo(corner2);
-	RS_Vector center = (corner1 + corner2)*0.5;
+    double const da = 2.*M_PI/number;
+    double const r = 0.5*len/sin(0.5*da);
+    double const angle1 = corner1.angleTo(corner2);
+    RS_Vector center = (corner1 + corner2)*0.5;
 
-	//TODO, the center or the polygon could be at left or right side
-	//left is chosen here
-	center += RS_Vector::polar(0.5*len/tan(0.5*da), angle1 + M_PI_2);
-	double const angle0 = center.angleTo(corner1);
+    //TODO, the center or the polygon could be at left or right side
+    //left is chosen here
+    center += RS_Vector::polar(0.5*len/tan(0.5*da), angle1 + M_PI_2);
+    double const angle0 = center.angleTo(corner1);
 
 
-	for (int i=0; i<number; ++i) {
-		RS_Vector const& c0 = center +
-				RS_Vector::polar(r, angle0 + i*da);
-		RS_Vector const& c1 = center +
-				RS_Vector::polar(r, angle0 + ((i+1)%number)*da);
+    for (int i=0; i<number; ++i) {
+        RS_Vector const& c0 = center +
+                RS_Vector::polar(r, angle0 + i*da);
+        RS_Vector const& c1 = center +
+                RS_Vector::polar(r, angle0 + ((i+1)%number)*da);
 
-		RS_Line* line = new RS_Line{container, c0, c1};
+        RS_Line* line = new RS_Line{container, c0, c1};
         line->setLayerToActive();
         line->setPenToActive();
 
-		if (!ret) ret = line;
+        if (!ret) ret = line;
 
-		if (container) {
+        if (container) {
             container->addEntity(line);
         }
         undo.addUndoable(line);
-		if (graphicView) {
+        if (graphicView) {
             graphicView->drawEntity(line);
         }
 
@@ -962,7 +892,7 @@ RS_Insert* RS_Creation::createInsert(const RS_InsertData* pdata) {
     LC_UndoSection undo( document, handleUndo);
     RS_Insert* ins = new RS_Insert(container, *pdata);
     // inserts are also on layers
-	setEntity(ins);
+    setEntity(ins);
 
     RS_DEBUG->print("RS_Creation::createInsert: OK");
 
@@ -979,7 +909,7 @@ RS_Image* RS_Creation::createImage(const RS_ImageData* data) {
     LC_UndoSection undo( document, handleUndo);
     RS_Image* img = new RS_Image(container, *data);
     img->update();
-	setEntity(img);
+    setEntity(img);
 
     return img;
 }
@@ -1006,25 +936,25 @@ RS_Block* RS_Creation::createBlock(const RS_BlockData* data,
         block = new RS_Block(container, RS_BlockData(*data));
     }
 
-	// copy entities into a block
-	for(auto e: *container){
+    // copy entities into a block
+    for(auto e: *container){
         //for (unsigned i=0; i<container->count(); ++i) {
         //RS_Entity* e = container->entityAt(i);
 
-		if (e && e->isSelected()) {
+        if (e && e->isSelected()) {
 
             // delete / redraw entity in graphic view:
             if (remove) {
-				if (graphicView) {
+                if (graphicView) {
                     graphicView->deleteEntity(e);
                 }
                 e->setSelected(false);
             } else {
-				if (graphicView) {
+                if (graphicView) {
                     graphicView->deleteEntity(e);
                 }
                 e->setSelected(false);
-				if (graphicView) {
+                if (graphicView) {
                     graphicView->drawEntity(e);
                 }
             }
@@ -1043,7 +973,7 @@ RS_Block* RS_Creation::createBlock(const RS_BlockData* data,
         }
     }
 
-	if (graphic) {
+    if (graphic) {
         graphic->addBlock(block);
     }
 
@@ -1063,11 +993,11 @@ RS_Insert* RS_Creation::createLibraryInsert(RS_LibraryInsertData& data) {
     if (!g.open(data.file, RS2::FormatUnknown)) {
         RS_DEBUG->print(RS_Debug::D_WARNING,
                         "RS_Creation::createLibraryInsert: Cannot open file: %s", data.file.toStdString().c_str());
-		return nullptr;
+        return nullptr;
     }
 
     // unit conversion:
-	if (graphic) {
+    if (graphic) {
         double uf = RS_Units::convert(1.0, g.getUnit(),
                                       graphic->getUnit());
         g.scale(RS_Vector(0.0, 0.0), RS_Vector(uf, uf));
@@ -1089,22 +1019,22 @@ RS_Insert* RS_Creation::createLibraryInsert(RS_LibraryInsertData& data) {
 
     RS_DEBUG->print("RS_Creation::createLibraryInsert: OK");
 
-	return nullptr;
+    return nullptr;
 }
 
 void RS_Creation::setEntity(RS_Entity* en) const
 {
-	en->setLayerToActive();
-	en->setPenToActive();
+    en->setLayerToActive();
+    en->setPenToActive();
 
-	if (container) {
-		container->addEntity(en);
-	}
+    if (container) {
+        container->addEntity(en);
+    }
     LC_UndoSection undo( document, handleUndo);
     undo.addUndoable(en);
     if (graphicView) {
-		graphicView->drawEntity(en);
-	}
+        graphicView->drawEntity(en);
+    }
 }
 
 

--- a/librecad/src/lib/creation/rs_creation.cpp
+++ b/librecad/src/lib/creation/rs_creation.cpp
@@ -83,10 +83,6 @@ RS_LineData fromLineCoordinate(const RS_Vector& line)
     return {start/(-start.dotP(line)), stop/(-stop.dotP(line))};
 }
 
-// point to a line distance
-double getPointLineDist(const RS_Vector& point, const RS_Line& line) {
-    return point.distanceTo(line.getNearestPointOnEntity(point));
-}
 }
 
 /**
@@ -607,35 +603,22 @@ std::vector<std::unique_ptr<RS_Line>> RS_Creation::createTangent2(
                 sol1.push_back(vp);
     }
 
+
     // find the tangent point for a line in line coordinates
     auto getTangentPoint = [](const RS_Entity& circle, const RS_Vector& line) -> RS_Vector {
         auto rsLine = std::make_unique<RS_Line>(nullptr, fromLineCoordinate(line));
-        auto tangentPs = circle.getTangentPoint(rsLine->getStartpoint());
-        if (tangentPs.empty())
+        auto s0 = RS_Information::getIntersection(&circle, rsLine.get());
+        if (s0.empty())
             return {};
-        RS_Vector vp = *std::min_element(tangentPs.begin(), tangentPs.end(), [&rsLine](const RS_Vector& lhs, const RS_Vector& rhs)
-        {
-            double dist0 = getPointLineDist(lhs, *rsLine);
-            double dist1 = getPointLineDist(rhs, *rsLine);
-            return dist0 < dist1;
-        });
-        if (getPointLineDist(vp, *rsLine) > RS_TOLERANCE)
-            return {};
-        return vp;
+        return s0.at(0);
     };
     // verify the tangent lines
     std::vector<std::unique_ptr<RS_Line>> tangents;
     std::transform(sol1.begin(), sol1.end(), std::back_inserter(tangents),
                    [&getTangentPoint, circle1, circle2](const RS_Vector& line) -> std::unique_ptr<RS_Line> {
-        RS_Vector tangentP = getTangentPoint(*circle1, line);
-        if (!tangentP.valid)
-            return {};
         auto rsLine = std::make_unique<RS_Line>(nullptr, fromLineCoordinate(line));
-        if (std::abs(std::remainder(tangentP.angleTo(rsLine->getStartpoint()) - tangentP.angleTo(rsLine->getEndpoint()),
-                                    M_PI/2)) > RS_TOLERANCE_ANGLE)
-            return {};
-        rsLine->setStartpoint(tangentP);
-        rsLine->setEndpoint(getTangentPoint(*circle2, line));
+        rsLine->setStartpoint(circle1->dualLineTangentPoint(line));
+        rsLine->setEndpoint(circle2->dualLineTangentPoint(line));
         return std::unique_ptr<RS_Line>(std::move(rsLine));
     });
     // cleanup invalid lines

--- a/librecad/src/lib/creation/rs_creation.h
+++ b/librecad/src/lib/creation/rs_creation.h
@@ -28,6 +28,7 @@
 #ifndef RS_CREATION_H
 #define RS_CREATION_H
 
+#include <memory>
 #include "rs_vector.h"
 
 class RS_Document;
@@ -114,7 +115,7 @@ public:
     RS_Line* createLineOrthTan(const RS_Vector& coord,
                                RS_Line* normal,
                                RS_Entity* circle);
-    RS_Line* createTangent2(const RS_Vector& coord,
+    std::unique_ptr<RS_Line> createTangent2(const RS_Vector& coord,
                             RS_Entity* circle1,
                             RS_Entity* circle2);
     /**

--- a/librecad/src/lib/creation/rs_creation.h
+++ b/librecad/src/lib/creation/rs_creation.h
@@ -115,15 +115,9 @@ public:
     RS_Line* createLineOrthTan(const RS_Vector& coord,
                                RS_Line* normal,
                                RS_Entity* circle);
-    std::unique_ptr<RS_Line> createTangent2(const RS_Vector& coord,
+    std::vector<std::unique_ptr<RS_Line>> createTangent2(
                             RS_Entity* circle1,
                             RS_Entity* circle2);
-    /**
-      * create the path of centers of common tangent circles of the two given circles
-      *@ return nullptr, if failed
-      *@ at success return either an ellipse or hyperbola
-      */
-    std::vector<RS_Entity*> createCircleTangent2( RS_Entity* circle1,RS_Entity* circle2);
 
     RS_Line* createLineRelAngle(const RS_Vector& coord,
                                 RS_Entity* entity,

--- a/librecad/src/lib/engine/lc_parabola.cpp
+++ b/librecad/src/lib/engine/lc_parabola.cpp
@@ -311,6 +311,13 @@ double LC_ParabolaData::FindX(const RS_Vector& point) const
     return vp.x;
 }
 
+RS_Vector LC_ParabolaData::FromX(double x) const
+{
+    // in regular coordinates (4hy=x^2)
+    auto vp = RS_Vector{x, x*x/(4.*axis.magnitude())}.rotate(axis.angle() - M_PI/2) + vertex;
+    return vp;
+}
+
 /** \brief return the equation of the entity
 a quadratic contains coefficients for quadratic:
 m0 x^2 + m1 xy + m2 y^2 + m3 x + m4 y + m5 =0
@@ -384,6 +391,20 @@ RS_VectorSolutions LC_Parabola::getTangentPoint(const RS_Vector& point) const
         return {point};
     return {pf(p0.x + dx), pf(p0.x - dx)};
 }
+
+RS_Vector LC_Parabola::dualLineTangentPoint(const RS_Vector& line) const
+{
+    // rotate to regular form
+    // coordinates: dual
+    // rotate(-a) : rotate(a)
+    auto uv = RS_Vector{line}.rotate(data.axis.angle() - M_PI/2.);
+    // slope = {2h, x} <(2h,x)|uv> = 0
+    // x=-2h uv.x/(uv.y)
+    if (std::abs(uv.y) < RS_TOLERANCE)
+        return RS_Vector{false};
+    return data.FromX(-2.*data.axis.magnitude()*uv.x/uv.y);
+}
+
 
 RS2::Ending LC_Parabola::getTrimPoint(const RS_Vector& trimCoord,
                          const RS_Vector& trimPoint)

--- a/librecad/src/lib/engine/lc_parabola.cpp
+++ b/librecad/src/lib/engine/lc_parabola.cpp
@@ -307,7 +307,7 @@ RS_LineData LC_ParabolaData::GetAxis() const
 double LC_ParabolaData::FindX(const RS_Vector& point) const
 {
     // in regular coordinates (4hy=x^2)
-    const auto vp = RS_Vector{point}.rotate(M_PI/2 - axis.angle()) - vertex;
+    const auto vp = RS_Vector{point}.rotate(vertex, M_PI/2 - axis.angle()) - vertex;
     return vp.x;
 }
 
@@ -395,9 +395,7 @@ RS_VectorSolutions LC_Parabola::getTangentPoint(const RS_Vector& point) const
 RS_Vector LC_Parabola::dualLineTangentPoint(const RS_Vector& line) const
 {
     // rotate to regular form
-    // coordinates: dual
-    // rotate(-a) : rotate(a)
-    auto uv = RS_Vector{line}.rotate(data.axis.angle() - M_PI/2.);
+    auto uv = RS_Vector{line}.rotate(M_PI/2. - data.axis.angle());
     // slope = {2h, x} <(2h,x)|uv> = 0
     // x=-2h uv.x/(uv.y)
     if (std::abs(uv.y) < RS_TOLERANCE)

--- a/librecad/src/lib/engine/lc_parabola.h
+++ b/librecad/src/lib/engine/lc_parabola.h
@@ -57,6 +57,7 @@ struct LC_ParabolaData
     **/
     LC_Quadratic getQuadratic() const;
     double FindX(const RS_Vector& point) const;
+    RS_Vector FromX(double x) const;
 
     // The three control points, and all other properties are calculated from control points
     std::array<RS_Vector, 3> controlPoints;
@@ -138,6 +139,7 @@ public:
                                             const RS_Line& normal,
                                             bool onEntity ) const override;
 
+    RS_Vector dualLineTangentPoint(const RS_Vector& line) const override;
     RS2::Ending getTrimPoint(const RS_Vector& trimCoord,
                              const RS_Vector& trimPoint) override;
     RS_Vector prepareTrim(const RS_Vector& trimCoord,

--- a/librecad/src/lib/engine/lc_parabola.h
+++ b/librecad/src/lib/engine/lc_parabola.h
@@ -30,6 +30,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "lc_splinepoints.h"
 
 struct RS_LineData;
+class RS_Line;
 
 /**
  * Holds the data that defines a parabola.

--- a/librecad/src/lib/engine/rs_arc.cpp
+++ b/librecad/src/lib/engine/rs_arc.cpp
@@ -549,6 +549,17 @@ RS_Vector RS_Arc::getNearestOrthTan(const RS_Vector& coord,
         return getCenter()+vp;
 }
 
+RS_Vector RS_Arc::dualLineTangentPoint(const RS_Vector& line) const
+{
+    RS_Vector dr = line.normalized() * data.radius;
+    RS_Vector vp0 = data.center + dr;
+    RS_Vector vp1 = data.center - dr;
+    auto lineEqu = [&line](const RS_Vector& vp) {
+        return std::abs(line.dotP(vp) + 1.);
+    };
+    return lineEqu(vp0) < lineEqu(vp1) ? vp0 : vp1;
+}
+
 void RS_Arc::moveStartpoint(const RS_Vector& pos) {
     // polyline arcs: move point not angle:
 	//if (parent && parent->rtti()==RS2::EntityPolyline) {

--- a/librecad/src/lib/engine/rs_arc.h
+++ b/librecad/src/lib/engine/rs_arc.h
@@ -213,6 +213,7 @@ public:
 	RS_Vector getNearestOrthTan(const RS_Vector& coord,
                     const RS_Line& normal,
 					bool onEntity = false) const override;
+    RS_Vector dualLineTangentPoint(const RS_Vector& line) const override;
 	RS_VectorSolutions getTangentPoint(const RS_Vector& point) const override;//find the tangential points seeing from given point
 	RS_Vector getTangentDirection(const RS_Vector& point) const override;
 	void move(const RS_Vector& offset) override;

--- a/librecad/src/lib/engine/rs_circle.cpp
+++ b/librecad/src/lib/engine/rs_circle.cpp
@@ -674,6 +674,17 @@ RS_Vector RS_Circle::getNearestOrthTan(const RS_Vector& coord,
         }
 }
 
+RS_Vector RS_Circle::dualLineTangentPoint(const RS_Vector& line) const
+{
+    RS_Vector dr = line.normalized() * data.radius;
+    RS_Vector vp0 = data.center + dr;
+    RS_Vector vp1 = data.center - dr;
+    auto lineEqu = [&line](const RS_Vector& vp) {
+        return std::abs(line.dotP(vp) + 1.);
+    };
+    return lineEqu(vp0) < lineEqu(vp1) ? vp0 : vp1;
+}
+
 void RS_Circle::move(const RS_Vector& offset) {
 	data.center.move(offset);
     moveBorders(offset);

--- a/librecad/src/lib/engine/rs_circle.h
+++ b/librecad/src/lib/engine/rs_circle.h
@@ -144,6 +144,8 @@ with Cx the center of the common tangent circle, Rx the radius. Ci and Ri are th
                                         const RS_Line& normal,
 										bool onEntity = false) const override;
 
+    RS_Vector dualLineTangentPoint(const RS_Vector& line) const override;
+
 	bool offset(const RS_Vector& coord, const double& distance) override;
 	RS_VectorSolutions getTangentPoint(const RS_Vector& point) const override;//find the tangential points seeing from given point
 	RS_Vector getTangentDirection(const RS_Vector& point)const override;

--- a/librecad/src/lib/engine/rs_ellipse.cpp
+++ b/librecad/src/lib/engine/rs_ellipse.cpp
@@ -1204,6 +1204,27 @@ RS_Vector RS_Ellipse::getNearestOrthTan(const RS_Vector& coord,
 }
 
 
+RS_Vector RS_Ellipse::dualLineTangentPoint(const RS_Vector& line) const
+{
+    // u x + v y = 1
+    // coordinates : dual
+    // rotate (-a) : rotate(a)
+    RS_Vector uv = RS_Vector{line}.rotate(data.majorP.angle());
+    // slope = -b c/ a s ( a s, - b c)
+    // x a s - b c y =0 -> s/c = b y / a x
+    // elliptical angle
+    double t = std::atan2(data.ratio * uv.y, uv.x);
+    RS_Vector vp{data.majorP.magnitude()*std::cos(t), data.majorP.magnitude()*data.ratio*std::sin(t)};
+    vp.rotate(data.majorP.angle());
+
+    RS_Vector vp0 = data.center + vp;
+    RS_Vector vp1 = data.center - vp;
+    auto lineEqu = [&line](const RS_Vector& vp) {
+        return std::abs(line.dotP(vp) + 1.);
+    };
+    return lineEqu(vp0) < lineEqu(vp1) ? vp0 : vp1;
+}
+
 void RS_Ellipse::move(const RS_Vector& offset) {
     data.center.move(offset);
     //calculateEndpoints();

--- a/librecad/src/lib/engine/rs_ellipse.cpp
+++ b/librecad/src/lib/engine/rs_ellipse.cpp
@@ -1209,7 +1209,7 @@ RS_Vector RS_Ellipse::dualLineTangentPoint(const RS_Vector& line) const
     // u x + v y = 1
     // coordinates : dual
     // rotate (-a) : rotate(a)
-    RS_Vector uv = RS_Vector{line}.rotate(data.majorP.angle());
+    RS_Vector uv = RS_Vector{line}.rotate(-data.majorP.angle());
     // slope = -b c/ a s ( a s, - b c)
     // x a s - b c y =0 -> s/c = b y / a x
     // elliptical angle

--- a/librecad/src/lib/engine/rs_ellipse.h
+++ b/librecad/src/lib/engine/rs_ellipse.h
@@ -192,6 +192,9 @@ public:
 	RS_Vector getNearestOrthTan(const RS_Vector& coord,
                                     const RS_Line& normal,
 									 bool onEntity = false) const override;
+
+    RS_Vector dualLineTangentPoint(const RS_Vector& line) const override;
+
     bool switchMajorMinor(void); //switch major minor axes to keep major the longer ellipse radius
 	void correctAngles();//make sure angleLength() is not more than 2*M_PI
 	bool isPointOnEntity(const RS_Vector& coord,

--- a/librecad/src/lib/engine/rs_entity.h
+++ b/librecad/src/lib/engine/rs_entity.h
@@ -373,6 +373,16 @@ public:
     }
 
     /**
+     * @brief dualLineTangentPoint find the tangent point for a line in line coordinates
+     * @param line a tangent line in line coordinates
+     * @return the tangent point for the line
+     */
+    virtual RS_Vector dualLineTangentPoint([[maybe_unused]] const RS_Vector& line) const
+    {
+        return RS_Vector{false};
+    }
+
+    /**
      * Must be overwritten to get the nearest reference point for this entity.
      *
      * @param coord Coordinate (typically a mouse coordinate)

--- a/librecad/src/lib/engine/rs_line.h
+++ b/librecad/src/lib/engine/rs_line.h
@@ -93,12 +93,12 @@ public:
         return data.endpoint;
     }
     /** Sets the startpoint */
-    void setStartpoint(RS_Vector s) {
+    void setStartpoint(const RS_Vector& s) {
         data.startpoint = s;
         calculateBorders();
     }
     /** Sets the endpoint */
-    void setEndpoint(RS_Vector e) {
+    void setEndpoint(const RS_Vector& e) {
         data.endpoint = e;
         calculateBorders();
     }

--- a/librecad/src/lib/math/lc_quadratic.cpp
+++ b/librecad/src/lib/math/lc_quadratic.cpp
@@ -516,7 +516,7 @@ RS_VectorSolutions LC_Quadratic::getIntersection(const LC_Quadratic& l1, const L
             return ret;
         }
         std::vector<std::vector<double> >  ce(0);
-		if(fabs(p2->m_vLinear(1))<RS_TOLERANCE){
+        if(std::abs(p2->m_vLinear(1))<RS_TOLERANCE){
             const double angle=0.25*M_PI;
             LC_Quadratic p11(*p1);
             LC_Quadratic p22(*p2);
@@ -539,11 +539,11 @@ RS_VectorSolutions LC_Quadratic::getIntersection(const LC_Quadratic& l1, const L
 //        }
         return ret;
     }
-    if( fabs(p1->m_mQuad(0,0))<RS_TOLERANCE && fabs(p1->m_mQuad(0,1))<RS_TOLERANCE
+    if( std::abs(p1->m_mQuad(0,0))<RS_TOLERANCE && fabs(p1->m_mQuad(0,1))<RS_TOLERANCE
             &&
-            fabs(p2->m_mQuad(0,0))<RS_TOLERANCE && fabs(p2->m_mQuad(0,1))<RS_TOLERANCE
+            std::abs(p2->m_mQuad(0,0))<RS_TOLERANCE && fabs(p2->m_mQuad(0,1))<RS_TOLERANCE
             ){
-        if(fabs(p1->m_mQuad(1,1))<RS_TOLERANCE && fabs(p2->m_mQuad(1,1))<RS_TOLERANCE){
+        if(std::abs(p1->m_mQuad(1,1))<RS_TOLERANCE && fabs(p2->m_mQuad(1,1))<RS_TOLERANCE){
             //linear
             std::vector<double> ce(0);
             ce.push_back(p1->m_vLinear(0));
@@ -599,7 +599,7 @@ RS_VectorSolutions LC_Quadratic::getIntersection(const LC_Quadratic& l1, const L
    cos x, sin x
    -sin x, cos x
    */
-boost::numeric::ublas::matrix<double>  LC_Quadratic::rotationMatrix(const double& angle)
+boost::numeric::ublas::matrix<double> LC_Quadratic::rotationMatrix(const double& angle)
 {
     boost::numeric::ublas::matrix<double> ret(2,2);
     ret(0,0)=cos(angle);
@@ -608,6 +608,25 @@ boost::numeric::ublas::matrix<double>  LC_Quadratic::rotationMatrix(const double
     ret(1,1)=ret(0,0);
     return ret;
 }
+
+LC_Quadratic LC_Quadratic::getDualCurve() const
+{
+    if (!isQuadratic())
+        return LC_Quadratic{};
+    auto getCes = [this]() -> std::array<double, 6>{
+        std::vector<double> cev = getCoefficients();
+        return {cev[0], cev[1], cev[2], cev[3], cev[4], cev[5]};
+    };
+    const auto& [a,b,c,d,e,f] = getCes();
+
+    std::vector<double> dce = {{
+                                   e*e - 4.*c*f, 4.*b*f - 2.*d*e, d*d - 4.*a*f,
+                                   4.*c*d-2.*b*e, 4.*a*e-2.*b*d,
+                                   b*b-4.*a*c
+                               }};
+    return {dce};
+}
+
 
 
 /**

--- a/librecad/src/lib/math/lc_quadratic.h
+++ b/librecad/src/lib/math/lc_quadratic.h
@@ -94,6 +94,14 @@ public:
 
     /** switch x,y coordinates */
     LC_Quadratic flipXY(void) const;
+
+    /**
+     * @brief getDualCurve: the dual curve of the current conic section
+     * @return the quadratic of the dual curve, if the current curve is a conic section;
+     *         returns an invalid object, if the current curve is not quadratic
+     */
+    LC_Quadratic getDualCurve() const;
+
     /** the matrix of rotation by angle **/
     static boost::numeric::ublas::matrix<double> rotationMatrix(const double& angle);
 


### PR DESCRIPTION
Our common tangent (C, C) is now extended to find common tangents for any two conic sections (not considering degenerate lines/points, etc.).

The new algorithm is simplified to a generic common tangent finding algorithm:

1, Find the quadratic form of the dual conic sections of the input ones;
2, It's known that dual curves of conic sections are also conic sections;
3, find intersections of dual conic sections;
4, the intersections are the common tangent in line coordinates of input conic sections;
5, new methods are created to find the tangent point, given a conic section and one of its tangent lines in line coordinates.

Dual curve of a conic section:
Given a general conic section with homogeneous coordinates $[a,b,c,d,e,f]$:
$$ax^2+b x y+c y^2+d x + e y + f = 0 $$
The dual curve is:
$$(e^2-4 c f)A^2+(4b f-2 d e) A B+(d^2-4 a f)B^2 +(4c d -2 b e) A C+(4a e - 2b d) B C+(b^2 - 4 a c) C^2= 0$$

The common tangents of two conic sections are the intersections of their dual curves, and the lines are in line coordinates, _i.e._, their dual points


