### PR TITLE
Issue #2069: dlgmtext default to unicode fonts

### DIFF
--- a/librecad/src/ui/forms/qg_dlgmtext.cpp
+++ b/librecad/src/ui/forms/qg_dlgmtext.cpp
@@ -58,11 +58,7 @@ QG_DlgMText::QG_DlgMText(QWidget* parent, bool modal, Qt::WindowFlags fl)
 /*
  *  Destroys the object and frees any allocated resources
  */
-QG_DlgMText::~QG_DlgMText()
-{
-    destroy();
-    // no need to delete child widgets, Qt does it all for us
-}
+QG_DlgMText::~QG_DlgMText() = default;
 
 /*
  *  Sets the strings of the subwidgets using the current
@@ -125,7 +121,7 @@ void QG_DlgMText::updateUniCharComboBox(int) {
 
     cbUniChar->clear();
     for (int c=min; c<=max; c++) {
-        char buf[5];
+        char buf[5] = {};
         snprintf(buf,5, "%04X", c);
         cbUniChar->addItem(QString("[%1] %2").arg(buf).arg(QChar(c)));
     }
@@ -369,7 +365,13 @@ int QG_DlgMText::getAlignment() {
 }
 
 void QG_DlgMText::setFont(const QString& f) {
-    cbFont->setCurrentIndex( cbFont->findText(f) );
+    int index = cbFont->findText(f);
+
+    // Issue #2069: default to unicode fonts
+    if (index == -1)
+        index = cbFont->findText("unicode");
+    if (index >= 0)
+        cbFont->setCurrentIndex(index);
     font = cbFont->getFont();
     defaultChanged(false);
 }
@@ -460,4 +462,3 @@ bool QG_DlgMText::eventFilter(QObject *obj, QEvent *event) {
     }
     return false;
 }
-

--- a/librecad/src/ui/forms/qg_dlgmtext.cpp
+++ b/librecad/src/ui/forms/qg_dlgmtext.cpp
@@ -58,7 +58,11 @@ QG_DlgMText::QG_DlgMText(QWidget* parent, bool modal, Qt::WindowFlags fl)
 /*
  *  Destroys the object and frees any allocated resources
  */
-QG_DlgMText::~QG_DlgMText() = default;
+QG_DlgMText::~QG_DlgMText()
+{
+    destroy();
+    // no need to delete child widgets, Qt does it all for us
+}
 
 /*
  *  Sets the strings of the subwidgets using the current

--- a/librecad/src/ui/forms/qg_dlgmtext.h
+++ b/librecad/src/ui/forms/qg_dlgmtext.h
@@ -35,7 +35,7 @@ class QG_DlgMText : public QDialog, public Ui::QG_DlgMText
 
 public:
     QG_DlgMText(QWidget* parent = 0, bool modal = false, Qt::WindowFlags fl = {});
-    ~QG_DlgMText();
+    ~QG_DlgMText() override;
 
     virtual int getAlignment();
 

--- a/librecad/src/ui/forms/qg_dlgtext.cpp
+++ b/librecad/src/ui/forms/qg_dlgtext.cpp
@@ -425,7 +425,12 @@ int QG_DlgText::getAlignment() {
 }
 
 void QG_DlgText::setFont(const QString& f) {
-    cbFont->setCurrentIndex( cbFont->findText(f) );
+   int index = cbFont->findText(f);
+    // Issue #2069: default to unicode fonts
+    if (index == -1)
+        index = cbFont->findText("unicode");
+    if (index >= 0)
+        cbFont->setCurrentIndex(index);
     font = cbFont->getFont();
 //    defaultChanged(false);
 }
@@ -494,4 +499,3 @@ void QG_DlgText::insertChar() {
 //    teText->textCursor().insertText( QString("%1").arg(QChar(c)) );
     teText->insert( QString("%1").arg(QChar(c)) );
 }
-


### PR DESCRIPTION
avoid invalid fonts in dlgmtext