### PR TITLE
drw_entities: add missing return in DRW_Tolerance::parseCode()

### DIFF
--- a/libraries/libdxfrw/src/drw_entities.cpp
+++ b/libraries/libdxfrw/src/drw_entities.cpp
@@ -1162,6 +1162,7 @@ bool DRW_Tolerance::parseCode(int code, dxfReader* reader) {
         default:
             return DRW_Entity::parseCode(code, reader);
     }
+    return true;
 }
 
 bool DRW_Tolerance::parseDwg(DRW::Version v, dwgBuffer* buf, duint32 bs) {


### PR DESCRIPTION
The below commit added DRW_Tolerance::parseCode() without actually returning anything from all except the default case. Return `true` in that case.

The compiler correctly complains:
```
src/drw_entities.cpp:1165:1: error: control reaches end of non-void function [-Werror=return-type]
```

Fixes: 944e6340fe5a (Ordinate Dimensions (#2131))

Noted there:
https://github.com/LibreCAD/LibreCAD/commit/944e6340fe5a1e17a4e44d9de25c78131bfb4cb5#r164908446