### PR TITLE
fix for the issue with drawing snapper and coordinates in coordinates…

### DIFF
--- a/librecad/src/actions/lc_abstractactionwithpreview.cpp
+++ b/librecad/src/actions/lc_abstractactionwithpreview.cpp
@@ -20,21 +20,24 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 **********************************************************************/
 
+#include <QList>
+#include <QMouseEvent>
+
+#include "lc_abstractactionwithpreview.h"
+#include "lc_actiondrawslicedivide.h"
+#include "rs_arc.h"
+#include "rs_circle.h"
+#include "rs_commandevent.h"
+#include "rs_commands.h"
+#include "rs_coordinateevent.h"
+#include "rs_debug.h"
+#include "rs_dialogfactory.h"
+#include "rs_graphicview.h"
+#include "rs_line.h"
 #include "lc_linemath.h"
 #include "rs_point.h"
-#include "QMouseEvent"
-#include <QList>
-#include "rs_circle.h"
-#include "rs_arc.h"
-#include "rs_debug.h"
-#include "rs_commands.h"
-#include "rs_dialogfactory.h"
-#include "rs_coordinateevent.h"
-#include "rs_commandevent.h"
-#include "rs_graphicview.h"
+#include "rs_polyline.h"
 #include "rs_preview.h"
-#include "lc_actiondrawslicedivide.h"
-#include "lc_abstractactionwithpreview.h"
 
 /**
  * Utility base class for actions. It includes some basic logic and utilities, that simplifies creation of specific actions

--- a/librecad/src/actions/lc_abstractactionwithpreview.cpp
+++ b/librecad/src/actions/lc_abstractactionwithpreview.cpp
@@ -149,6 +149,23 @@ bool LC_AbstractActionWithPreview::isAcceptSelectedEntityToTriggerOnInit([[maybe
 void LC_AbstractActionWithPreview::doPerformOriginalEntitiesDeletionOnInitTrigger([[maybe_unused]]QList<RS_Entity *> &list){}
 
 
+void LC_AbstractActionWithPreview::updateSnapperAndCoordinateWidget(QMouseEvent* e, [[maybe_unused]]int status){
+    // todo - actually, this is a bit ugly to call snap point  - yet as side effect, it will draw snapper and update coordinates widget..
+    RS_Vector mouse = snapPoint(e);
+}
+
+/**
+ * Explicitly updates coordinate widget by current mouse position.
+ * Method is useful for actions states that do not call snapPoint() method on mouse move (which, in turn, updates the widget)
+ * @param e
+ */
+void LC_AbstractActionWithPreview::doUpdateCoordinateWidgetByMouse(QMouseEvent* e){
+    RS_Vector mouse = graphicView->toGraph(e->x(), e->y());
+    RS_Vector relMouse = mouse - graphicView->getRelativeZero();
+    RS_DIALOGFACTORY->updateCoordinateWidget(mouse, relMouse);
+}
+
+
 /**
  * Creation of entities on init trigger
  * @param entities selected entities to trigger
@@ -513,6 +530,9 @@ void LC_AbstractActionWithPreview::mouseMoveEvent(QMouseEvent *e){
             lastSnapPoint = snap; // store snap point for later use (like redraw preview on options change)
         }
         graphicView->redraw();
+    }
+    else{
+        updateSnapperAndCoordinateWidget(e, status);
     }
     doMouseMoveEnd(status, e);
     clearAlternativeActionMode();

--- a/librecad/src/actions/lc_abstractactionwithpreview.cpp
+++ b/librecad/src/actions/lc_abstractactionwithpreview.cpp
@@ -160,7 +160,7 @@ void LC_AbstractActionWithPreview::updateSnapperAndCoordinateWidget(QMouseEvent*
  * @param e
  */
 void LC_AbstractActionWithPreview::doUpdateCoordinateWidgetByMouse(QMouseEvent* e){
-    RS_Vector mouse = graphicView->toGraph(e->x(), e->y());
+    RS_Vector mouse = graphicView->toGraph(e->position());
     RS_Vector relMouse = mouse - graphicView->getRelativeZero();
     RS_DIALOGFACTORY->updateCoordinateWidget(mouse, relMouse);
 }

--- a/librecad/src/actions/lc_abstractactionwithpreview.h
+++ b/librecad/src/actions/lc_abstractactionwithpreview.h
@@ -219,7 +219,8 @@ protected:
     RS_Line* createLine(const RS_Vector &startPoint, const RS_Vector &endPoint, QList<RS_Entity *> &list) const;
     virtual void checkAlternativeActionMode(const QMouseEvent *e, int status, bool shiftPressed);
     virtual void clearAlternativeActionMode();
-
+    void updateSnapperAndCoordinateWidget(QMouseEvent *e, int status);
+    void doUpdateCoordinateWidgetByMouse(QMouseEvent *e);
 };
 
 #endif // LC_ABSTRACTACTIONWITHPREVIEW_H

--- a/librecad/src/actions/lc_abstractactionwithpreview.h
+++ b/librecad/src/actions/lc_abstractactionwithpreview.h
@@ -25,11 +25,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #include "qg_actionhandler.h"
 #include "rs_previewactioninterface.h"
+#include "rs_vector.h"
 
 class RS_Line;
 class RS_Point;
 class RS_Polyline;
-class RS_Vector;
 
 /**
  * Utility base class for actions. It includes some basic logic and utilities, that simplifies creation of specific actions

--- a/librecad/src/actions/lc_abstractactionwithpreview.h
+++ b/librecad/src/actions/lc_abstractactionwithpreview.h
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "rs_previewactioninterface.h"
 
 class RS_Line;
+class RS_Point;
 class RS_Polyline;
 class RS_Vector;
 

--- a/librecad/src/actions/lc_abstractactionwithpreview.h
+++ b/librecad/src/actions/lc_abstractactionwithpreview.h
@@ -24,10 +24,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define LC_ABSTRACTACTIONWITHPREVIEW_H
 
 #include "qg_actionhandler.h"
-#include "rs_line.h"
-#include "rs_polyline.h"
-#include "rs_vector.h"
 #include "rs_previewactioninterface.h"
+
+class RS_Line;
+class RS_Polyline;
+class RS_Vector;
 
 /**
  * Utility base class for actions. It includes some basic logic and utilities, that simplifies creation of specific actions


### PR DESCRIPTION
a small fix for recently added actions

In my initial implementation, coordinates widget was not updated and snapper (if enabled) was not shown for cases where preview is not drawn (i.e - for initial states of action). 

Now these actions works in more consistent way with other actions. 

Fix is applicable both for master branch and 2.2.1