### PR TITLE
Update build-appimg.sh

### DIFF
--- a/CI/build-appimg.sh
+++ b/CI/build-appimg.sh
@@ -35,16 +35,16 @@ mkdir -p appdir/usr/share/metainfo
 mkdir -p appdir/usr/share/doc/librecad
 mkdir -p appdir/usr/share/icons/hicolor/256x256/apps
 mkdir -p appdir/usr/share/icons/hicolor/scalable/apps
-mkdir -p appdir/usr/share/librecad
+mkdir -p appdir/usr/share/librecad/qm
 
 # strip binaries
 strip unix/librecad
-strip unix/resources/plugins/*.so
+strip unix/resources/plugins/*/*.so
 
 # copy executables and binary resources
 cp unix/librecad appdir/usr/bin/
-cp unix/resources/plugins/*.so appdir/usr/lib/librecad/
-cp -r unix/resources/qm appdir/usr/share/librecad/
+cp unix/resources/plugins/*/*.so appdir/usr/lib/librecad/
+cp -r unix/*.qm appdir/usr/share/librecad/qm/
 
 cp desktop/librecad.desktop appdir/usr/share/applications/
 cp desktop/org.librecad.librecad.appdata.xml appdir/usr/share/metainfo/


### PR DESCRIPTION
Next commands bundled nothing to AppImage

```
cp unix/resources/plugins/*.so appdir/usr/lib/librecad/
cp -r unix/resources/qm appdir/usr/share/librecad/
```

From CI log (https://github.com/LibreCAD/LibreCAD/actions/runs/14540989853/job/40798788196), 

- *.qm files located in `unix/*.qm`, not in `unix/resources/qm`?
```
2025-04-18T20:01:26.7974926Z Updating '/home/runner/work/LibreCAD/LibreCAD/unix/librecad_tr.qm'...
2025-04-18T20:01:26.8141273Z Updating '/home/runner/work/LibreCAD/LibreCAD/unix/librecad_uk.qm'...
2025-04-18T20:01:26.8200334Z Updating '/home/runner/work/LibreCAD/LibreCAD/unix/librecad_zh_cn.qm'...
```

- its not clear where are  plugins *.so located, and so nothing copied
```
2025-04-18T20:07:56.8675329Z + strip 'unix/resources/plugins/*.so'
2025-04-18T20:07:56.8688868Z strip: 'unix/resources/plugins/*.so': No such file
2025-04-18T20:07:56.8691342Z + cp unix/librecad appdir/usr/bin/
2025-04-18T20:07:56.8834834Z + cp 'unix/resources/plugins/*.so' appdir/usr/lib/librecad/
2025-04-18T20:07:56.8848304Z cp: cannot stat 'unix/resources/plugins/*.so': No such file or directory
2025-04-18T20:07:56.8850434Z + cp -r unix/resources/qm appdir/usr/share/librecad/
2025-04-18T20:07:56.8862185Z cp: cannot stat 'unix/resources/qm': No such file or directory
```

- fonts/library/patterns copied, but LibreCAD does not see them
```
2025-04-18T20:07:56.8907995Z + cp -r librecad/support/fonts appdir/usr/share/librecad/
2025-04-18T20:07:56.9118611Z + cp -r librecad/support/library appdir/usr/share/librecad/
2025-04-18T20:07:56.9734447Z + cp -r librecad/support/patterns appdir/usr/share/librecad/
```

File `../AppRun` **not configured for use bundled** `fonts/library/patterns` paths?
Or CMake issue flags issue?

Also, I has installed LibreCAD 2.2.1 via DEB-package system wide, so there are files on PC

- /usr/share/librecad/library/../*.dxf
- /usr/share/librecad/patterns/../*.dxf
- /usr/share/librecad/fonts/*.lff
- /usr/lib/librecad/*.so
- /usr/share/librecad/plugins/*.so
- /usr/share/librecad/qm/*.qm

But AppImage not see these system wide files too.

And if extract appimge and try to run AppRun it fails

```
$ ./LibreCAD-2.2.2_alpha1-394-g522ec60a8.AppImage --appimage-extract
$ ./squashfs-root/AppRun
./squashfs-root/AppRun: 101: exec: ./squashfs-root/usr/lib64/ld-linux-x86-64.so.2: Permission denied
```