### PR TITLE
Reverting key CLI commands for CAD agnostic compatibility

### DIFF
--- a/librecad/src/cmd/lc_commandItems.h
+++ b/librecad/src/cmd/lc_commandItems.h
@@ -255,7 +255,8 @@ const LC_CommandItem g_commandList[] = {
         {
             {{"linepar", QObject::tr("linepar", "create parallel")},
              {"parallel", QObject::tr("parallel", "create parallel")},
-             {"lineoff", QObject::tr("lineoff", "create parallel")}},
+             {"lineoff", QObject::tr("lineoff", "create parallel")},
+             {"offset", QObject::tr("offset", "create parallel")}},
             {{"pa", QObject::tr("pa", "create parallel")},
              {"ll", QObject::tr("ll", "create parallel")}},
             RS2::ActionDrawLineParallel
@@ -702,19 +703,22 @@ const LC_CommandItem g_commandList[] = {
         },
         // rotate
         {
-            {{"modrotate", QObject::tr("modrotate", "modify - rotate")}},
+            {{"modrotate", QObject::tr("modrotate", "modify - rotate")},
+             {"rotate", QObject::tr("rotate", "modify - rotate")}},
             {{"ro", QObject::tr("ro", "modify - rotate")}},
             RS2::ActionModifyRotate
         },
         // scale
         {
-            {{"modscale", QObject::tr("modscale", "modify - scale")}},
+            {{"modscale", QObject::tr("modscale", "modify - scale")},
+             {"scale", QObject::tr("scale", "modify - scale")}},
             {{"sz", QObject::tr("sz", "modify - scale")}},
             RS2::ActionModifyScale
         },
         // mirror  (Removed extra space from translation sting.)
         {
-            {{"modmirror", QObject::tr("modmirror", "modify -  mirror")}},
+            {{"modmirror", QObject::tr("modmirror", "modify -  mirror")},
+             {"mirror", QObject::tr("mirror", "modify -  mirror")}},
             {{"mi", QObject::tr("mi", "modify -  mirror")}},
             RS2::ActionModifyMirror
         },
@@ -739,7 +743,8 @@ const LC_CommandItem g_commandList[] = {
         },
         // trim
         {
-            {{"modtrim", QObject::tr("modtrim", "modify - trim (extend)")}},
+            {{"modtrim", QObject::tr("modtrim", "modify - trim (extend)")},
+             {"trim", QObject::tr("trim", "modify - trim (extend)")}},
             {{"tm", QObject::tr("tm", "modify - trim (extend)")}},
             RS2::ActionModifyTrim
         },
@@ -758,26 +763,24 @@ const LC_CommandItem g_commandList[] = {
         },
         // offset
         {
-            {{"modoffset", QObject::tr("modoffset", "modify - offset")},
-             {"offset", QObject::tr("offset", "modify - offset")}
-         },
+            {{"modoffset", QObject::tr("modoffset", "modify - offset")}},
             {{"mo", QObject::tr("mo", "modify - offset")},   // - v2.2.0r2
              {"moff", QObject::tr("moff", "modify - offset")}},
             RS2::ActionModifyOffset
         },
         // bevel
         {
-            {{"modbevel", QObject::tr("modbevel", "modify - bevel")}},
+            {{"modbevel", QObject::tr("modbevel", "modify - bevel")},
+             {"bevel", QObject::tr("bevel", "modify - bevel")}},
             {{"bev", QObject::tr("bev", "modify - bevel")},
              {"ch", QObject::tr("ch", "modify - bevel")}},
             RS2::ActionModifyBevel
         },
         // fillet
         {
-            {{"modfillet", QObject::tr("modfillet", "modify - fillet")}},
-            {{"fi", QObject::tr("fi", "modify - fillet")},
-             {"fillet", QObject::tr("fillet", "modify - fillet")},
-             {"bevel", QObject::tr("bevel", "modify - fillet")}},
+            {{"modfillet", QObject::tr("modfillet", "modify - fillet")},
+             {"fillet", QObject::tr("fillet", "modify - fillet")}},
+            {{"fi", QObject::tr("fi", "modify - fillet")}},
             RS2::ActionModifyRound
         },
         // divide
@@ -816,7 +819,8 @@ const LC_CommandItem g_commandList[] = {
         },
         // explode
         {
-            {{"modexplode", QObject::tr("modexplode", "explode block/polyline into entities")}},
+            {{"modexplode", QObject::tr("modexplode", "explode block/polyline into entities")},
+             {"explode", QObject::tr("explode", "explode block/polyline into entities")}},
             {{"xp", QObject::tr("xp", "explode block/polyline into entities")}},
             RS2::ActionBlocksExplode
         },

--- a/librecad/src/cmd/lc_commandItems.h
+++ b/librecad/src/cmd/lc_commandItems.h
@@ -253,11 +253,10 @@ const LC_CommandItem g_commandList[] = {
         },
         // draw parallel line
         {
+            {{"parallel", QObject::tr("parallel", "create parallel")}},
             {{"linepar", QObject::tr("linepar", "create parallel")},
-             {"parallel", QObject::tr("parallel", "create parallel")},
              {"lineoff", QObject::tr("lineoff", "create parallel")},
-             {"offset", QObject::tr("offset", "create parallel")}},
-            {{"pa", QObject::tr("pa", "create parallel")},
+             {"pa", QObject::tr("pa", "create parallel")},
              {"ll", QObject::tr("ll", "create parallel")}},
             RS2::ActionDrawLineParallel
         },
@@ -703,23 +702,23 @@ const LC_CommandItem g_commandList[] = {
         },
         // rotate
         {
+            {{"rotate", QObject::tr("rotate", "modify - rotate")}},
             {{"modrotate", QObject::tr("modrotate", "modify - rotate")},
-             {"rotate", QObject::tr("rotate", "modify - rotate")}},
-            {{"ro", QObject::tr("ro", "modify - rotate")}},
+             {"ro", QObject::tr("ro", "modify - rotate")}},
             RS2::ActionModifyRotate
         },
         // scale
         {
+            {{"scale", QObject::tr("scale", "modify - scale")}},
             {{"modscale", QObject::tr("modscale", "modify - scale")},
-             {"scale", QObject::tr("scale", "modify - scale")}},
-            {{"sz", QObject::tr("sz", "modify - scale")}},
+             {"sz", QObject::tr("sz", "modify - scale")}},
             RS2::ActionModifyScale
         },
         // mirror  (Removed extra space from translation sting.)
         {
+            {{"mirror", QObject::tr("mirror", "modify -  mirror")}},
             {{"modmirror", QObject::tr("modmirror", "modify -  mirror")},
-             {"mirror", QObject::tr("mirror", "modify -  mirror")}},
-            {{"mi", QObject::tr("mi", "modify -  mirror")}},
+             {"mi", QObject::tr("mi", "modify -  mirror")}},
             RS2::ActionModifyMirror
         },
         // move and rotate - v2.2.0r2
