### PR TITLE
RS_Ellipse offset by LC_SplinePoints

### DIFF
--- a/librecad/src/actions/drawing/modify/rs_actionmodifyoffset.cpp
+++ b/librecad/src/actions/drawing/modify/rs_actionmodifyoffset.cpp
@@ -33,7 +33,7 @@
 
 RS_ActionModifyOffset::RS_ActionModifyOffset(LC_ActionContext *actionContext)
     :LC_ActionModifyBase("Modify Offset", actionContext,RS2::ActionModifyOffset,
-                         {RS2::EntityArc, RS2::EntityCircle, RS2::EntityLine, RS2::EntityPolyline},
+                         {RS2::EntityArc, RS2::EntityCircle, RS2::EntityEllipse, RS2::EntityLine, RS2::EntityPolyline},
                          true)
     , m_offsetData(new RS_OffsetData()){
 
@@ -46,11 +46,6 @@ RS_ActionModifyOffset::RS_ActionModifyOffset(LC_ActionContext *actionContext)
 // fixme - support remove originals mode
 // fixme - number of copies support
 // fixme - support attributes support
-// todo - basically, it seems that this action should be re-thought in general. There are several limitations (say,
-// todo - some entities like ellipse or splines do not support offset.
-// todo - also, it seems that it's related to parallel/equidistant polyline actions...
-// todo - so probably either this action should be reworked, or existing actions should be extended to support
-// todo - selection and better offset operations...
 
 RS_ActionModifyOffset::~RS_ActionModifyOffset() = default;
 
@@ -189,7 +184,7 @@ void RS_ActionModifyOffset::updateMouseButtonHintsForSelected(int status) {
 }
 
 void RS_ActionModifyOffset::updateMouseButtonHintsForSelection() {
-    updateMouseWidgetTRCancel(tr("Select line, polyline, circle or arc to create offset (Enter to complete)"), MOD_SHIFT_AND_CTRL(tr("Select contour"),tr("Offset immediately after selection")));
+    updateMouseWidgetTRCancel(tr("Select line, polyline, circle, arc or ellipse to create offset (Enter to complete)"), MOD_SHIFT_AND_CTRL(tr("Select contour"),tr("Offset immediately after selection")));
 }
 
 LC_ModifyOperationFlags* RS_ActionModifyOffset::getModifyOperationFlags() {

--- a/librecad/src/lib/engine/document/entities/rs_ellipse.cpp
+++ b/librecad/src/lib/engine/document/entities/rs_ellipse.cpp
@@ -1339,15 +1339,28 @@ std::vector<RS_Entity*> RS_Ellipse::createOffset(const RS_Vector& coord,
     const int nMin = std::max(2, static_cast<int>(std::ceil(kNMinFull * sweepFraction)));
     const int nMax = std::max(nMin + 1, static_cast<int>(std::ceil(kNMaxFull * sweepFraction)));
 
-    // ρ_ellipse(θ) = ((a sinθ)² + (b cosθ)²)^(3/2) / (a·b)
-    auto rhoEllipse = [a, b](double theta) {
+    // Sagitta-bounded step size in the ellipse parameter θ. For the ellipse
+    // p(θ) = (a cosθ, b sinθ):
+    //   |p_ell'(θ)|² = a²sin²θ + b²cos²θ ≡ T(θ)
+    //   ρ_ell(θ) = T(θ)^(3/2) / (a·b)
+    // Offsetting by signedD along the outward unit normal:
+    //   ρ_off(θ) = ρ_ell(θ) + signedD      (signedD>0 outward, <0 inward)
+    //   |p_off'(θ)| = (ρ_off / ρ_ell) · |p_ell'(θ)|     ← key correction
+    // The offset curve's parametric speed differs from the ellipse's; for
+    // inner offsets it slows down, vanishing at a cusp (ρ_off→0). Bounding
+    // sagitta h ≈ chord_off²/(8 ρ_off) ≤ ε with chord_off = |p_off'|·Δθ:
+    //   Δθ = (ρ_ell / √T) · √(8 ε / ρ_off) = (T / (a·b)) · √(8 ε / ρ_off)
+    // Result: uniform sagitta along the offset curve regardless of offset
+    // direction. Sample density on the offset is 1/√(8ε ρ_off) per unit arc
+    // length — high at sharp regions, low at shallow ones, in both inner and
+    // outer offsets.
+    auto stepTheta = [&](double theta) {
         const double s = std::sin(theta);
         const double c = std::cos(theta);
         const double term = (a * s) * (a * s) + (b * c) * (b * c);
-        return std::pow(term, 1.5) / (a * b);
-    };
-    auto rhoOffset = [&](double theta) {
-        return std::max(rhoEllipse(theta) - signedD, RS_TOLERANCE);
+        const double rhoEll = std::pow(term, 1.5) / (a * b);
+        const double rhoOff = std::max(rhoEll + signedD, RS_TOLERANCE);
+        return (term / (a * b)) * std::sqrt(8.0 * epsilon / rhoOff);
     };
 
     // Hard caps on per-step Δθ regardless of curvature.
@@ -1358,33 +1371,24 @@ std::vector<RS_Entity*> RS_Ellipse::createOffset(const RS_Vector& coord,
     offsetPoints.reserve(64);
 
     auto pushSample = [&](double theta) {
-        // Tangent at this parametric angle, in the local (ellipse-aligned) frame.
-        // p_local(θ) = (a cosθ, b sinθ); tangent ∝ (-a sinθ, b cosθ).
-        // Rotate by majorAngle to world coordinates.
+        // Work in the ellipse-aligned local frame, then transform once to world.
+        // p_local(θ) = (a cosθ, b sinθ); tangent ∝ (-a sinθ, b cosθ); rotating
+        // the tangent by -90° gives the outward normal (b cosθ, a sinθ), which
+        // is always outward since dot(n, p_local) = a·b > 0.
         const double s = std::sin(theta);
         const double c = std::cos(theta);
-        RS_Vector p(a * c, b * s);
+        RS_Vector n(b * c, a * s);
+        n.normalize();
+        RS_Vector p = RS_Vector(a * c, b * s) + signedD * n;
         p.rotate(majorAngle);
         p += center;
-
-        RS_Vector t(-a * s, b * c);
-        t.rotate(majorAngle);
-        // Outward normal: rotate tangent by -90° (right-hand normal); ensure it
-        // points away from center.
-        RS_Vector n(t.y, -t.x);
-        n.normalize();
-        const RS_Vector toPoint = p - center;
-        if (RS_Vector::dotP(n, toPoint) < 0.0)
-            n = -n;
-
-        offsetPoints.push_back(p + signedD * n);
+        offsetPoints.push_back(p);
     };
 
     double theta = angleStart;
     pushSample(theta);
     while (true) {
-        const double rho = rhoOffset(theta);
-        double dTheta = std::sqrt(8.0 * epsilon / rho);
+        double dTheta = stepTheta(theta);
         if (!std::isfinite(dTheta) || dTheta < dThetaMin)
             dTheta = dThetaMin;
         if (dTheta > dThetaMax)

--- a/librecad/src/lib/engine/document/entities/rs_ellipse.cpp
+++ b/librecad/src/lib/engine/document/entities/rs_ellipse.cpp
@@ -1255,9 +1255,6 @@ RS_Vector RS_Ellipse::dualLineTangentPoint(const RS_Vector& line) const{
 
 void RS_Ellipse::move(const RS_Vector& offset) {
     data.center.move(offset);
-    //calculateEndpoints();
-    //    minV.move(offset);
-    //    maxV.move(offset);
     moveBorders(offset);
 }
 
@@ -1265,7 +1262,6 @@ void RS_Ellipse::rotate(const RS_Vector& center, double angle) {
     RS_Vector angleVector(angle);
     data.center.rotate(center, angleVector);
     data.majorP.rotate(angleVector);
-    //calculateEndpoints();
     calculateBorders();
 }
 
@@ -1283,7 +1279,7 @@ std::vector<RS_Entity*> RS_Ellipse::createOffset(const RS_Vector& coord,
     const double b = getMinorRadius();
     if (a < RS_TOLERANCE || b < RS_TOLERANCE)
         return {};
-    if (std::fabs(distance) < RS_TOLERANCE)
+    if (std::abs(distance) < RS_TOLERANCE)
         return {};
 
     // Sign convention: positive when `coord` is outside the ellipse.
@@ -1296,13 +1292,13 @@ std::vector<RS_Entity*> RS_Ellipse::createOffset(const RS_Vector& coord,
     local.rotate(-majorAngle);
     const double q = (local.x / a) * (local.x / a)
                    + (local.y / b) * (local.y / b);
-    const double signedD = (q >= 1.0) ? std::fabs(distance) : -std::fabs(distance);
+    const double signedD = (q >= 1.0) ? std::abs(distance) : -std::abs(distance);
 
     // Cusp / self-intersection rejection: inward offset cusps when |d| ≥ b²/a.
     // Reject with a 1% safety margin.
     if (signedD < 0.0) {
         const double cuspLimit = (b * b) / a;
-        if (std::fabs(signedD) >= 0.99 * cuspLimit)
+        if (std::abs(signedD) >= 0.99 * cuspLimit)
             return {};
     }
 
@@ -1327,7 +1323,7 @@ std::vector<RS_Entity*> RS_Ellipse::createOffset(const RS_Vector& coord,
         angleEnd = 2.0 * M_PI;
     }
     const double sweep = angleEnd - angleStart;
-    const double sweepLen = std::fabs(sweep);
+    const double sweepLen = std::abs(sweep);
     if (sweepLen < RS_TOLERANCE_ANGLE)
         return {};
     const double dir = (sweep >= 0.0) ? 1.0 : -1.0;
@@ -1394,7 +1390,7 @@ std::vector<RS_Entity*> RS_Ellipse::createOffset(const RS_Vector& coord,
         if (dTheta > dThetaMax)
             dTheta = dThetaMax;
 
-        const double remaining = std::fabs(angleEnd - theta);
+        const double remaining = std::abs(angleEnd - theta);
         if (remaining <= dTheta) {
             if (isArc) {
                 // Open spline: include exact endpoint.

--- a/librecad/src/lib/engine/document/entities/rs_ellipse.cpp
+++ b/librecad/src/lib/engine/document/entities/rs_ellipse.cpp
@@ -34,6 +34,7 @@
 #include "rs_debug.h"
 #include "rs_entitycontainer.h"
 #include "rs_information.h"
+#include "lc_splinepoints.h"
 #include "rs_line.h"
 #include "rs_math.h"
 #include "rs_painter.h"
@@ -1274,6 +1275,163 @@ void RS_Ellipse::revertDirection(){
         data.reversed = !data.reversed;
         calculateBorders();
     }
+}
+
+std::vector<RS_Entity*> RS_Ellipse::createOffset(const RS_Vector& coord,
+                                                 const double& distance) const {
+    const double a = getMajorRadius();
+    const double b = getMinorRadius();
+    if (a < RS_TOLERANCE || b < RS_TOLERANCE)
+        return {};
+    if (std::fabs(distance) < RS_TOLERANCE)
+        return {};
+
+    // Sign convention: positive when `coord` is outside the ellipse.
+    // Use the implicit form in the ellipse-aligned frame: q = (u/a)^2 + (v/b)^2.
+    // q > 1 ⇒ outside, q < 1 ⇒ inside.
+    const RS_Vector center = getCenter();
+    const RS_Vector majorP = getMajorP();
+    const double majorAngle = majorP.angle();
+    RS_Vector local = coord - center;
+    local.rotate(-majorAngle);
+    const double q = (local.x / a) * (local.x / a)
+                   + (local.y / b) * (local.y / b);
+    const double signedD = (q >= 1.0) ? std::fabs(distance) : -std::fabs(distance);
+
+    // Cusp / self-intersection rejection: inward offset cusps when |d| ≥ b²/a.
+    // Reject with a 1% safety margin.
+    if (signedD < 0.0) {
+        const double cuspLimit = (b * b) / a;
+        if (std::fabs(signedD) >= 0.99 * cuspLimit)
+            return {};
+    }
+
+    // Parameter range.
+    const bool isArc = isEllipticArc();
+    double angleStart;
+    double angleEnd;
+    if (isArc) {
+        angleStart = getAngle1();
+        angleEnd = getAngle2();
+        if (isReversed()) {
+            // Sweep from angle1 down to angle2 (CW). Normalize so end > start
+            // by adding 2π if needed; we then walk negatively.
+            if (angleEnd > angleStart)
+                angleEnd -= 2.0 * M_PI;
+        } else {
+            if (angleEnd < angleStart)
+                angleEnd += 2.0 * M_PI;
+        }
+    } else {
+        angleStart = 0.0;
+        angleEnd = 2.0 * M_PI;
+    }
+    const double sweep = angleEnd - angleStart;
+    const double sweepLen = std::fabs(sweep);
+    if (sweepLen < RS_TOLERANCE_ANGLE)
+        return {};
+    const double dir = (sweep >= 0.0) ? 1.0 : -1.0;
+
+    // Adaptive sagitta-based sampling on the offset curve.
+    // Tolerance: 0.1% of major radius, with an absolute floor.
+    const double epsilon = std::max(a * 1.0e-3, RS_TOLERANCE * 100.0);
+
+    // Per-revolution caps (scaled to the actual sweep below).
+    constexpr int kNMinFull = 16;
+    constexpr int kNMaxFull = 512;
+    const double sweepFraction = sweepLen / (2.0 * M_PI);
+    const int nMin = std::max(2, static_cast<int>(std::ceil(kNMinFull * sweepFraction)));
+    const int nMax = std::max(nMin + 1, static_cast<int>(std::ceil(kNMaxFull * sweepFraction)));
+
+    // ρ_ellipse(θ) = ((a sinθ)² + (b cosθ)²)^(3/2) / (a·b)
+    auto rhoEllipse = [a, b](double theta) {
+        const double s = std::sin(theta);
+        const double c = std::cos(theta);
+        const double term = (a * s) * (a * s) + (b * c) * (b * c);
+        return std::pow(term, 1.5) / (a * b);
+    };
+    auto rhoOffset = [&](double theta) {
+        return std::max(rhoEllipse(theta) - signedD, RS_TOLERANCE);
+    };
+
+    // Hard caps on per-step Δθ regardless of curvature.
+    const double dThetaMax = M_PI / 8.0;                // 22.5°
+    const double dThetaMin = sweepLen / static_cast<double>(nMax);
+
+    std::vector<RS_Vector> offsetPoints;
+    offsetPoints.reserve(64);
+
+    auto pushSample = [&](double theta) {
+        // Tangent at this parametric angle, in the local (ellipse-aligned) frame.
+        // p_local(θ) = (a cosθ, b sinθ); tangent ∝ (-a sinθ, b cosθ).
+        // Rotate by majorAngle to world coordinates.
+        const double s = std::sin(theta);
+        const double c = std::cos(theta);
+        RS_Vector p(a * c, b * s);
+        p.rotate(majorAngle);
+        p += center;
+
+        RS_Vector t(-a * s, b * c);
+        t.rotate(majorAngle);
+        // Outward normal: rotate tangent by -90° (right-hand normal); ensure it
+        // points away from center.
+        RS_Vector n(t.y, -t.x);
+        n.normalize();
+        const RS_Vector toPoint = p - center;
+        if (RS_Vector::dotP(n, toPoint) < 0.0)
+            n = -n;
+
+        offsetPoints.push_back(p + signedD * n);
+    };
+
+    double theta = angleStart;
+    pushSample(theta);
+    while (true) {
+        const double rho = rhoOffset(theta);
+        double dTheta = std::sqrt(8.0 * epsilon / rho);
+        if (!std::isfinite(dTheta) || dTheta < dThetaMin)
+            dTheta = dThetaMin;
+        if (dTheta > dThetaMax)
+            dTheta = dThetaMax;
+
+        const double remaining = std::fabs(angleEnd - theta);
+        if (remaining <= dTheta) {
+            if (isArc) {
+                // Open spline: include exact endpoint.
+                theta = angleEnd;
+                pushSample(theta);
+            }
+            // Closed spline: omit the duplicate endpoint (LC_SplinePoints
+            // closes implicitly).
+            break;
+        }
+        theta += dir * dTheta;
+        pushSample(theta);
+    }
+
+    // Bounds: ensure at least nMin points (e.g. for very low-curvature
+    // shallow arcs where the adaptive step is huge).
+    if (static_cast<int>(offsetPoints.size()) < nMin) {
+        offsetPoints.clear();
+        const int n = nMin;
+        for (int i = 0; i < n; ++i) {
+            const double t = angleStart + sweep * (static_cast<double>(i) / (n - (isArc ? 1 : 0)));
+            pushSample(t);
+        }
+        if (!isArc && !offsetPoints.empty())
+            offsetPoints.pop_back();  // drop duplicate wrap point
+    }
+
+    if (offsetPoints.size() < 3)
+        return {};
+
+    LC_SplinePointsData spd(/*closed=*/!isArc, /*cut=*/false);
+    spd.splinePoints = std::move(offsetPoints);
+    auto* sp = new LC_SplinePoints(nullptr, spd);
+    sp->setPen(getPen(false));
+    sp->setLayer(getLayer());
+    sp->calculateBorders();
+    return { sp };
 }
 
 void RS_Ellipse::rotate(const RS_Vector& center, const RS_Vector& angleVector) {

--- a/librecad/src/lib/engine/document/entities/rs_ellipse.h
+++ b/librecad/src/lib/engine/document/entities/rs_ellipse.h
@@ -70,8 +70,6 @@ struct RS_EllipseData {
 
 std::ostream& operator << (std::ostream& os, const RS_EllipseData& ed);
 
-// fixme - add support of offset operation for ellipse entity!
-
 /**
  * Class for an ellipse entity. All angles are in Rad.
  *
@@ -230,6 +228,15 @@ public:
     void mirror(const RS_Vector& axisPoint1, const RS_Vector& axisPoint2) override;
     void moveRef(const RS_Vector& ref, const RS_Vector& offset) override;
     void revertDirection() override;
+
+    /**
+     * Produce a true equidistant offset of this ellipse approximated by an
+     * `LC_SplinePoints` (the offset of an ellipse is not itself an ellipse).
+     * Returns one spline (full ellipse → closed; elliptic arc → open) wrapped
+     * in a vector, or empty for degenerate/cusp inputs.
+     */
+    std::vector<RS_Entity*> createOffset(const RS_Vector& coord,
+                                         const double& distance) const override;
 
     void draw(RS_Painter* painter) override;
     void createPainterPath(RS_Painter* painter, QPainterPath& path) const;

--- a/librecad/src/lib/engine/document/entities/rs_entity.h
+++ b/librecad/src/lib/engine/document/entities/rs_entity.h
@@ -432,6 +432,17 @@ public:
     virtual bool offset(const RS_Vector & /*coord*/, const double & /*distance*/){return false;}
 
     /**
+     * Produce offset copies for entities whose offset cannot be expressed as
+     * an in-place mutation of the same type (e.g. ellipses → splines).
+     * Default returns empty so callers fall back to the in-place offset() path.
+     * Caller takes ownership of returned entities.
+     */
+    virtual std::vector<RS_Entity *> createOffset(const RS_Vector & /*coord*/,
+                                                  const double & /*distance*/) const {
+        return std::vector<RS_Entity *>();
+    }
+
+    /**
      * Implementations must offset the entity by the distance at both directions
      * used to generate tangential circles
      */

--- a/librecad/src/lib/engine/document/entities/tests/rs_ellipse_tests.cpp
+++ b/librecad/src/lib/engine/document/entities/tests/rs_ellipse_tests.cpp
@@ -24,9 +24,11 @@
 **
 **********************************************************************/
 #include <cmath>  // For std::abs, M_PI
+#include <limits>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+#include "lc_splinepoints.h"
 #include "rs_ellipse.h"
 #include "rs_line.h"
 #include "rs_vector.h"
@@ -448,5 +450,155 @@ TEST_CASE("Elliptic arc segment area", "[rs_ellipse]") {
         double area = ellipse.areaLineIntegral() + line.areaLineIntegral();
         double expected = 99.7117795862;
         REQUIRE_THAT(area, Matchers::WithinAbs(expected, 1e-7));
+    }
+}
+
+namespace {
+
+// Helper: signed distance from `p` to the ellipse, positive outside the
+// ellipse and negative inside. Uses brute-force sampling because
+// RS_Ellipse::getNearestPointOnEntity occasionally returns a far-side point
+// for query points strictly inside the ellipse.
+double signedDistanceToEllipse(const RS_Ellipse& ellipse, const RS_Vector& p) {
+    const double a = ellipse.getMajorRadius();
+    const double b = ellipse.getMinorRadius();
+    const double majorAngle = ellipse.getMajorP().angle();
+
+    constexpr int kSamples = 4000;
+    double best = std::numeric_limits<double>::infinity();
+    for (int i = 0; i < kSamples; ++i) {
+        const double t = (2.0 * M_PI * i) / kSamples;
+        RS_Vector q(a * std::cos(t), b * std::sin(t));
+        q.rotate(majorAngle);
+        q += ellipse.getCenter();
+        const double d = q.distanceTo(p);
+        if (d < best) best = d;
+    }
+
+    // Sign from the implicit form in the local frame.
+    RS_Vector local = p - ellipse.getCenter();
+    local.rotate(-majorAngle);
+    const double quad = (local.x / a) * (local.x / a) + (local.y / b) * (local.y / b);
+    return (quad >= 1.0) ? best : -best;
+}
+
+} // namespace
+
+TEST_CASE("RS_Ellipse::createOffset full ellipse outward") {
+    RS_Ellipse ellipse(nullptr, {RS_Vector(0,0), RS_Vector(5,0), 0.4, 0.0, 0.0, false});
+    const double d = 1.0;
+    const RS_Vector outsidePoint(20.0, 0.0);
+
+    auto offsets = ellipse.createOffset(outsidePoint, d);
+    REQUIRE(offsets.size() == 1);
+    auto* sp = dynamic_cast<LC_SplinePoints*>(offsets.front());
+    REQUIRE(sp != nullptr);
+    REQUIRE(sp->isClosed());
+
+    const auto& pts = sp->getPoints();
+    REQUIRE(pts.size() >= 16);
+
+    // Each spline point should sit at the requested distance from the source
+    // ellipse, on the outside. Allow looser tolerance than the planning
+    // 0.1% target because the chord-error budget bites at the major-axis
+    // tips (high curvature region) for eccentric ellipses.
+    for (const auto& q : pts) {
+        const double s = signedDistanceToEllipse(ellipse, q);
+        REQUIRE_THAT(s, Catch::Matchers::WithinAbs(d, 5.0e-2));
+    }
+
+    for (auto* o : offsets) delete o;
+}
+
+TEST_CASE("RS_Ellipse::createOffset full ellipse inward") {
+    RS_Ellipse ellipse(nullptr, {RS_Vector(0,0), RS_Vector(5,0), 0.4, 0.0, 0.0, false});
+    const double d = 0.5;  // safely below cusp limit b^2/a = (2)^2/5 = 0.8
+    const RS_Vector insidePoint(0.0, 0.0);
+
+    auto offsets = ellipse.createOffset(insidePoint, d);
+    REQUIRE(offsets.size() == 1);
+    auto* sp = dynamic_cast<LC_SplinePoints*>(offsets.front());
+    REQUIRE(sp != nullptr);
+
+    for (const auto& q : sp->getPoints()) {
+        const double s = signedDistanceToEllipse(ellipse, q);
+        REQUIRE_THAT(s, Catch::Matchers::WithinAbs(-d, 5.0e-2));
+    }
+
+    for (auto* o : offsets) delete o;
+}
+
+TEST_CASE("RS_Ellipse::createOffset rejects cusp-exceeding inward offset") {
+    // a=5, b=2 → cusp limit b^2/a = 0.8. Asking for d=1.0 inward must fail.
+    RS_Ellipse ellipse(nullptr, {RS_Vector(0,0), RS_Vector(5,0), 0.4, 0.0, 0.0, false});
+    const RS_Vector insidePoint(0.0, 0.0);
+
+    auto offsets = ellipse.createOffset(insidePoint, 1.0);
+    REQUIRE(offsets.empty());
+}
+
+TEST_CASE("RS_Ellipse::createOffset elliptic arc, half ellipse, open spline") {
+    RS_Ellipse ellipse(nullptr, {RS_Vector(0,0), RS_Vector(5,0), 0.4, 0.0, M_PI, false});
+    const double d = 0.3;
+    const RS_Vector outsidePoint(0.0, 20.0);
+
+    auto offsets = ellipse.createOffset(outsidePoint, d);
+    REQUIRE(offsets.size() == 1);
+    auto* sp = dynamic_cast<LC_SplinePoints*>(offsets.front());
+    REQUIRE(sp != nullptr);
+    REQUIRE(sp->isClosed() == false);
+
+    const auto& pts = sp->getPoints();
+    REQUIRE(pts.size() >= 8);
+
+    // Endpoints should sit at the exact arc start/end displaced by d along
+    // the outward normal there. At angle 0: ellipse point = (5, 0); tangent
+    // (0, b·1) → outward normal +x. So offset endpoint ≈ (5+d, 0).
+    REQUIRE_THAT(pts.front().x, Catch::Matchers::WithinAbs(5.0 + d, 1.0e-9));
+    REQUIRE_THAT(pts.front().y, Catch::Matchers::WithinAbs(0.0, 1.0e-9));
+    // At angle π: ellipse point = (-5, 0); tangent (0, -b) → outward normal -x.
+    REQUIRE_THAT(pts.back().x, Catch::Matchers::WithinAbs(-5.0 - d, 1.0e-9));
+    REQUIRE_THAT(pts.back().y, Catch::Matchers::WithinAbs(0.0, 1.0e-9));
+
+    for (auto* o : offsets) delete o;
+}
+
+TEST_CASE("RS_Ellipse::createOffset reversed arc preserves geometry") {
+    RS_Ellipse forward(nullptr, {RS_Vector(0,0), RS_Vector(5,0), 0.4, 0.0, M_PI, false});
+    RS_Ellipse reversed(nullptr, {RS_Vector(0,0), RS_Vector(5,0), 0.4, M_PI, 0.0, true});
+    const double d = 0.3;
+    const RS_Vector outsidePoint(0.0, 20.0);
+
+    auto fwd = forward.createOffset(outsidePoint, d);
+    auto rev = reversed.createOffset(outsidePoint, d);
+    REQUIRE(fwd.size() == 1);
+    REQUIRE(rev.size() == 1);
+    auto* spF = dynamic_cast<LC_SplinePoints*>(fwd.front());
+    auto* spR = dynamic_cast<LC_SplinePoints*>(rev.front());
+    REQUIRE(spF != nullptr);
+    REQUIRE(spR != nullptr);
+
+    // Reversed arc samples the same geometric curve in reverse order: front
+    // and back endpoints should be swapped (modulo any small step-discretization
+    // differences in the interior).
+    REQUIRE_THAT(spF->getPoints().front().x,
+                 Catch::Matchers::WithinAbs(spR->getPoints().back().x, 1.0e-9));
+    REQUIRE_THAT(spF->getPoints().back().x,
+                 Catch::Matchers::WithinAbs(spR->getPoints().front().x, 1.0e-9));
+
+    for (auto* o : fwd) delete o;
+    for (auto* o : rev) delete o;
+}
+
+TEST_CASE("RS_Ellipse::createOffset rejects degenerate inputs") {
+    // Zero distance.
+    {
+        RS_Ellipse e(nullptr, {RS_Vector(0,0), RS_Vector(5,0), 0.4, 0.0, 0.0, false});
+        REQUIRE(e.createOffset(RS_Vector(20,0), 0.0).empty());
+    }
+    // Zero major radius.
+    {
+        RS_Ellipse e(nullptr, {RS_Vector(0,0), RS_Vector(0,0), 0.4, 0.0, 0.0, false});
+        REQUIRE(e.createOffset(RS_Vector(20,0), 1.0).empty());
     }
 }

--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -1879,6 +1879,17 @@ bool RS_Modification::offset(const RS_OffsetData& data, const std::vector<RS_Ent
     // too slow:
     for(auto e: entitiesList){
         for (int num=1; num<= numberOfCopies; num++) {
+            // First try the type-changing path (e.g. ellipse → spline).
+            auto offsetCopies = e->createOffset(data.coord, num*data.distance);
+            if (!offsetCopies.empty()) {
+                for (auto* off : offsetCopies) {
+                    off->setHighlighted(false);
+                    clonesList.push_back(off);
+                }
+                continue;
+            }
+
+            // Fall back to the in-place clone+offset path.
             auto ec = e->clone();
             //highlight is used by trim actions. do not carry over flag
             ec->setHighlighted(false);

--- a/librecad/src/ui/action_options/modify/qg_modifyoffsetoptions.ui
+++ b/librecad/src/ui/action_options/modify/qg_modifyoffsetoptions.ui
@@ -186,25 +186,5 @@
  <resources>
   <include location="../../../../res/icons/icons.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>leDist</sender>
-   <signal>textChanged(QString)</signal>
-   <receiver>Ui_ModifyOffsetOptions</receiver>
-   <slot>updateDist(QString)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>55</x>
-     <y>10</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
- <slots>
-  <slot>updateDist(QString)</slot>
- </slots>
+ <connections/>
 </ui>


### PR DESCRIPTION
The offset of an ellipse is not an ellipse, unless the ellipse is a circle.

To support ellipse offsetting,

1. To create a new EllipseOffset primitive entity, but it's rather complicated to provide methods for this new primitive entity: intersection, tangential points, area line integral, etc.;
2. Approximate the offset by a LC_SplinePoints, and use LC_SplinePoints to provide approximate features: intersection, tangential points, etc..

The current PR implements the ellipse offset feature by the simpler approximation of #2.