### PR TITLE
added closing tag for the bash build.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ To build unit tests (e.g., for `rs_math.cpp`), enable the `BUILD_TESTS` flag:
 cmake -DBUILD_TESTS=ON ..
 make
 ./build/librecad_tests
+```
 
 **Contributing**
 


### PR DESCRIPTION
Hi.

Quick typo fix for the read me. I noticed it had a broken bash code example with a missing closing tag.

have a nice day !