### PR TITLE
Fix print to pdf issue

### DIFF
--- a/librecad/src/lib/gui/lc_graphicviewport.cpp
+++ b/librecad/src/lib/gui/lc_graphicviewport.cpp
@@ -719,7 +719,7 @@ void LC_GraphicViewport::setOffsetAndFactor(int ox, int oy, double f){
 }
 
 void LC_GraphicViewport::justSetOffsetAndFactor(int ox, int oy, double f){
-    offsetY = ox;
+    offsetX = ox;
     offsetY = oy;
     factor.x = std::abs(f);
     factor.y = std::abs(f);


### PR DESCRIPTION
Currently, printing a drawing not at origin to pdf results in blank white pages. This is because the coordinate assigned during printing is wrong, and is set to 0. This fixes the code typo when assigning coordinate.