### PR TITLE
Compilation warning on main.cpp

### DIFF
--- a/librecad/src/main/main.cpp
+++ b/librecad/src/main/main.cpp
@@ -247,8 +247,14 @@ int main(int argc, char** argv) {
 
 #    else
 
-    QT_REQUIRE_VERSION(argc, argv, "6.4");
-
+    // Create compilater's error: this QT macros may be in .pro file only.
+    //QT_REQUIRE_VERSION(argc, argv, "6.4");
+    
+    // May be this code must be on begin of main.cpp?
+    #if QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
+        #error "This programm requires Qt6 ver.6.4.0 or higher."
+    #endif
+    
     // Check first two arguments in order to decide if we want to run librecad
     // as console dxf2pdf or dxf2png tools. On Linux we can create a link to
     // librecad executable and  name it dxf2pdf. So, we can run either:


### PR DESCRIPTION
Qt macros in .cpp file create compilator's warning: QT_REQUIRE_VERSION can be in .pro file only.