### PR TITLE
Cmd widget height fix and other widgets polishing

### DIFF
--- a/librecad/src/ui/forms/qg_commandwidget.ui
+++ b/librecad/src/ui/forms/qg_commandwidget.ui
@@ -6,35 +6,87 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>332</width>
-    <height>196</height>
+    <width>260</width>
+    <height>241</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Command Line</string>
   </property>
-  <layout class="QVBoxLayout">
-   <property name="spacing">
-    <number>1</number>
-   </property>
+  <layout class="QGridLayout" name="gridLayout" rowstretch="10,0,0">
    <property name="leftMargin">
-    <number>1</number>
+    <number>2</number>
    </property>
    <property name="topMargin">
     <number>1</number>
    </property>
    <property name="rightMargin">
-    <number>1</number>
+    <number>2</number>
    </property>
    <property name="bottomMargin">
     <number>1</number>
    </property>
-   <item>
-    <widget class="QG_CommandHistory" name="teHistory">
+   <item row="2" column="0">
+    <widget class="QG_CommandEdit" name="leCommand">
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>46</height>
+       <height>23</height>
+      </size>
+     </property>
+     <property name="baseSize">
+      <size>
+       <width>0</width>
+       <height>23</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QToolButton" name="options_button">
+     <property name="text">
+      <string>...</string>
+     </property>
+     <property name="icon">
+      <iconset resource="../../../res/icons/icons.qrc">
+       <normaloff>:/icons/options.svg</normaloff>:/icons/options.svg</iconset>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>12</width>
+       <height>12</height>
+      </size>
+     </property>
+     <property name="popupMode">
+      <enum>QToolButton::InstantPopup</enum>
+     </property>
+     <property name="toolButtonStyle">
+      <enum>Qt::ToolButtonIconOnly</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QLabel" name="lCommand">
+     <property name="text">
+      <string>Command:</string>
+     </property>
+     <property name="wordWrap">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QG_CommandHistory" name="teHistory">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>1</width>
+       <height>1</height>
       </size>
      </property>
      <property name="focusPolicy">
@@ -65,8 +117,8 @@ p, li { white-space: pre-wrap; }
 hr { height: 1px; border-width: 0; }
 li.unchecked::marker { content: &quot;\2610&quot;; }
 li.checked::marker { content: &quot;\2612&quot;; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Segoe UI'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans'; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="acceptRichText">
       <bool>false</bool>
@@ -74,82 +126,6 @@ li.checked::marker { content: &quot;\2612&quot;; }
      <property name="linkUnderline" stdset="0">
       <bool>false</bool>
      </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="lCommand">
-     <property name="text">
-      <string>Command:</string>
-     </property>
-     <property name="wordWrap">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QFrame" name="frame">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="spacing">
-       <number>2</number>
-      </property>
-      <property name="leftMargin">
-       <number>2</number>
-      </property>
-      <property name="topMargin">
-       <number>2</number>
-      </property>
-      <property name="rightMargin">
-       <number>2</number>
-      </property>
-      <property name="bottomMargin">
-       <number>2</number>
-      </property>
-      <item>
-       <widget class="QG_CommandEdit" name="leCommand">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="baseSize">
-         <size>
-          <width>0</width>
-          <height>23</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="options_button">
-        <property name="text">
-         <string>...</string>
-        </property>
-        <property name="icon">
-         <iconset resource="../../../res/icons/icons.qrc">
-          <normaloff>:/icons/options.svg</normaloff>:/icons/options.svg</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>12</width>
-          <height>12</height>
-         </size>
-        </property>
-        <property name="popupMode">
-         <enum>QToolButton::InstantPopup</enum>
-        </property>
-        <property name="toolButtonStyle">
-         <enum>Qt::ToolButtonIconOnly</enum>
-        </property>
-       </widget>
-      </item>
-     </layout>
     </widget>
    </item>
   </layout>

--- a/librecad/src/ui/generic/colorwizard.ui
+++ b/librecad/src/ui/generic/colorwizard.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>305</width>
-    <height>200</height>
+    <width>260</width>
+    <height>227</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,6 +20,18 @@
    <enum>QFrame::Raised</enum>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>1</number>
+   </property>
+   <property name="topMargin">
+    <number>2</number>
+   </property>
+   <property name="rightMargin">
+    <number>1</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
+   </property>
    <item>
     <widget class="QFrame" name="frame_0">
      <property name="frameShape">
@@ -29,6 +41,18 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item>
        <widget class="QToolButton" name="add_button">
         <property name="toolTip">
@@ -77,7 +101,11 @@
     </widget>
    </item>
    <item>
-    <widget class="QListWidget" name="fav_list"/>
+    <widget class="QListWidget" name="fav_list">
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -89,8 +117,8 @@
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../../../res/extui/extui.qrc"/>
   <include location="../../../res/ui/ui.qrc"/>
+  <include location="../../../res/extui/extui.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/librecad/src/ui/lc_layertreemodel.cpp
+++ b/librecad/src/ui/lc_layertreemodel.cpp
@@ -876,7 +876,7 @@ QVariant LC_LayerTreeModel::data ( const QModelIndex & index, int role ) const {
             }
             else if (layerItem->isActiveLayer()){
                 return options->activeLayerBgColor;
-            }
+            }            
         }
         break;
 

