### PR TITLE
UI: Add option to force light theme in settings

### DIFF
--- a/librecad/src/main/main.cpp
+++ b/librecad/src/main/main.cpp
@@ -40,6 +40,7 @@
 
 #include <QDir>
 #include <QPushButton>
+#include <QStyleFactory>
 #include <QTimer>
 #include <QToolBar>
 
@@ -252,12 +253,12 @@ int main(int argc, char** argv) {
 
     // Create compilater's error: this QT macros may be in .pro file only.
     //QT_REQUIRE_VERSION(argc, argv, "6.4");
-    
+
     // May be this code must be on begin of main.cpp?
     #if QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
         #error "This programm requires Qt6 ver.6.4.0 or higher."
     #endif
-    
+
     // Check first two arguments in order to decide if we want to run librecad
     // as console dxf2pdf or dxf2png tools. On Linux we can create a link to
     // librecad executable and  name it dxf2pdf. So, we can run either:
@@ -284,16 +285,39 @@ int main(int argc, char** argv) {
     RS_DEBUG->setLevel(RS_Debug::D_WARNING);
 
     LC_Application app(argc, argv);
+
     QCoreApplication::setOrganizationName("LibreCAD");
     QCoreApplication::setApplicationName("LibreCAD");
     QCoreApplication::setApplicationVersion(XSTR(LC_VERSION));
+    RS_Settings::init(app.organizationName(), app.applicationName());
+
+    // Conditionally force a light color scheme regardless of the OS dark theme,
+    // because many toolbar icons are designed for a light background.
+    if (LC_GET_ONE_BOOL("Widgets", "ForceLightTheme", false)) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+        app.styleHints()->setColorScheme(Qt::ColorScheme::Light);
+#else
+        // Qt < 6.5: setColorScheme() is unavailable; apply Fusion's standard
+        // palette which is always light regardless of the OS color scheme.
+        QStyle* fusionStyle = QStyleFactory::create("Fusion");
+        if (fusionStyle != nullptr) {
+            QApplication::setPalette(fusionStyle->standardPalette());
+            delete fusionStyle;
+        }
+        // On Linux with XDG icon themes, also reset to "hicolor" (the universal
+        // freedesktop fallback theme with colored icons), so that
+        // QIcon::fromTheme() no longer returns white dark-mode system icons.
+        // Not needed on Windows/macOS which don't use XDG icon themes.
+#ifdef Q_OS_LINUX
+        QIcon::setThemeName("hicolor");
+#endif
+#endif
+    }
 
     // fixme - sand - NEED TO CHECK WHERE lc_svgicons.so is located under linux and mac!!! That's tested for Windows
     auto appDir = app.applicationDirPath();
     auto inconEnginesDir = appDir + "/iconengines";
     app.addLibraryPath(inconEnginesDir);
-
-    RS_Settings::init(app.organizationName(), app.applicationName());
 
     QGuiApplication::setDesktopFileName("librecad");
 

--- a/librecad/src/ui/dialogs/settings/options_widget/lc_widgetoptionsdialog.cpp
+++ b/librecad/src/ui/dialogs/settings/options_widget/lc_widgetoptionsdialog.cpp
@@ -66,6 +66,9 @@ LC_WidgetOptionsDialog::LC_WidgetOptionsDialog(QWidget* parent)
         if (!sheet_path.isEmpty() && QFile::exists(sheet_path))
             stylesheet_field->setText(sheet_path);
 
+        bool forceLightTheme = LC_GET_BOOL("ForceLightTheme", false);
+        cbForceLightTheme->setChecked(forceLightTheme);
+
         // bool allow_theme = LC_GET_BOOL("AllowTheme", false);
         // theme_checkbox->setChecked(allow_theme);
 
@@ -337,6 +340,8 @@ void LC_WidgetOptionsDialog::accept() {
 
         bool pickValuesButtonsFlatIcons = cbFlatPickValuesButtons->isChecked();
         LC_SET("PickValueButtonsFlatIcons", pickValuesButtonsFlatIcons);
+
+        LC_SET("ForceLightTheme", cbForceLightTheme->isChecked());
 
         bool allow_theme = false; //theme_checkbox->isChecked();
         LC_SET("AllowTheme", allow_theme);

--- a/librecad/src/ui/dialogs/settings/options_widget/lc_widgetoptionsdialog.ui
+++ b/librecad/src/ui/dialogs/settings/options_widget/lc_widgetoptionsdialog.ui
@@ -136,6 +136,16 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="cbForceLightTheme">
+        <property name="toolTip">
+         <string>If checked, the application uses a light color palette regardless of the OS dark theme. Requires restart to take effect.</string>
+        </property>
+        <property name="text">
+         <string>Force light theme (requires restart)</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
When the dark theme is enabled, some toolbar icons become difficult to see.
To provide a simple solution without having to redesign all icons for dark theme compatibility, this pull request introduces an option to force the application to use a light theme.

Changes introduced
- Added a new checkbox in the Settings panel that allows users to enforce a light color scheme, regardless of the operating system's theme.
- When enabled, the application switches to a light palette, improving visibility of toolbar icons that were designed for light backgrounds.
- A restart of the application is required for the change to take effect.

- Dark theme issue (icons are hard to see)

<img width="1789" height="847" alt="image" src="https://github.com/user-attachments/assets/88f92a91-44af-4f0a-8cf1-6f1fb05feb66" />

- Option to force the light theme

<img width="400" height="749" alt="image" src="https://github.com/user-attachments/assets/f5921cd8-efb0-41ff-aff8-4de14ab9adce" />

- Result after restarting the application

<img width="1789" height="847" alt="image" src="https://github.com/user-attachments/assets/e329641a-abec-415f-ab08-4720add34ece" />

This could be a quick fix for the issues:
#1144
#364
#1606
#1700