### PR TITLE
Offset implementation proposal for ellipses

### DIFF
--- a/librecad/src/lib/engine/rs_ellipse.cpp
+++ b/librecad/src/lib/engine/rs_ellipse.cpp
@@ -1220,6 +1220,40 @@ RS_Vector RS_Ellipse::dualLineTangentPoint(const RS_Vector& line) const
     return lineEqu(vp0) < lineEqu(vp1) ? vp0 : vp1;
 }
 
+/**
+  * this function creates offset
+  *@coord, position indicates the direction of offset
+  *@distance, distance of offset
+  * return true, if success, otherwise, false
+  *
+  *Author: Dongxu Li & qwilvove
+  */
+bool RS_Ellipse::offset(const RS_Vector& coord, const double& distance) {
+    double r0(coord.distanceTo(getCenter()));
+    double r1(r0);
+    double nearestRadius = getNearestPointOnEntity(coord).distanceTo(getCenter());
+    double majorRadius = getMajorRadius();
+    double minorRadius = getMinorRadius();
+    if(r0 > nearestRadius){
+        //external
+        r0 = majorRadius + fabs(distance);
+        r1 = minorRadius + fabs(distance);
+    }else{
+        r0 = majorRadius - fabs(distance);
+        r1 = minorRadius - fabs(distance);
+        if(std::min(r0, r1)<RS_TOLERANCE) {
+            return false;
+        }
+    }
+
+    setRatio(r1 / r0);
+    RS_Vector majorP = getMajorP();
+    majorP.scale(r0 / majorRadius);
+    setMajorP(majorP);
+    calculateBorders();
+    return true;
+}
+
 void RS_Ellipse::move(const RS_Vector& offset) {
     data.center.move(offset);
     //calculateEndpoints();

--- a/librecad/src/lib/engine/rs_ellipse.h
+++ b/librecad/src/lib/engine/rs_ellipse.h
@@ -200,6 +200,7 @@ public:
 	bool isPointOnEntity(const RS_Vector& coord,
 								 double tolerance=RS_TOLERANCE) const override;
 
+    bool offset(const RS_Vector& position, const double& distance) override;
 	void move(const RS_Vector& offset) override;
 	void rotate(const double& angle);
 	void rotate(const RS_Vector& angleVector);


### PR DESCRIPTION
Hello community,

After working with ellipses, I have noticed that the offset tool did not work for them.

I have implemented the offset function for ellipses, and I want to share this implementation since it could be useful for users.

For this implementation, I use getNearestPointOnEntity() to determine  the correct sign of the distance to apply.
I have noticed that we can observe jitters when trying to offset the ellipse with "Snap on entity" enabled. Sometimes, the projected result of the offset is drawn inside, and sometimes it is drawn outside of the initial ellipse.
This "issue" can be observed when offsetting other existing shapes as well. (So I suppose that it's not due to this implementation, and I don't even know if this is an issue).

Maybe offsetting an ellipse requires a different approach, and I am convinced that there are hundreds of ways to perform and optimise this functionality.

Regards,

qwilvove