--- a/librecad/src/ui/lc_layertreewidget.cpp
+++ b/librecad/src/ui/lc_layertreewidget.cpp
@@ -112,7 +112,9 @@ LC_LayerTreeView *LC_LayerTreeWidget::initTreeView(){
     treeView->setSelectionMode(QAbstractItemView::NoSelection);
     treeView->setEditTriggers(QAbstractItemView::NoEditTriggers);
     treeView->setFocusPolicy(Qt::NoFocus);
-    treeView->setMinimumHeight(140);
+    treeView->setMinimumHeight(65);
+    //treeView->setMinimumHeight(140);
+
 
     treeView->setDragDropMode(QAbstractItemView::InternalMove);
     treeView->setDragEnabled(true);
@@ -122,6 +124,8 @@ LC_LayerTreeView *LC_LayerTreeWidget::initTreeView(){
     treeView->setExpandsOnDoubleClick(false);
 
     treeView->setContextMenuPolicy(Qt::CustomContextMenu);
+
+    // treeView->setStyleSheet("background-color: white;");
 
     connect(treeView, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onCustomContextMenu(QPoint)));
     connect(treeView, &QTreeView::clicked, this, &LC_LayerTreeWidget::slotTreeClicked);
@@ -156,10 +160,10 @@ QLayout *LC_LayerTreeWidget::initFilterAndSettingsSection(){
     layFiltering->addWidget(matchModeCheckBox);
 
     // settings button
-    const QSize minButSize(28, 28);
+    // const QSize minButSize(28, 28);
     auto* but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/settings.svg"));
-    but->setMinimumSize(minButSize);
+    // but->setMinimumSize(minButSize);
     but->setToolTip(tr("Settings"));
     connect(but, &QToolButton::clicked, this, &LC_LayerTreeWidget::invokeSettingsDialog);
     layFiltering->addWidget(but);
@@ -176,12 +180,12 @@ QLayout *LC_LayerTreeWidget::initButtonsBar(){
 //    auto *layButtons = new QHBoxLayout;
     auto *layButtons = new LC_FlexLayout(  );
     QToolButton *but;
-    const QSize minButSize(28, 28);
+//    const QSize minButSize(28, 28);
 
     // show all layer:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/visible.svg"));
-    but->setMinimumSize(minButSize);
+//    but->setMinimumSize(minButSize);
     but->setToolTip(tr("Show all layers"));
     connect(but, &QToolButton::clicked, this, &LC_LayerTreeWidget::showAllLayers);
     layButtons->addWidget(but);
@@ -189,7 +193,7 @@ QLayout *LC_LayerTreeWidget::initButtonsBar(){
     // hide all layer:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/invisible.svg"));
-    but->setMinimumSize(minButSize);
+//    but->setMinimumSize(minButSize);
     but->setToolTip(tr("Hide all layers"));
     connect(but, &QToolButton::clicked, this, &LC_LayerTreeWidget::hideAllLayers);
     layButtons->addWidget(but);
@@ -197,7 +201,7 @@ QLayout *LC_LayerTreeWidget::initButtonsBar(){
     // toggle secondary layers
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/dim_vertical.svg"));
-    but->setMinimumSize(minButSize);
+//    but->setMinimumSize(minButSize);
     but->setToolTip(tr("Show Secondary Layers"));
     but->setCheckable(true);
     but->setChecked(true); // visible by default
@@ -208,7 +212,7 @@ QLayout *LC_LayerTreeWidget::initButtonsBar(){
     // Visible only active
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/select_all.svg"));
-    but->setMinimumSize(minButSize);
+//    but->setMinimumSize(minButSize);
     but->setToolTip(tr("Show Active Layer Only"));
     connect(but, &QToolButton::clicked, this, &LC_LayerTreeWidget::showActiveLayerOnly);
     layButtons->addWidget(but);
@@ -218,7 +222,7 @@ QLayout *LC_LayerTreeWidget::initButtonsBar(){
     // expand all layers
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/order.svg"));
-    but->setMinimumSize(minButSize);
+//    but->setMinimumSize(minButSize);
     but->setToolTip(tr("Expand All"));
     connect(but, &QToolButton::clicked, this, &LC_LayerTreeWidget::expandAllLayers);
     layButtons->addWidget(but);
@@ -227,7 +231,7 @@ QLayout *LC_LayerTreeWidget::initButtonsBar(){
     // collapse all layers
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/upmost.svg"));
-    but->setMinimumSize(minButSize);
+//    but->setMinimumSize(minButSize);
     but->setToolTip(tr("Collapse All"));
     connect(but, &QToolButton::clicked, this, &LC_LayerTreeWidget::collapseAllLayers);
     layButtons->addWidget(but/*, 10*/);
@@ -236,7 +240,7 @@ QLayout *LC_LayerTreeWidget::initButtonsBar(){
     // expand all layers
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/dim_aligned.svg"));
-    but->setMinimumSize(minButSize);
+//    but->setMinimumSize(minButSize);
     but->setToolTip(tr("Collapse Secondary"));
     connect(but, &QToolButton::clicked, this, &LC_LayerTreeWidget::collapseSecondaryLayers);
     layButtons->addWidget(but);
@@ -247,7 +251,7 @@ QLayout *LC_LayerTreeWidget::initButtonsBar(){
     // unlock all layers:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/unlocked.svg"));
-    but->setMinimumSize(minButSize);
+//    but->setMinimumSize(minButSize);
     but->setToolTip(tr("Unlock all layers"));
     connect(but, &QToolButton::clicked, this, &LC_LayerTreeWidget::unlockAllLayers);
     layButtons->addWidget(but);
@@ -255,7 +259,7 @@ QLayout *LC_LayerTreeWidget::initButtonsBar(){
     // lock all layers:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/locked.svg"));
-    but->setMinimumSize(minButSize);
+//    but->setMinimumSize(minButSize);
     but->setToolTip(tr("Lock all layers"));
     connect(but, &QToolButton::clicked, this, &LC_LayerTreeWidget::lockAllLayers);
     layButtons->addWidget(but);
@@ -263,7 +267,7 @@ QLayout *LC_LayerTreeWidget::initButtonsBar(){
     // add layer:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/add.svg"));
-    but->setMinimumSize(minButSize);
+//    but->setMinimumSize(minButSize);
     but->setToolTip(tr("Add a layer"));
     connect(but, &QToolButton::clicked, this, &LC_LayerTreeWidget::addLayer);
     layButtons->addWidget(but);
@@ -271,7 +275,7 @@ QLayout *LC_LayerTreeWidget::initButtonsBar(){
     // add dimensional layer:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/dim_horizontal.svg"));
-    but->setMinimumSize(minButSize);
+//    but->setMinimumSize(minButSize);
     but->setToolTip(tr("Add dimensions Layer"));
     connect(but, &QToolButton::clicked, this, &LC_LayerTreeWidget::addDimensionalLayerForActiveLayer);
 
@@ -281,7 +285,7 @@ QLayout *LC_LayerTreeWidget::initButtonsBar(){
     // remove layer:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/remove.svg"));
-    but->setMinimumSize(minButSize);
+//    but->setMinimumSize(minButSize);
     but->setToolTip(tr("Remove layer"));
     connect(but, &QToolButton::clicked, this, &LC_LayerTreeWidget::removeActiveLayers);
     layButtons->addWidget(but);
@@ -289,7 +293,7 @@ QLayout *LC_LayerTreeWidget::initButtonsBar(){
     // rename layer:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/rename_active_block.svg"));
-    but->setMinimumSize(minButSize);
+//    but->setMinimumSize(minButSize);
     but->setToolTip(tr("Modify layer attributes / rename"));
     connect(but, &QToolButton::clicked, this, &LC_LayerTreeWidget::editActiveLayer);
     layButtons->addWidget(but);
@@ -297,14 +301,14 @@ QLayout *LC_LayerTreeWidget::initButtonsBar(){
 //    layButtons->addStretch(10);
 
     // add separator line
-    auto *vFrame = new QFrame;
-    vFrame->setFrameShape(QFrame::VLine);
-    layButtons->addWidget(vFrame);
+    // auto *vFrame = new QFrame;
+    // vFrame->setFrameShape(QFrame::VLine);
+    // layButtons->addWidget(vFrame);
 
     // rename layer:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/down.svg"));
-    but->setMinimumSize(minButSize);
+//    but->setMinimumSize(minButSize);
     but->setToolTip(tr("Flat List Mode)"));
     but->setCheckable(true);
     connect(but, &QToolButton::clicked, this, &LC_LayerTreeWidget::toggleFlatView);

--- a/librecad/src/ui/lc_layertreewidget.cpp
+++ b/librecad/src/ui/lc_layertreewidget.cpp
@@ -178,7 +178,7 @@ QLayout *LC_LayerTreeWidget::initFilterAndSettingsSection(){
  */
 QLayout *LC_LayerTreeWidget::initButtonsBar(){
 //    auto *layButtons = new QHBoxLayout;
-    auto *layButtons = new LC_FlexLayout(  );
+    auto *layButtons = new LC_FlexLayout(0,5,5);
     QToolButton *but;
 //    const QSize minButSize(28, 28);
 

--- a/librecad/src/ui/lc_penpalettewidget.cpp
+++ b/librecad/src/ui/lc_penpalettewidget.cpp
@@ -83,27 +83,29 @@ LC_PenPaletteWidget::LC_PenPaletteWidget(const QString& title, QWidget* parent) 
     setupUi(this);
 
     // make buttons flexible
-    auto *layButtonsFlex = new LC_FlexLayout(2, 6, 6);
+    auto *layButtonsFlex = new LC_FlexLayout(0, 5, 5);
     layButtonsFlex->fillFromLayout(layButtons);
     int buttonsPosition = gridLayout->indexOf(layButtons);
     QLayoutItem *pItem = gridLayout->takeAt(buttonsPosition);
     delete pItem;
 
     int settingsWidgetPosition = gridLayout->indexOf(tbSettings);
-    QLayoutItem *pLayoutItem = gridLayout->takeAt(settingsWidgetPosition);
-    delete pLayoutItem;
+//     int settingsWidgetPosition = gridLayout->indexOf(laySettings);
+     QLayoutItem *pLayoutItem = gridLayout->takeAt(settingsWidgetPosition);
+     delete pLayoutItem;
 
     gridLayout->addLayout(layButtonsFlex, 0, 0, 1, 1);
     gridLayout->addWidget(tbSettings, 0,1,1,1);
-    gridLayout->setAlignment(tbSettings,Qt::AlignTop);
+   //  gridLayout->addLayout(laySettings, 0,1,1,1);
+   gridLayout->setAlignment(tbSettings,Qt::AlignTop);
 
     // make controls flexible
 
-    auto *layPenColorFlex = new LC_FlexLayout(2, 6, 6, 45);
+    auto *layPenColorFlex = new LC_FlexLayout(0, 5, 5, 45);
     layPenColorFlex->fillFromLayout(layPenColor);
     layPenColorFlex->fillFromLayout(layTypeWidth);
     layPenColorFlex->setSoftBreakItems({2, 4, 6});
-    layPenColorFlex->setFullWidthItems({1});
+    layPenColorFlex->setFullWidthItems({1,3,5,7});
     gridLayout->addLayout(layPenColorFlex,4,0,1, 2);
 
     setWindowTitle(title);

--- a/librecad/src/ui/lc_penpalettewidget.ui
+++ b/librecad/src/ui/lc_penpalettewidget.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>404</width>
-    <height>246</height>
+    <width>339</width>
+    <height>224</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+   <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -22,6 +22,18 @@
   <layout class="QGridLayout" name="gridLayout">
    <property name="sizeConstraint">
     <enum>QLayout::SetDefaultConstraint</enum>
+   </property>
+   <property name="leftMargin">
+    <number>2</number>
+   </property>
+   <property name="topMargin">
+    <number>2</number>
+   </property>
+   <property name="rightMargin">
+    <number>2</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
    </property>
    <item row="8" column="0" colspan="2">
     <widget class="Line" name="line">
@@ -477,12 +489,11 @@
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../../res/extui/extui.qrc"/>
+  <include location="../../res/ui/ui.qrc"/>
   <include location="../../res/actions/actions.qrc"/>
   <include location="../../res/icons/icons.qrc"/>
   <include location="../../res/icons/icons.qrc"/>
-  <include location="../../res/icons/icons.qrc"/>
-  <include location="../../res/ui/ui.qrc"/>
+  <include location="../../res/extui/extui.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/librecad/src/ui/lc_penpalettewidget.ui
+++ b/librecad/src/ui/lc_penpalettewidget.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>339</width>
-    <height>224</height>
+    <width>334</width>
+    <height>180</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -35,265 +35,9 @@
    <property name="bottomMargin">
     <number>2</number>
    </property>
-   <item row="8" column="0" colspan="2">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="layPenColor">
-     <item>
-      <widget class="QLabel" name="lblName">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Pen Name:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="lePenName">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-         <horstretch>1</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>60</width>
-         <height>22</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="baseSize">
-        <size>
-         <width>130</width>
-         <height>22</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="lColor">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>40</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Color:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QG_ColorBox" name="cbColor" native="true"/>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>0</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="12" column="0" colspan="2">
-    <widget class="QTableView" name="tableView">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>1</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>100</width>
-       <height>100</height>
-      </size>
-     </property>
-     <property name="sizeAdjustPolicy">
-      <enum>QAbstractScrollArea::AdjustToContents</enum>
-     </property>
-     <property name="autoScrollMargin">
-      <number>6</number>
-     </property>
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
-     </property>
-     <property name="showDropIndicator" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="dragDropOverwriteMode">
-      <bool>false</bool>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::SingleSelection</enum>
-     </property>
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
-     </property>
-     <property name="iconSize">
-      <size>
-       <width>24</width>
-       <height>24</height>
-      </size>
-     </property>
-     <property name="showGrid">
-      <bool>false</bool>
-     </property>
-     <property name="gridStyle">
-      <enum>Qt::DashLine</enum>
-     </property>
-     <property name="cornerButtonEnabled">
-      <bool>false</bool>
-     </property>
-     <attribute name="horizontalHeaderVisible">
-      <bool>false</bool>
-     </attribute>
-     <attribute name="horizontalHeaderMinimumSectionSize">
-      <number>24</number>
-     </attribute>
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-     <attribute name="verticalHeaderVisible">
-      <bool>false</bool>
-     </attribute>
-    </widget>
-   </item>
-   <item row="10" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="layFilter">
-     <item>
-      <widget class="QLineEdit" name="leFilterMask">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="placeholderText">
-        <string>Filter...</string>
-       </property>
-       <property name="clearButtonEnabled">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="cbHighlightMode">
-       <property name="text">
-        <string>Highlight Mode</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="7" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="layTypeWidth">
-     <item>
-      <widget class="QLabel" name="lType">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>40</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Type:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QG_LineTypeBox" name="cbType" native="true"/>
-     </item>
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>40</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Width:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QG_WidthBox" name="cbWidth" native="true"/>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>0</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="1" column="1">
-    <widget class="QToolButton" name="tbSettings">
-     <property name="toolTip">
-      <string>Settings</string>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="icon">
-      <iconset resource="../../res/actions/actions.qrc">
-       <normaloff>:/actions/configure.png</normaloff>:/actions/configure.png</iconset>
-     </property>
-    </widget>
-   </item>
+   <property name="horizontalSpacing">
+    <number>0</number>
+   </property>
    <item row="1" column="0">
     <layout class="QHBoxLayout" name="layButtons">
      <item>
@@ -464,6 +208,277 @@
        <property name="icon">
         <iconset resource="../../res/icons/icons.qrc">
          <normaloff>:/icons/remove.svg</normaloff>:/icons/remove.svg</iconset>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="12" column="0" colspan="2">
+    <widget class="QTableView" name="tableView">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>1</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContents</enum>
+     </property>
+     <property name="autoScrollMargin">
+      <number>6</number>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="showDropIndicator" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="dragDropOverwriteMode">
+      <bool>false</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SingleSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>24</width>
+       <height>24</height>
+      </size>
+     </property>
+     <property name="showGrid">
+      <bool>false</bool>
+     </property>
+     <property name="gridStyle">
+      <enum>Qt::DashLine</enum>
+     </property>
+     <property name="cornerButtonEnabled">
+      <bool>false</bool>
+     </property>
+     <attribute name="horizontalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="horizontalHeaderMinimumSectionSize">
+      <number>24</number>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="layTypeWidth">
+     <item>
+      <widget class="QLabel" name="lType">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>40</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Type:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QG_LineTypeBox" name="cbType" native="true"/>
+     </item>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>40</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Width:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QG_WidthBox" name="cbWidth" native="true"/>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="layPenColor">
+     <item>
+      <widget class="QLabel" name="lblName">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Pen Name:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lePenName">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>2</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="baseSize">
+        <size>
+         <width>130</width>
+         <height>22</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lColor">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>40</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Color:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QG_ColorBox" name="cbColor" native="true"/>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="8" column="0" colspan="2">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QToolButton" name="tbSettings">
+     <property name="toolTip">
+      <string>Settings</string>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="../../res/actions/actions.qrc">
+       <normaloff>:/actions/configure.png</normaloff>:/actions/configure.png</iconset>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="layFilter">
+     <item>
+      <widget class="QLineEdit" name="leFilterMask">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="placeholderText">
+        <string>Filter...</string>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="cbHighlightMode">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Highlight Mode</string>
        </property>
       </widget>
      </item>

--- a/librecad/src/ui/lc_quickinfowidget.cpp
+++ b/librecad/src/ui/lc_quickinfowidget.cpp
@@ -49,7 +49,7 @@ LC_QuickInfoWidget::LC_QuickInfoWidget(QWidget *parent, QMap<QString, QAction *>
     ui->setupUi(this);
 
     // support flexible layout for buttons and small size displays
-    auto *layButtonsFlex = new LC_FlexLayout(2, 6, 6);
+    auto *layButtonsFlex = new LC_FlexLayout(0, 5, 5);
     layButtonsFlex->fillFromLayout(ui->layToFlexible);
     int buttonsPosition = ui->horizontalLayout->indexOf(ui->layToFlexible);
     QLayoutItem *pItem = ui->horizontalLayout->takeAt(buttonsPosition);

--- a/librecad/src/ui/lc_quickinfowidget.ui
+++ b/librecad/src/ui/lc_quickinfowidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>382</width>
-    <height>237</height>
+    <width>358</width>
+    <height>234</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -47,6 +47,9 @@
     <layout class="QVBoxLayout" name="verticalLayout_2">
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="spacing">
+        <number>2</number>
+       </property>
        <item>
         <layout class="QHBoxLayout" name="layToFlexible">
          <item>
@@ -189,6 +192,12 @@
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="spacing">
+          <number>2</number>
+         </property>
+         <property name="topMargin">
+          <number>2</number>
+         </property>
          <item>
           <spacer name="horizontalSpacer">
            <property name="orientation">
@@ -256,12 +265,11 @@ p, li { white-space: pre-wrap; }
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../../res/extui/extui.qrc"/>
-  <include location="../../res/icons/icons.qrc"/>
-  <include location="../../res/icons/icons.qrc"/>
-  <include location="../../res/icons/icons.qrc"/>
   <include location="../../res/ui/ui.qrc"/>
   <include location="../../res/main/main.qrc"/>
+  <include location="../../res/icons/icons.qrc"/>
+  <include location="../../res/icons/icons.qrc"/>
+  <include location="../../res/extui/extui.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/librecad/src/ui/lc_quickinfowidget.ui
+++ b/librecad/src/ui/lc_quickinfowidget.ui
@@ -196,7 +196,7 @@
           <number>2</number>
          </property>
          <property name="topMargin">
-          <number>2</number>
+          <number>0</number>
          </property>
          <item>
           <spacer name="horizontalSpacer">

--- a/librecad/src/ui/lc_widgetfactory.cpp
+++ b/librecad/src/ui/lc_widgetfactory.cpp
@@ -64,12 +64,12 @@ LC_WidgetFactory::LC_WidgetFactory(QC_ApplicationWindow* main_win,
     , ag_manager(agm)
 {
     file_actions
-		<< a_map["FileNew"]
-		<< a_map["FileNewTemplate"]
-		<< a_map["FileOpen"]
-		<< a_map["FileSave"]
-		<< a_map["FileSaveAs"]
-		<< a_map["FileSaveAll"];
+        << a_map["FileNew"]
+        << a_map["FileNewTemplate"]
+        << a_map["FileOpen"]
+        << a_map["FileSave"]
+        << a_map["FileSaveAs"]
+        << a_map["FileSaveAll"];
     line_actions
         << a_map["DrawLine"]
         << a_map["DrawLineAngle"]
@@ -337,8 +337,9 @@ void LC_WidgetFactory::createRightSidebar(QG_ActionHandler* action_handler)
     if (usePenPallet()) {
         dock_pen_palette = new QDockWidget(main_window);
         dock_pen_palette->setWindowTitle(QC_ApplicationWindow::tr("Pen Palette"));
+        dock_pen_palette->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
         dock_pen_palette->setObjectName("pen_palette_dockwidget");
-        pen_palette = new LC_PenPaletteWidget("Layer", dock_pen_palette);
+        pen_palette = new LC_PenPaletteWidget("PenPalette", dock_pen_palette);
         pen_palette->setFocusPolicy(Qt::NoFocus);
         connect(pen_palette, SIGNAL(escape()), main_window, SLOT(slotFocus()));
         connect(main_window, SIGNAL(windowsChanged(bool)), pen_palette, SLOT(setEnabled(bool)));
@@ -359,6 +360,7 @@ void LC_WidgetFactory::createRightSidebar(QG_ActionHandler* action_handler)
         dock_layer_tree = new QDockWidget(main_window);
         dock_layer_tree->setWindowTitle(QC_ApplicationWindow::tr("Layer Tree"));
         dock_layer_tree->setObjectName("layer_tree_dockwidget");
+        dock_layer_tree->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
         layer_tree_widget = new LC_LayerTreeWidget(action_handler, dock_layer_tree, "Layer Tree");
         layer_tree_widget->setFocusPolicy(Qt::NoFocus);
         connect(layer_tree_widget, SIGNAL(escape()), main_window, SLOT(slotFocus()));
@@ -406,11 +408,11 @@ void LC_WidgetFactory::createRightSidebar(QG_ActionHandler* action_handler)
     dock_library->resize(240, 400);
 
     QDockWidget* dock_command = new QDockWidget(tr("Command line"), main_window);
-    dock_command->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
+    // dock_command->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
     dock_command->setObjectName("command_dockwidget");
     command_widget = new QG_CommandWidget(dock_command, "Command");
     command_widget->setActionHandler(action_handler);
-    command_widget->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
+    // command_widget->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
     connect(main_window, SIGNAL(windowsChanged(bool)), command_widget, SLOT(setEnabled(bool)));
     connect(command_widget->leCommand, SIGNAL(escape()), main_window, SLOT(setFocus()));
     dock_command->setWidget(command_widget);

--- a/librecad/src/ui/qg_blockwidget.cpp
+++ b/librecad/src/ui/qg_blockwidget.cpp
@@ -37,6 +37,7 @@
 #include <QLineEdit>
 #include <QContextMenuEvent>
 
+#include "lc_flexlayout.h"
 #include "qg_actionhandler.h"
 #include "qg_blockwidget.h"
 #include "rs_blocklist.h"
@@ -152,77 +153,80 @@ QG_BlockWidget::QG_BlockWidget(QG_ActionHandler* ah, QWidget* parent,
     blockView->horizontalHeader()->hide();
 
     QVBoxLayout* lay = new QVBoxLayout(this);
-    lay->setSpacing ( 0 );
+    lay->setSpacing ( 2 );
     lay->setContentsMargins(2, 2, 2, 2);
 
-    QHBoxLayout* layButtons = new QHBoxLayout();
-    QHBoxLayout* layButtons2 = new QHBoxLayout();
+    auto *layButtons = new LC_FlexLayout(0,5,5);
+
+    // QHBoxLayout* layButtons = new QHBoxLayout();
+    // QHBoxLayout* layButtons2 = new QHBoxLayout();
     QToolButton* but;
     const QSize button_size(28,28);
     // show all blocks:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/visible.svg"));
-    but->setMinimumSize(button_size);
+    // but->setMinimumSize(button_size);
     but->setToolTip(tr("Show all blocks"));
     connect(but, &QToolButton::clicked, actionHandler, &QG_ActionHandler::slotBlocksDefreezeAll);
     layButtons->addWidget(but);
     // hide all blocks:
     but = new QToolButton(this);
     but->setIcon( QIcon(":/icons/invisible.svg") );
-    but->setMinimumSize(button_size);
+    // but->setMinimumSize(button_size);
     but->setToolTip(tr("Hide all blocks"));
     connect(but, &QToolButton::clicked, actionHandler, &QG_ActionHandler::slotBlocksFreezeAll);
     layButtons->addWidget(but);
     // create block:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/create_block.svg"));
-    but->setMinimumSize(button_size);
+    // but->setMinimumSize(button_size);
     but->setToolTip(tr("Create Block"));
     connect(but, &QToolButton::clicked, actionHandler, &QG_ActionHandler::slotBlocksCreate);
     layButtons->addWidget(but);
     // add block:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/add.svg"));
-    but->setMinimumSize(button_size);
+    // but->setMinimumSize(button_size);
     but->setToolTip(tr("Add an empty block"));
     connect(but, &QToolButton::clicked, actionHandler, &QG_ActionHandler::slotBlocksAdd);
     layButtons->addWidget(but);
     // remove block:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/remove.svg"));
-    but->setMinimumSize(button_size);
+    // but->setMinimumSize(button_size);
     but->setToolTip(tr("Remove block"));
     connect(but, &QToolButton::clicked, actionHandler, &QG_ActionHandler::slotBlocksRemove);
     layButtons->addWidget(but);
     // edit attributes:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/rename_active_block.svg"));
-    but->setMinimumSize(button_size);
+    // but->setMinimumSize(button_size);
     but->setToolTip(tr("Rename the active block"));
     connect(but, &QToolButton::clicked, actionHandler, &QG_ActionHandler::slotBlocksAttributes);
-    layButtons2->addWidget(but);
+      // layButtons2->addWidget(but);
+    layButtons->addWidget(but);
     // edit block:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/properties.svg"));
-    but->setMinimumSize(button_size);
+    // but->setMinimumSize(button_size);
     but->setToolTip(tr("Edit the active block\n"
                           "in a separate window"));
     connect(but, &QToolButton::clicked, actionHandler, &QG_ActionHandler::slotBlocksEdit);
-    layButtons2->addWidget(but);
+    layButtons->addWidget(but);
     // save block:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/save.svg"));
-    but->setMinimumSize(button_size);
+    // but->setMinimumSize(button_size);
     but->setToolTip(tr("save the active block to a file"));
     connect(but, &QToolButton::clicked, actionHandler, &QG_ActionHandler::slotBlocksSave);
-    layButtons2->addWidget(but);
+    layButtons->addWidget(but);
     // insert block:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/insert_active_block.svg"));
-    but->setMinimumSize(button_size);
+    // but->setMinimumSize(button_size);
     but->setToolTip(tr("Insert the active block"));
     connect(but, &QToolButton::clicked, actionHandler, &QG_ActionHandler::slotBlocksInsert);
-    layButtons2->addWidget(but);
+    layButtons->addWidget(but);
 
     // lineEdit to filter block list with RegEx
     matchBlockName = new QLineEdit(this);
@@ -234,7 +238,7 @@ QG_BlockWidget::QG_BlockWidget(QG_ActionHandler* ah, QWidget* parent,
 
     lay->addWidget(matchBlockName);
     lay->addLayout(layButtons);
-    lay->addLayout(layButtons2);
+    // lay->addLayout(layButtons2);
     lay->addWidget(blockView);
 
     connect(blockView, &QTableView::clicked, this, &QG_BlockWidget::slotActivated);

--- a/librecad/src/ui/qg_layerwidget.cpp
+++ b/librecad/src/ui/qg_layerwidget.cpp
@@ -206,7 +206,8 @@ QG_LayerWidget::QG_LayerWidget(QG_ActionHandler* ah, QWidget* parent,
     layerView->setSelectionMode(QAbstractItemView::ExtendedSelection);
     layerView->setEditTriggers(QAbstractItemView::NoEditTriggers);
     layerView->setFocusPolicy(Qt::NoFocus);
-    layerView->setMinimumHeight(140);
+    // layerView->setMinimumHeight(140);
+    layerView->setMinimumHeight(60);
     QHeaderView *pHeader {layerView->horizontalHeader()};
     pHeader->setMinimumSectionSize( QG_LayerModel::ICONWIDTH + 4);
     pHeader->setStretchLastSection(true);

--- a/librecad/src/ui/qg_layerwidget.cpp
+++ b/librecad/src/ui/qg_layerwidget.cpp
@@ -229,49 +229,49 @@ QG_LayerWidget::QG_LayerWidget(QG_ActionHandler* ah, QWidget* parent,
     // show all layer:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/visible.svg"));
-    but->setMinimumSize(minButSize);
+    // but->setMinimumSize(minButSize);
     but->setToolTip(tr("Show all layers"));
     connect(but, &QToolButton::clicked, actionHandler, &QG_ActionHandler::slotLayersDefreezeAll);
     layButtons->addWidget(but);
     // hide all layer:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/invisible.svg"));
-    but->setMinimumSize(minButSize);
+    // but->setMinimumSize(minButSize);
     but->setToolTip(tr("Hide all layers"));
     connect(but, &QToolButton::clicked, actionHandler, &QG_ActionHandler::slotLayersFreezeAll);
     layButtons->addWidget(but);
     // unlock all layers:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/unlocked.svg"));
-    but->setMinimumSize(minButSize);
+    // but->setMinimumSize(minButSize);
     but->setToolTip(tr("Unlock all layers"));
     connect(but, &QToolButton::clicked, actionHandler, &QG_ActionHandler::slotLayersUnlockAll);
     layButtons->addWidget(but);
     // lock all layers:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/locked.svg"));
-    but->setMinimumSize(minButSize);
+    // but->setMinimumSize(minButSize);
     but->setToolTip(tr("Lock all layers"));
     connect(but, &QToolButton::clicked, actionHandler, &QG_ActionHandler::slotLayersLockAll);
     layButtons->addWidget(but);
     // add layer:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/add.svg"));
-    but->setMinimumSize(minButSize);
+    // but->setMinimumSize(minButSize);
     but->setToolTip(tr("Add a layer"));
     connect(but, &QToolButton::clicked, actionHandler, &QG_ActionHandler::slotLayersAdd);
     layButtons->addWidget(but);
     // remove layer:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/remove.svg"));
-    but->setMinimumSize(minButSize);
+    // but->setMinimumSize(minButSize);
     but->setToolTip(tr("Remove layer"));
     connect(but, &QToolButton::clicked, actionHandler, &QG_ActionHandler::slotLayersRemove);
     layButtons->addWidget(but);
     // rename layer:
     but = new QToolButton(this);
     but->setIcon(QIcon(":/icons/rename_active_block.svg"));
-    but->setMinimumSize(minButSize);
+    // but->setMinimumSize(minButSize);
     but->setToolTip(tr("Modify layer attributes / rename"));
     connect(but, &QToolButton::clicked, actionHandler, &QG_ActionHandler::slotLayersEdit);
     layButtons->addWidget(but);


### PR DESCRIPTION
This pull request addresses #1805   - plus, adds some polishing for other widgets. 

In my environment, it seems that now widgets are located and resizing more nicely, yet probably it will be necessary to get more feedback from  users, I suspect that the overall operations of docking widgets works under QT6 with some subtle differences comparing to QT5.