### PR TITLE
feat: show the command next to menu item

### DIFF
--- a/librecad/src/cmd/rs_commands.cpp
+++ b/librecad/src/cmd/rs_commands.cpp
@@ -438,6 +438,24 @@ QString RS_Commands::command(const QString& cmd) {
 
 
 
+QStringList RS_Commands::aliasesForAction(RS2::ActionType a) const {
+    QStringList res;
+    for (auto const& p : m_shortCommands) {
+        if (p.second == a) {
+            res << p.first;
+        }
+    }
+    auto it = m_actionToCommand.find(a);
+    if (it != m_actionToCommand.end()) {
+        // ensure main command present and first
+        if (!it->second.isEmpty() && !res.contains(it->second)) {
+            res.prepend(it->second);
+        }
+    }
+    return res;
+}
+
+
 /**
  * Checks if the given string 'str' matches the given command 'cmd' for action
  * 'action'.

--- a/librecad/src/cmd/rs_commands.h
+++ b/librecad/src/cmd/rs_commands.h
@@ -61,6 +61,8 @@ public:
     RS2::ActionType cmdToAction(const QString& cmd, bool verbose = true) const;
     RS2::ActionType keycodeToAction(const QString& code) const;
 
+    QStringList aliasesForAction(RS2::ActionType a) const;
+
     static QString command(const QString& cmd);
 
     static bool checkCommand(const QString& cmd, const QString& str,

--- a/librecad/src/ui/actions/lc_actionfactorybase.cpp
+++ b/librecad/src/ui/actions/lc_actionfactorybase.cpp
@@ -28,6 +28,7 @@
 #include "lc_shortcutinfo.h"
 #include "qc_applicationwindow.h"
 #include "qg_actionhandler.h"
+#include "rs_commands.h"
 
 LC_ActionFactoryBase::LC_ActionFactoryBase(QC_ApplicationWindow* parent, QG_ActionHandler* a_handler):
     QObject(parent), LC_AppWindowAware(parent),m_actionHandler(a_handler){
@@ -60,11 +61,14 @@ QAction * LC_ActionFactoryBase::createAction_AH(const char* name, RS2::ActionTyp
                                             QActionGroup *parent,
                                             QMap<QString, QAction *> &a_map) const{
     QAction *action = justCreateAction(a_map, name, text, iconName, themeIconName, parent);
-    // LC_ERR <<  " ** original action handler" << this->action_handler;
+    // Use the first command alias as the object name when available
+    QStringList aliases = RS_COMMANDS->aliasesForAction(actionType);
+    if (!aliases.isEmpty()) {
+        action->setObjectName(aliases.first());
+    }
     // well, a bit crazy hacky code to let the lambda properly capture action handler... without local var, class member is not captured
     QG_ActionHandler* capturedHandler = m_actionHandler;
     connect(action, &QAction::triggered, capturedHandler, [ capturedHandler, actionType](bool){ // fixme - sand - simplify by using data() on QAction and sender()
-        // LC_ERR << " ++ captured action handler "<<   capturedHandler;
         capturedHandler->setCurrentAction(actionType);
     });
     LC_ActionGroupManager::associateQActionWithActionType(action, actionType);

--- a/librecad/src/ui/dialogs/settings/options_general/qg_dlgoptionsgeneral.cpp
+++ b/librecad/src/ui/dialogs/settings/options_general/qg_dlgoptionsgeneral.cpp
@@ -638,6 +638,8 @@ void QG_DlgOptionsGeneral::init(){
 
         m_originalShowToolbarTooltips = LC_GET_BOOL("ShowToolbarsTooltip", true);
         cbStartupTBTooltips->setChecked(m_originalShowToolbarTooltips);
+
+        cbShowCommandInMenu->setChecked(LC_GET_BOOL("ShowCommandInMenu", true));
     }
     LC_GROUP_END();
 
@@ -924,6 +926,7 @@ void QG_DlgOptionsGeneral::ok(){
             LC_SET("ExpandedToolsMenu", cbExpandToolsMenu->isChecked());
             LC_SET("ExpandedToolsMenuTillEntity", cbExpandToolsMenuTillEntity->isChecked());
             LC_SET("ShowToolbarsTooltip", cbStartupTBTooltips->isChecked());
+            LC_SET("ShowCommandInMenu", cbShowCommandInMenu->isChecked());
         }
         LC_GROUP_END();
 

--- a/librecad/src/ui/dialogs/settings/options_general/qg_dlgoptionsgeneral.ui
+++ b/librecad/src/ui/dialogs/settings/options_general/qg_dlgoptionsgeneral.ui
@@ -4943,6 +4943,16 @@
             </property>
            </widget>
           </item>
+          <item row="10" column="0">
+           <widget class="QCheckBox" name="cbShowCommandInMenu">
+            <property name="toolTip">
+             <string>If enabled, command aliases will be shown next to menu items</string>
+            </property>
+            <property name="text">
+             <string>Show command next to menu items</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/librecad/src/ui/main/init/lc_applicationwindowinitializer.cpp
+++ b/librecad/src/ui/main/init/lc_applicationwindowinitializer.cpp
@@ -90,6 +90,7 @@ void LC_ApplicationWindowInitializer::initApplication(){
     loadCmdWidgetVariablesFile();
     initAutoSaveTimer();
     updateCommandsAlias();
+    m_appWin->refreshMenuAliases();
     initPlugins();
     m_appWin->showStatusMessage(qApp->applicationName() + " Ready", 2000);
     initReleaseChecker();

--- a/librecad/src/ui/main/init/lc_applicationwindowinitializer.cpp
+++ b/librecad/src/ui/main/init/lc_applicationwindowinitializer.cpp
@@ -110,6 +110,7 @@ void LC_ApplicationWindowInitializer::initReleaseChecker(){
 void LC_ApplicationWindowInitializer::initActionGroupManager(){
     m_appWin->m_actionGroupManager = std::make_unique<LC_ActionGroupManager>(m_appWin);
     connect(RS_SETTINGS, &RS_Settings::optionsChanged, m_appWin->m_actionGroupManager.get(), &LC_ActionGroupManager::onOptionsChanged);
+    connect(RS_SETTINGS, &RS_Settings::optionsChanged, m_appWin, &QC_ApplicationWindow::refreshMenuAliases);
 }
 
 void LC_ApplicationWindowInitializer::initActionOptionsManager(){

--- a/librecad/src/ui/main/qc_applicationwindow.cpp
+++ b/librecad/src/ui/main/qc_applicationwindow.cpp
@@ -1831,6 +1831,10 @@ void QC_ApplicationWindow::changeEvent([[maybe_unused]] QEvent *event) {
 
 void QC_ApplicationWindow::refreshMenuAliases()
 {
+    LC_GROUP("Startup");
+    bool showCommandInMenu = LC_GET_BOOL("ShowCommandInMenu", true);
+    LC_GROUP_END();
+
     QMap<QString, QAction*>& a_map = m_actionGroupManager->getActionsMap();
 
     for (auto it = a_map.constBegin(); it != a_map.constEnd(); ++it) {
@@ -1841,6 +1845,11 @@ void QC_ApplicationWindow::refreshMenuAliases()
         if (orig.isEmpty()) {
             orig = act->text();
             act->setProperty("origText", orig);
+        }
+
+        if (!showCommandInMenu) {
+            act->setText(orig);
+            continue;
         }
 
         // Retrieve the ActionType from the property set by associateQActionWithActionType

--- a/librecad/src/ui/main/qc_applicationwindow.h
+++ b/librecad/src/ui/main/qc_applicationwindow.h
@@ -229,6 +229,7 @@ public slots:
     void restoreNamedView5();
     void restoreNamedViewCurrent();
     void restoreNamedView(const QString& viewName);
+    void refreshMenuAliases();
     void invokeLicenseWindow() const;
     void onNewVersionAvailable();
     void checkForNewVersion();


### PR DESCRIPTION
When learning librecad it was difficult for me to know what menu item mapped to what command.  My goal is to make myself more productive and I'm hoping this will help others as well.

This change makes it very obvious by updating the menu item to include the command name, secondary command name (not sure what to call it), and the alias, if one exists.

I understand that this could be considered noisy.  Perhaps if this becomes noisy enough it could be a preference item to enable/disable this, but default it to enabled?

I can backport this to 2.2.1 as well.

<img width="409" height="456" alt="image" src="https://github.com/user-attachments/assets/a4432b1d-4ce4-4fb5-a2e4-21de1a53ebe0" />

<img width="426" height="360" alt="image" src="https://github.com/user-attachments/assets/23d43605-41af-49b0-83c8-b25b18b5febf" />