@@ -743,9 +742,9 @@ const LC_CommandItem g_commandList[] = {
         },
         // trim
         {
+            {{"trim", QObject::tr("trim", "modify - trim (extend)")}},
             {{"modtrim", QObject::tr("modtrim", "modify - trim (extend)")},
-             {"trim", QObject::tr("trim", "modify - trim (extend)")}},
-            {{"tm", QObject::tr("tm", "modify - trim (extend)")}},
+             {"tm", QObject::tr("tm", "modify - trim (extend)")}},
             RS2::ActionModifyTrim
         },
         // trim2
@@ -763,24 +762,26 @@ const LC_CommandItem g_commandList[] = {
         },
         // offset
         {
-            {{"modoffset", QObject::tr("modoffset", "modify - offset")}},
-            {{"mo", QObject::tr("mo", "modify - offset")},   // - v2.2.0r2
+            {{"offset", QObject::tr("offset", "modify - offset")}},
+            {{"modoffset", QObject::tr("modoffset", "modify - offset")},
+             {"mo", QObject::tr("mo", "modify - offset")},   // - v2.2.0r2
              {"moff", QObject::tr("moff", "modify - offset")}},
             RS2::ActionModifyOffset
         },
         // bevel
         {
+            {{"bevel", QObject::tr("bevel", "modify - bevel")},
+             {"chamfer", QObject::tr("chamfer", "modify - bevel")}},
             {{"modbevel", QObject::tr("modbevel", "modify - bevel")},
-             {"bevel", QObject::tr("bevel", "modify - bevel")}},
-            {{"bev", QObject::tr("bev", "modify - bevel")},
+             {"bev", QObject::tr("bev", "modify - bevel")},
              {"ch", QObject::tr("ch", "modify - bevel")}},
             RS2::ActionModifyBevel
         },
         // fillet
         {
+            {{"fillet", QObject::tr("fillet", "modify - fillet")}},
             {{"modfillet", QObject::tr("modfillet", "modify - fillet")},
-             {"fillet", QObject::tr("fillet", "modify - fillet")}},
-            {{"fi", QObject::tr("fi", "modify - fillet")}},
+             {"fi", QObject::tr("fi", "modify - fillet")}},
             RS2::ActionModifyRound
         },
         // divide
@@ -819,9 +820,9 @@ const LC_CommandItem g_commandList[] = {
         },
         // explode
         {
+            {{"explode", QObject::tr("explode", "explode block/polyline into entities")}},
             {{"modexplode", QObject::tr("modexplode", "explode block/polyline into entities")},
-             {"explode", QObject::tr("explode", "explode block/polyline into entities")}},
-            {{"xp", QObject::tr("xp", "explode block/polyline into entities")}},
+             {"xp", QObject::tr("xp", "explode block/polyline into entities")}},
             RS2::ActionBlocksExplode
         },
         // delete

