### PR TITLE
Introducing LibreCAD Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LibreCAD [![Build Status](https://travis-ci.org/LibreCAD/LibreCAD.svg?branch=master)](https://travis-ci.org/LibreCAD/LibreCAD) 
+# LibreCAD [![Build Status](https://travis-ci.org/LibreCAD/LibreCAD.svg?branch=master)](https://travis-ci.org/LibreCAD/LibreCAD) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20LibreCAD%20Guru-006BFF)](https://gurubase.io/g/librecad)
 
 [→ Download ←](https://github.com/LibreCAD/LibreCAD/wiki/Download)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LibreCAD [![Build Status](https://travis-ci.org/LibreCAD/LibreCAD.svg?branch=master)](https://travis-ci.org/LibreCAD/LibreCAD) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20LibreCAD%20Guru-006BFF)](https://gurubase.io/g/librecad)
+# LibreCAD [![Build Status](https://travis-ci.org/LibreCAD/LibreCAD.svg?branch=master)](https://travis-ci.org/LibreCAD/LibreCAD)
 
 [→ Download ←](https://github.com/LibreCAD/LibreCAD/wiki/Download)
 
@@ -50,6 +50,7 @@ $ librecad dxf2svg foo.dxf
 
 - [LibreCAD's Forum](https://forum.librecad.org/)
 - IRC: [#librecad](https://web.libera.chat/#librecad) at libera.chat
+- [Ask LibreCAD Guru](https://gurubase.io/g/librecad), it is a LibreCAD-focused AI to answer your questions.
 
 **Building**
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [LibreCAD Guru](https://gurubase.io/g/librecad) to Gurubase. LibreCAD Guru uses the data from this repo and data from the [docs](https://docs.librecad.org/en/2.2.0_a/) to answer questions by leveraging the LLM.

In this PR, I showcased the "LibreCAD Guru", which highlights that LibreCAD now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable LibreCAD Guru in Gurubase, just let me know that's totally fine.
