### PR TITLE
Set Dark splash for 'alpha'

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -38,6 +38,13 @@ jobs:
         run: |
           sudo apt-get -qq install clang-10 clang-tools-10
 
+      - name: Set Dark splash
+        # Test setting dark splash screen for `2.2.2_alpha`
+        # Comment this if `master` is used for releases
+        if: github.ref == 'refs/heads/master'
+        run: |
+          cp ${{github.workspace}}/desktop/media/splash/librecad01_dark.png ${{github.workspace}}/librecad/res/main/splash_librecad.png
+
       - name: Build and analyze
         run: |
           export CC=g++
@@ -64,7 +71,7 @@ jobs:
           github_token: ${{ secrets.LC_PUSH_ANALYZER_REPORT }}
           branch: gh-pages
           force: true
-          directory: out
+          directory: out        
 
       - name: Create AppImage
         run: |

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -71,7 +71,7 @@ jobs:
           github_token: ${{ secrets.LC_PUSH_ANALYZER_REPORT }}
           branch: gh-pages
           force: true
-          directory: out        
+          directory: out
 
       - name: Create AppImage
         run: |


### PR DESCRIPTION
Set different splash for `2.2.2_alpha` (actually only for AppImage / Linux).

Edit Windows / Mac OS workflows to apply this too.