--- a/librecad/src/cmd/lc_commandItems.h
+++ b/librecad/src/cmd/lc_commandItems.h
@@ -764,6 +764,7 @@ const LC_CommandItem g_commandList[] = {
         {
             {{"offset", QObject::tr("offset", "modify - offset")}},
             {{"modoffset", QObject::tr("modoffset", "modify - offset")},
+             {"o", QObject::tr("o", "modify - offset")},
              {"mo", QObject::tr("mo", "modify - offset")},   // - v2.2.0r2
              {"moff", QObject::tr("moff", "modify - offset")}},
             RS2::ActionModifyOffset


### PR DESCRIPTION
Somewhere between 2.2.0 and 2.2.1 key CLI commands in LibreCAD were changed. These represent a serious shift for long time CAD users. Previously the CLI had major overlap with AutoCAD CLI which goes back decades and has a strong historical user base. This platform agnostic CLI was a major draw for users coming to and from LibreCAD or AutoCAD.

This was discussed in Issue #1683 and other users chimed in about this matter.

Fixes #1683
Fixes #1833

## Update: reworked to add, not remove

The original patch simply reverted the `mod*`-prefixed names back to their pre-2.2.1 equivalents, which meant removing the newer names. That traded one set of broken muscle memory for another. It's been reworked around a different rule instead, so nobody loses a command they're already used to:

- the most reasonable/cross-platform name becomes the **main** command for its action
- whatever it displaces becomes a **short** command on the same action, so it still works
- nothing that works before this PR stops working after it

Main commands are now the names shared with AutoCAD, BricsCAD, DraftSight and QCAD: `rotate`, `scale`, `mirror`, `trim`, `explode`, `fillet`, `bevel` (+ `chamfer`), `offset`, and `parallel`. The `mod*`-prefixed names from 2.2.1 (`modrotate`, `modscale`, `modmirror`, `modtrim`, `modexplode`, `modfillet`, `modbevel`, `modoffset`) are kept as short commands, alongside `linepar`/`lineoff` for the parallel-line tool.

### `offset` stays on the Modify > Offset action (not moved to Parallel)

The original patch moved `offset` to be an alias of the parallel-line tool, matching its pre-2.2.0 meaning. That would re-open issue #1833: `RS_Creation::createParallel` only handles lines, arcs, circles and parabolas, so the parallel tool can't offset a polyline, whereas `RS_Polyline::offset()` is implemented and reachable through the real Modify > Offset action. AutoCAD, BricsCAD and DraftSight all define OFFSET over polylines too, and QCAD - the project LibreCAD forked - binds `offset` to its own Modify > Offset tool and `lineoffset`/`parallel` to the parallel tool, i.e. the same split LibreCAD master already has. A command name can only map to one action, so this had to be a choice, not an alias, and issue #1833 is the reason it was chosen this way originally.

This also restores the `o` short command on Modify > Offset, which has been unbound since the fix for #1833 (the toolbar button has displayed "Offset : offset, o" as its available commands for about two years without `o` actually working).

### `bevel` changes meaning - the one deliberate breaking change

`bevel` currently runs the *fillet* action (asks for a radius) because it was added to fillet's alias list by mistake in c2e41bfb7. It now runs the actual bevel/chamfer action (asks for two lengths), matching LibreCAD 2.2.0, LibreCAD's own `CORNER_BEVEL` vs `CORNER_RADIUS` terminology, and the Bevel menu entry. Also added `chamfer` as a main command, since that's the name AutoCAD/BricsCAD/DraftSight actually use - "bevel" as a bound command is essentially QCAD/LibreCAD-only.

### Verification

No duplicate main commands, no duplicate short commands, and no command name appearing as both main and short, anywhere in the table - checked before and after merging current master. The table also compiles cleanly in both states.

---

<details>
<summary>Original PR description</summary>

I am submitting this PR to revert LibreCAD's CLI compatibility on key commands that I use regularly as a CAD user.

Note that `offset` is now an alias for `lineoff` and not for `modoffset`, in keeping with the reversion to a more platform agnostic CLI. `offset` was used for this up to v2.2.0.

Here are the changes I originally identified to revert this:

```
incompatible command --> compatible command

lineoff    --> offset
modrotate  --> rotate
modscale   --> scale
modmirror  --> mirror
modtrim    --> trim
modoffset  --> offset
modbevel   --> bevel
modexplode --> explode
```

Other critical commands maintain good compatibility like `l`, `pl`, `c`, `move`, `mtext`, `dimlinear`, and many other common commands. But the above list is the scope of the regression I identified.

</details>

