### PR TITLE
Ellipse: areaLineIntegral() added unit tests

### DIFF
--- a/librecad/src/lib/engine/document/entities/rs_ellipse.cpp
+++ b/librecad/src/lib/engine/document/entities/rs_ellipse.cpp
@@ -1732,24 +1732,26 @@ LC_Quadratic RS_Ellipse::getQuadratic() const
  * \oint x dy = Cx y + \frac{1}{4}((a^{2}+b^{2})sin(2a)cos^{2}(t)-ab(2sin^{2}(a)sin(2t)-2t-sin(2t)))
  *@author Dongxu Li
  */
-double RS_Ellipse::areaLineIntegral() const{
-    const double a=getMajorRadius();
-    const double b=getMinorRadius();
-    if(!isEllipticArc())
-        return M_PI*a*b;
-    const double ab=a*b;
-    const double r2=a*a+b*b;
-    const double& cx=data.center.x;
-    const double aE=getAngle();
-    const double& a0=data.angle1;
-    const double& a1=data.angle2;
-    const double fStart=cx*getStartpoint().y+0.25*r2*sin(2.*aE)*cos(a0)*cos(a0)-0.25*ab*(2.*sin(aE)*sin(aE)*sin(2.*a0)-sin(2.*a0));
-    const double fEnd=cx*getEndpoint().y+0.25*r2*sin(2.*aE)*cos(a1)*cos(a1)-0.25*ab*(2.*sin(aE)*sin(aE)*sin(2.*a1)-sin(2.*a1));
-    if (isReversed()) {
-        return fEnd-fStart - 0.5 * a * b * getAngleLength();
-    } else {
-        return fEnd-fStart + 0.5 * a * b * getAngleLength();
-    }
+double RS_Ellipse::areaLineIntegral() const {
+  const double a = getMajorRadius();
+  const double b = getMinorRadius();
+  if (!isEllipticArc())
+    return M_PI * a * b;
+  const double ab = a * b;
+  const double r2 = a * a + b * b;
+  const double& cx = data.center.x;
+  const double aE = getAngle();
+  const double y_start = getStartpoint().y;
+  const double y_end = getEndpoint().y;
+  const double start_angle = data.angle1;
+  const double end_angle = isReversed() ? start_angle - getAngleLength() : start_angle + getAngleLength();
+  const double aE2 = aE + aE;
+  const auto antiDerivative = [&cx, c1 = r2 * std::sin(aE2), c2 = std::cos(aE2), &ab](double t, double y) {
+    const double t2 = t + t;
+    return cx * y + (c1 + c1 * std::cos(t2) + 2. * ab * ( t2 + c2 * std::sin(t2))) / 8.;
+  };
+
+  return antiDerivative(end_angle, y_end) - antiDerivative(start_angle, y_start);
 }
 
 bool RS_Ellipse::isReversed() const {
@@ -1761,7 +1763,7 @@ void RS_Ellipse::setReversed(bool r) {
 }
 
 double RS_Ellipse::getAngle() const {
-	return data.majorP.angle();
+        return data.majorP.angle();
 }
 
 double RS_Ellipse::getAngle1() const {


### PR DESCRIPTION
1. Simplified reversed handling in RS_Ellipse::areaLineIntegral();
2. Added unit tests.

TODO: review the similar logic for RS_Arc