### PR TITLE
CI: Add support for building LibreCAD binaries for windows arm64

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -311,12 +311,12 @@ jobs:
       - name: Install Qt6
         uses: jurplel/install-qt-action@v4
         with:
-          version: '6.9.*'
-          host: 'windows'
-          arch: 'win64_msvc2022_arm64_cross_compiled'
+          version: '6.10.*'
+          host: 'windows_arm64'
+          arch: 'win64_msvc2022_arm64'
           target: 'desktop'
           tools-only: 'false'
-          modules: 'qt3d qt5compat qtimageformats qtshadertools'
+          modules: 'qt5compat qtimageformats qtshadertools'
           tools: 'tools_cmake'
 
       - name: (3) Add MSBuild to PATH

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -298,9 +298,101 @@ jobs:
           path: LibreCAD*.exe
           retention-days: 2
 
+  BuildWindowsARM64:
+    runs-on: windows-11-arm
+    outputs:
+      output1: ${{ steps.artifact-upload-step.outputs.artifact-id }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+
+      - name: Install Qt6
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.9.*'
+          host: 'windows'
+          arch: 'win64_msvc2022_arm64_cross_compiled'
+          target: 'desktop'
+          tools-only: 'false'
+          modules: 'qt3d qt5compat qtimageformats qtshadertools'
+          tools: 'tools_cmake'
+
+      - name: (3) Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: arm64
+
+      - name: Install boost
+        run: |
+          curl -# -L -o boost.7z https://archives.boost.io/release/1.87.0/source/boost_1_87_0.7z
+          7z x -o. -y boost.7z
+          mkdir -p boost/include
+          mv boost_1_87_0/boost boost/include/
+          rm boost.7z
+          pwd
+          ls -ld boost/include/boost/version.hpp
+        shell: bash
+
+      - name: Configure CMake
+        run: |
+          cmake.exe -S . -B generated -G "Visual Studio 17 2022" -DBoost_INCLUDE_DIR=%BOOST_ROOT%/include -DBoost_LIBRARY_DIRS=%BOOST_ROOT%/lib 
+        shell: cmd
+        env:
+          BUILD_TYPE: release
+          MSVC_VER_NUMBER: "Visual Studio 17 2022"
+          BOOST_ROOT: boost
+          CMAKE_CXX_FLAGS: " /MP8"
+
+      - name: Build
+        run: |
+          cmake --build generated --config Release
+        shell: cmd
+
+      - name: listFile
+        run: |
+          cd generated
+          dir *.*
+          dir Release\*.*
+          dir ARM64\*.*
+        shell: cmd
+
+      - name: List files
+        run: |
+            echo "${{ github.workspace }}"
+            dir "${{ github.workspace }}"
+        shell: cmd
+
+      - name: winDeployment
+        run: |
+          copy CI\custom-win.pri custom.pri
+          copy CI\custom-win-ARM64.nsh scripts\postprocess-windows\custom.nsh
+          mkdir generated\plugins
+          for /r %%a in (*.dll) do copy "%%a" generated\plugins
+          cd generated
+          windeployqt6.exe --release --compiler-runtime Release\LibreCAD.exe
+          dir *.*
+          pushd "${{ github.workspace }}\scripts"
+          call build-win-setup.bat
+        shell: cmd
+        
+      - name: Rename installer
+        run: |
+          mv LibreCAD-Installer.exe LibreCAD-`git describe --always`-winARM64.exe
+        shell: bash
+
+      - name: Upload artifact
+        id: artifact-upload-step
+        uses: actions/upload-artifact@main
+        with:
+          name: winARM64Assets
+          path: LibreCAD*.exe
+          retention-days: 2
+
   UpdateAssets:
     if: github.repository_owner == 'LibreCAD'
-    needs: [BuildLinux, BuildLinuxAarch64, BuildMacOS, BuildWindows64, BuildSnap]
+    needs: [BuildLinux, BuildLinuxAarch64, BuildMacOS, BuildWindows64, BuildWindowsARM64, BuildSnap]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -328,5 +420,6 @@ jobs:
             linuxAssetsAarch64/LibreCAD*.AppImage
             macOSAssets/LibreCAD*.dmg
             win64Assets/LibreCAD*.exe
+            winARM64Assets/LibreCAD*.exe
             snapAssets/LibreCAD*.snap
             LICENSE

--- a/CI/custom-win-ARM64.nsh
+++ b/CI/custom-win-ARM64.nsh
@@ -1,0 +1,9 @@
+;local settings
+
+!define Qt_Dir 	"D:\a\LibreCAD\Qt"
+!define Qt_Version 	"6.9.0"
+!define Mingw_Ver 	"mingw_64"
+!define InstallerName 	"LibreCAD-Installer"
+!define ProgramsFolder 	"$PROGRAMFILES64"
+!define AppKeyName 	"LibreCADARM64"
+!define AppName	"LibreCAD (ARM64)"


### PR DESCRIPTION
PR Description:

* The adoption of Windows on ARM (WoA) devices is steadily increasing, yet many applications are still not available for this platform.
* GitHub Actions now offer native CI runners for Windows on ARM devices (windows-11-arm), enabling automated builds and testing.
* Currently, official LibreCAD application are not provided for Windows ARM64 and thus users/developers were facing difficulties using popular LibreCAD library natively.
* This PR introduces support for building LibreCAD on Windows ARM64, improving accessibility for developers and end users on this emerging platform.

Note: The generated packages are validated with basic functionality on a local windows arm64 device setup. Working fine as expected and natively on windows arm64 device