### PR TITLE
Issue #2306: added license.qrc to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,12 +268,13 @@ include_directories(librecad/src/plugins/intern)
 include_directories(librecad/src/test)
 
 set(SOURCES
-        librecad/res/arrows/arrows.qrc
-        librecad/res/images/images.qrc
-        librecad/res/controls/controls.qrc
-        librecad/res/icons/icons.qrc
-        librecad/res/gdt/gdt.qrc
-        librecad/res/dxf/dxf.qrc
+       librecad/res/icons/icons.qrc
+       librecad/res/controls/controls.qrc
+       librecad/res/images/images.qrc
+       librecad/res/arrows/arrows.qrc
+       librecad/res/dxf/dxf.qrc
+       librecad/res/gdt/gdt.qrc
+       licenses/licenses.qrc
         libraries/jwwlib/src/dl_attributes.h
         libraries/jwwlib/src/dl_codes.h
         libraries/jwwlib/src/dl_creationinterface.h


### PR DESCRIPTION
The root cause: missing resources files causes LC_AppWindowDialogsInvoker::showLicenseWindow() to crash due to missing files from qrc resources. The files are missing, because the relevant qrc resource file is not added to src.pro

The fix: add the licenses.qrc into the cmakelists.txt