### PR TITLE
Add global Shift+Spacebar keyboard shortcut

### DIFF
--- a/librecad/src/ui/forms/qg_commandwidget.cpp
+++ b/librecad/src/ui/forms/qg_commandwidget.cpp
@@ -32,6 +32,7 @@
 #include <QKeyEvent>
 #include <QFileDialog>
 #include <QSettings>
+#include <QShortcut>
 
 #include "lc_application.h"
 #include "qc_applicationwindow.h"
@@ -53,6 +54,7 @@ QG_CommandWidget::QG_CommandWidget(QWidget* parent, const char* name, Qt::Window
 {
     setObjectName(name);
     setupUi(this);
+    m_globalShortcut = new QShortcut(QKeySequence(Qt::SHIFT + Qt::Key_Space), this, SLOT(setFocus()));
     connect(leCommand, SIGNAL(command(QString)), this, SLOT(handleCommand(QString)));
     connect(leCommand, SIGNAL(escape()), this, SLOT(escape()));
     connect(leCommand, SIGNAL(focusOut()), this, SLOT(setNormalMode()));
@@ -104,6 +106,9 @@ QG_CommandWidget::~QG_CommandWidget()
     QSettings settings;
     auto action = findChild<QAction*>("keycode_action");
     settings.setValue("Widgets/KeycodeMode", action->isChecked());
+    if (m_globalShortcut) {
+        delete m_globalShortcut;
+    }
 }
 
 /*

--- a/librecad/src/ui/forms/qg_commandwidget.h
+++ b/librecad/src/ui/forms/qg_commandwidget.h
@@ -29,6 +29,7 @@
 #include "ui_qg_commandwidget.h"
 class QG_ActionHandler;
 class QAction;
+class QShortcut;
 
 class QG_CommandWidget : public QWidget, public Ui::QG_CommandWidget
 {
@@ -68,6 +69,7 @@ private slots:
 private:
     QG_ActionHandler* actionHandler = nullptr;
     QAction* m_docking = nullptr;
+    QShortcut* m_globalShortcut = nullptr;
 };
 
 #endif // QG_COMMANDWIDGET_H


### PR DESCRIPTION
In some situation the focus of the application is sticky which breaks the keyboard entry of commands. The typical example is setting the line type or width. The line selection drop down will hold the focus so the user is forced to activate the command widget with the mouse. With this change it's possible to activate the command widget in all cases by pressing Shift + Spacebar