### PR TITLE
more reliable selection of segments for break/divide action

### DIFF
--- a/librecad/src/actions/lc_actionmodifybreakdivide.cpp
+++ b/librecad/src/actions/lc_actionmodifybreakdivide.cpp
@@ -427,6 +427,17 @@ void LC_ActionModifyBreakDivide::createArcEntity(const RS_ArcData &arcData, bool
     list << createdArc;
 
 }
+
+/**
+ * For selection of entities, we'll rely on free snap mode, so point of selection is not affected by intersection points or endpoints.
+ * @param e
+ * @return
+ */
+RS_Vector LC_ActionModifyBreakDivide::doGetMouseSnapPoint(QMouseEvent *e){
+    RS_Vector result = snapFree(e);
+    return result;
+}
+
 /**
  * determines segment of line selected by the user
  * @param line line

--- a/librecad/src/actions/lc_actionmodifybreakdivide.h
+++ b/librecad/src/actions/lc_actionmodifybreakdivide.h
@@ -105,6 +105,8 @@ protected:
 
     TriggerData* triggerData = nullptr;
 
+
+
     bool doCheckMayDrawPreview(QMouseEvent *event, int status) override;
     void doPreparePreviewEntities(QMouseEvent *e, RS_Vector &snap, QList<RS_Entity *> &list, int status) override;
     LineSegmentData *calculateLineSegment(RS_Line *line, RS_Vector &snap);
@@ -129,6 +131,7 @@ protected:
     void createLineEntity(bool preview, const RS_Vector &start, const RS_Vector &end, const RS_Pen &pen, RS_Layer *layer, QList<RS_Entity *> &list) const;
     void doAfterTrigger() override;
     void doFinish(bool updateTB) override;
+    RS_Vector doGetMouseSnapPoint(QMouseEvent *e) override;
 };
 
 #endif // LC_ACTIONMODIFYBREAKOUTLINE_H


### PR DESCRIPTION
actually, this is improvement for selection of entities within Break/Divide action - now selection is not affected by current snap mode (snapping to intersection and so on)