### PR TITLE
Plugins: Gear module - add parameter's name

### DIFF
--- a/plugins/gear/gear.cpp
+++ b/plugins/gear/gear.cpp
@@ -45,7 +45,7 @@ void LC_Gear::execComm([[maybe_unused]] Document_Interface *doc,
                         QWidget *parent, [[maybe_unused]] QString cmd)
 {
     QPointF center;
-    if (!doc->getPoint(&center, QString("select center"))) {
+    if (!doc->getPoint(&center, tr("Select center of gear"))) {
         return;
     }
 
@@ -67,9 +67,7 @@ lc_Geardlg::lc_Geardlg(QWidget *parent) :
     QDialog(parent),
     settings(QSettings::IniFormat, QSettings::UserScope, "LibreCAD", "gear_plugin")
 {
-    const char *windowTitle = "Draw a gear";
-
-    setWindowTitle(tr(windowTitle));
+    setWindowTitle(tr("Option for gear (ISO 1328)"));
 
     QLabel *label;
     QGridLayout *mainLayout = new QGridLayout(this);


### PR DESCRIPTION
Add parameter's name.
Add limits for ISO 1328-1:2013:

5 ≤ z ≤ 1 000
5 mm ≤ d ≤ 15 000 mm
0,5 mm ≤ mn ≤ 70 mm
4 mm ≤ b ≤ 1 200 mm
β ≤ 45°