### PR TITLE
fix compilation with clang and llvm's libcxx

### DIFF
--- a/librecad/src/lib/debug/rs_debug.h
+++ b/librecad/src/lib/debug/rs_debug.h
@@ -28,6 +28,7 @@
 #ifndef RS_DEBUG_H
 #define RS_DEBUG_H
 
+#include <cstdio>
 #include <iosfwd>
 #ifdef __hpux
 #include <sys/_size_t.h>

--- a/librecad/src/lib/debug/rs_debug.h
+++ b/librecad/src/lib/debug/rs_debug.h
@@ -29,7 +29,6 @@
 #define RS_DEBUG_H
 
 #include <cstdio>
-#include <iosfwd>
 #ifdef __hpux
 #include <sys/_size_t.h>
 #endif


### PR DESCRIPTION
librecad/src/lib/debug/rs_debug.h requires cstdio to be included because of FILE type being used


log of compilation failure:

```bash
clang++ -c -pipe -g -O2 -std=gnu++11 -Wall -Wextra -D_REENTRANT -fPIC -DDWGSUPPORT -DQC_APPDIR="librecad" -DLC_VERSION="2.2.0.2-5-g3aa2c41c" -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_PRINTSUPPORT_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -I/usr/include -I../../libraries/libdxfrw/src -I../../libraries/jwwlib/src -Icmd -Ilib/actions -Ilib/creation -Ilib/debug -Ilib/engine -Ilib/fileio -Ilib/filters -Ilib/generators -Ilib/gui -Ilib/information -Ilib/math -Ilib/modification -Ilib/printing -Iactions -Imain -Imain/console_dxf2pdf -Itest -Iplugins -Iui -Iui/forms -Iui/generic -I../res -I/usr/include/qt5 -I/usr/include/qt5/QtSvg -I/usr/include/qt5/QtPrintSupport -I/usr/include/qt5/QtWidgets -I/usr/include/qt5/QtGui -I/usr/include/qt5/QtCore -I../../generated/librecad/moc -I../../generated/librecad/ui -I/usr/lib64/qt5/mkspecs/linux-clang -o ../../generated/librecad/obj/rs_arc.o lib/engine/rs_arc.cpp
In file included from lib/debug/rs_debug.cpp:28:
lib/debug/rs_debug.h:91:20: error: unknown type name 'FILE'
   91 |     void setStream(FILE* s) {
      |                    ^
lib/debug/rs_debug.h:99:5: error: unknown type name 'FILE'
   99 |     FILE* stream;
```