### PR TITLE
Mtext rtl port 2.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,7 @@ librecad/src/lib/debug/lc_crashhandler.cpp
 librecad/src/lib/engine/rs_flags.cpp
 librecad/src/lib/engine/rs_pen.cpp
 librecad/src/lib/engine/lc_rect.cpp
+librecad/src/lib/engine/lc_textbidi.cpp
 librecad/src/lib/engine/rs_leader.cpp
 librecad/src/lib/engine/rs_overlaybox.cpp
 librecad/src/lib/engine/rs_overlayline.cpp

--- a/libraries/libdxfrw/src/drw_entities.cpp
+++ b/libraries/libdxfrw/src/drw_entities.cpp
@@ -1470,9 +1470,12 @@ bool DRW_MText::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
     }
     height = buf->getBitDouble();/* Text height BD 40 Undocumented */
     textgen = buf->getBitShort(); /* Attachment BS 71 Similar to justification; */
-    /* Drawing dir BS 72 Left to right, etc.; see DXF doc */
-    dint16 draw_dir = buf->getBitShort();
-    DRW_UNUSED(draw_dir);
+    /* Drawing dir BS 72 Left to right, etc.; see DXF doc. Reuse the
+     * inherited alignH slot — for MTEXT this field carries the DXF group 72
+     * "drawing direction" code (1=LtoR, 3=TtoB, 5=ByStyle), not the TEXT
+     * horizontal-alignment values the HAlign enum was named for. The integer
+     * round-trips cleanly; consumers compare against the raw integer. */
+    alignH = static_cast<HAlign>(buf->getBitShort());
     /* Extents ht BD Undocumented and not present in DXF or entget */
     double ext_ht = buf->getBitDouble();
     DRW_UNUSED(ext_ht);

--- a/libraries/libdxfrw/src/libdxfrw.cpp
+++ b/libraries/libdxfrw/src/libdxfrw.cpp
@@ -1273,6 +1273,9 @@ bool dxfRW::writeMText(DRW_MText *ent){
         writer->writeInt16(73, ent->alignV);
         writer->writeDouble(44, ent->interlin);
 //RLZ ... 11, 21, 31 needed?
+        if (!ent->extData.empty()) {
+            writeExtData(ent->extData);
+        }
     } else {
         //RLZ: TODO convert mtext in text lines (not exist in acad 12)
     }
@@ -1826,6 +1829,18 @@ bool dxfRW::writeObjects() {
     iface->writeObjects();
 
     return true;
+}
+
+bool dxfRW::writeExtData(
+    const std::vector<std::shared_ptr<DRW_Variant>> &ed) {
+    // Re-pack as raw pointers so we share the existing implementation. The
+    // raw pointers do not own — same lifetime as the shared_ptrs in @p ed.
+    std::vector<DRW_Variant*> raw;
+    raw.reserve(ed.size());
+    for (const auto &sp : ed) {
+        if (sp) raw.push_back(sp.get());
+    }
+    return writeExtData(raw);
 }
 
 bool dxfRW::writeExtData(const std::vector<DRW_Variant*> &ed){

--- a/libraries/libdxfrw/src/libdxfrw.h
+++ b/libraries/libdxfrw/src/libdxfrw.h
@@ -125,6 +125,9 @@ private:
     bool writeBlocks();
     bool writeObjects();
     bool writeExtData(const std::vector<DRW_Variant*> &ed);
+    /* Entity-flavoured overload: entities own extData via shared_ptr, table
+     * records own raw pointers. Same DXF codes, different storage. */
+    bool writeExtData(const std::vector<std::shared_ptr<DRW_Variant>> &ed);
     /*use version from dwgutil.h*/
     std::string toHexStr(int n);//RLZ removeme
     bool writeAppData(const std::list<std::list<DRW_Variant>> &appData);

--- a/librecad/src/lib/engine/lc_textbidi.cpp
+++ b/librecad/src/lib/engine/lc_textbidi.cpp
@@ -1,0 +1,48 @@
+/****************************************************************************
+**
+** This file is part of the LibreCAD project, a 2D CAD program
+**
+** Copyright (C) 2026 LibreCAD (librecad.org)
+** Copyright (C) 2026 Dongxu Li github.com/dxli
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+**********************************************************************/
+
+#include "lc_textbidi.h"
+
+#include <QStringList>
+
+namespace lc { namespace textbidi {
+
+QString mirrorByLine(const QString& input) {
+    QStringList lines = input.split(QLatin1Char('\n'));
+    for (QString& line : lines) {
+        QString out;
+        out.reserve(line.size());
+        int i = line.size();
+        while (i > 0) {
+            --i;
+            if (i > 0 && line.at(i).isLowSurrogate()
+                && line.at(i - 1).isHighSurrogate()) {
+                out.append(line.at(i - 1));
+                out.append(line.at(i));
+                --i;
+            } else {
+                out.append(line.at(i));
+            }
+        }
+        line = out;
+    }
+    return lines.join(QLatin1Char('\n'));
+}
+
+}}  // namespace lc::textbidi

--- a/librecad/src/lib/engine/lc_textbidi.h
+++ b/librecad/src/lib/engine/lc_textbidi.h
@@ -1,0 +1,46 @@
+/****************************************************************************
+**
+** This file is part of the LibreCAD project, a 2D CAD program
+**
+** Copyright (C) 2026 LibreCAD (librecad.org)
+** Copyright (C) 2026 Dongxu Li github.com/dxli
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+**********************************************************************/
+
+#ifndef LC_TEXTBIDI_H
+#define LC_TEXTBIDI_H
+
+class QString;
+
+namespace lc { namespace textbidi {
+
+/**
+ * Reverse each line of @p input by code point, keeping surrogate pairs
+ * together. Lines (separated by '\n') are mirrored independently; line
+ * order is preserved.
+ *
+ * Used by the MText edit dialog to flip the visible buffer when the
+ * drawingDirection radio toggle is changed, so the same logical text
+ * reads in the new direction without changing what's stored on the
+ * entity.
+ *
+ * Involutive: mirrorByLine(mirrorByLine(s)) == s.
+ *
+ * Single-line input is supported transparently — without a newline the
+ * function reduces to a whole-string mirror.
+ */
+QString mirrorByLine(const QString& input);
+
+}}  // namespace lc::textbidi
+
+#endif  // LC_TEXTBIDI_H

--- a/librecad/src/lib/engine/rs_block.h
+++ b/librecad/src/lib/engine/rs_block.h
@@ -174,7 +174,7 @@ public:
     /**
      * Sets the parent documents modified status to 'm'.
      */
-	virtual void setModified(bool m);
+	void setModified(bool m) override;
 
     /**
      * Sets only this block modified status to 'm'

--- a/librecad/src/lib/engine/rs_document.h
+++ b/librecad/src/lib/engine/rs_document.h
@@ -114,7 +114,7 @@ public:
 	/**
 	 * Sets the documents modified status to 'm'.
 	 */
-    void setModified(bool m) {
+    virtual void setModified(bool m) {
 		//std::cout << "RS_Document::setModified: %d" << (int)m << std::endl;
 		modified = m;
 	}
@@ -123,7 +123,7 @@ public:
 	 * @retval true The document has been modified since it was last saved.
 	 * @retval false The document has not been modified since it was last saved.
 	 */
-    bool isModified() const {
+    virtual bool isModified() const {
         return modified;
     }
 

--- a/librecad/src/lib/engine/rs_graphic.h
+++ b/librecad/src/lib/engine/rs_graphic.h
@@ -264,14 +264,14 @@ public:
      * @retval true The document has been modified since it was last saved.
      * @retval false The document has not been modified since it was last saved.
      */
-    virtual bool isModified() const {
+    bool isModified() const override {
         return modified || layerList.isModified() || blockList.isModified();
     }
 
     /**
      * Sets the documents modified status to 'm'.
      */
-    virtual void setModified(bool m) {
+    void setModified(bool m) override {
         modified = m;
         layerList.setModified(m);
         blockList.setModified(m);

--- a/librecad/src/lib/engine/rs_mtext.cpp
+++ b/librecad/src/lib/engine/rs_mtext.cpp
@@ -99,6 +99,15 @@ void RS_MText::setText(QString t) {
   }
 }
 
+void RS_MText::setDrawingDirection(
+    RS_MTextData::MTextDrawingDirection direction) {
+  if (data.drawingDirection == direction) return;
+  data.drawingDirection = direction;
+  if (data.updateMode == RS2::Update) {
+    update();
+  }
+}
+
 /**
  * Gets the alignment as an int.
  *

--- a/librecad/src/lib/engine/rs_mtext.h
+++ b/librecad/src/lib/engine/rs_mtext.h
@@ -170,9 +170,7 @@ public:
   RS_MTextData::MTextDrawingDirection getDrawingDirection() const {
     return data.drawingDirection;
   }
-  void setDrawingDirection(RS_MTextData::MTextDrawingDirection direction) {
-    data.drawingDirection = direction;
-  }
+  void setDrawingDirection(RS_MTextData::MTextDrawingDirection direction);
   RS_MTextData::MTextLineSpacingStyle getLineSpacingStyle() const {
     return data.lineSpacingStyle;
   }

--- a/librecad/src/lib/filters/rs_filterdxfrw.cpp
+++ b/librecad/src/lib/filters/rs_filterdxfrw.cpp
@@ -801,6 +801,31 @@ void RS_FilterDXFRW::addMText(const DRW_MText& data) {
         }
     }
 
+    // RightToLeft has no DXF group-72 encoding. If the source file was
+    // written by LibreCAD with the XDATA marker (app id "LibreCad",
+    // code 1071), restore the RTL setting here.
+    {
+        bool wantRTL = false;
+        for (size_t k = 0; k + 1 < data.extData.size(); ++k) {
+            const auto& appTag = data.extData[k];
+            if (!appTag || appTag->code() != 1001
+                || appTag->type() != DRW_Variant::STRING
+                || appTag->content.s == nullptr
+                || *appTag->content.s != "LibreCad") continue;
+            for (size_t j = k + 1; j < data.extData.size(); ++j) {
+                const auto& v = data.extData[j];
+                if (!v) continue;
+                if (v->code() == 1001) break;
+                if (v->code() == 1071 && v->type() == DRW_Variant::INTEGER
+                    && v->content.i != 0) {
+                    wantRTL = true;
+                }
+            }
+            if (wantRTL) break;
+        }
+        if (wantRTL) dir = RS_MTextData::RightToLeft;
+    }
+
     RS_MTextData d(ip, data.height, data.widthscale,
                   valign, halign,
                   dir, lss,
@@ -2571,11 +2596,26 @@ void RS_FilterDXFRW::writeMText(RS_MText* t) {
         } else if (t->getVAlign()==RS_MTextData::VABottom) {
             text->textgen += 6;
         }
-        if (t->getDrawingDirection() == RS_MTextData::LeftToRight)
-            text->alignH = (DRW_Text::HAlign)1;
-        else if (t->getDrawingDirection() == RS_MTextData::TopToBottom)
-            text->alignH = (DRW_Text::HAlign)3;
-        else text->alignH = (DRW_Text::HAlign)5;
+        // DXF MTEXT group 72: 1=LeftToRight, 3=TopToBottom, 5=ByStyle.
+        // RightToLeft has no DXF encoding — emit LeftToRight so other
+        // readers see a defined direction; the RTL flag round-trips via
+        // XDATA (LibreCad app id, code 1071) appended below.
+        switch (t->getDrawingDirection()) {
+        case RS_MTextData::TopToBottom:
+            text->alignH = (DRW_Text::HAlign)3; break;
+        case RS_MTextData::ByStyle:
+            text->alignH = (DRW_Text::HAlign)5; break;
+        case RS_MTextData::LeftToRight:
+        case RS_MTextData::RightToLeft:
+        default:
+            text->alignH = (DRW_Text::HAlign)1; break;
+        }
+        if (t->getDrawingDirection() == RS_MTextData::RightToLeft) {
+            text->extData.push_back(std::make_shared<DRW_Variant>(
+                1001, std::string("LibreCad")));
+            text->extData.push_back(
+                std::make_shared<DRW_Variant>(1071, dint32{1}));
+        }
 		if (t->getLineSpacingStyle() == RS_MTextData::AtLeast)
             text->alignV = (DRW_Text::VAlign)1;
         else text->alignV = (DRW_Text::VAlign)2;

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -1632,6 +1632,13 @@ QC_MDIWindow* QC_ApplicationWindow::slotFileNew(RS_Document* doc) {
 
         // Link the block list to the block widget
         graphic->addBlockListListener(blockWidget);
+
+        // Let the MDI sub-window observe layer/block list changes too,
+        // so its windowModified state (the "[*]" in the title) reflects
+        // any modification — including entity adds, which propagate to
+        // the layer list via RS_Graphic::setModified.
+        graphic->addLayerListListener(w);
+        graphic->addBlockListListener(w);
     }
 	// Link the dialog factory to the coordinate widget:
 	if( coordinateWidget){

--- a/librecad/src/src.pro
+++ b/librecad/src/src.pro
@@ -195,6 +195,7 @@ HEADERS += \
     lib/engine/rs_leader.h \
     lib/engine/rs_line.h \
     lib/engine/rs_mtext.h \
+    lib/engine/lc_textbidi.h \
     lib/engine/rs_overlayline.h \
     lib/engine/rs_overlaybox.h \
     lib/engine/rs_pattern.h \
@@ -349,6 +350,7 @@ SOURCES += \
     lib/engine/rs_leader.cpp \
     lib/engine/rs_line.cpp \
     lib/engine/rs_mtext.cpp \
+    lib/engine/lc_textbidi.cpp \
     lib/engine/rs_overlayline.cpp \
     lib/engine/rs_overlaybox.cpp \
     lib/engine/rs_pattern.cpp \

--- a/librecad/src/ui/forms/qg_dlgmtext.cpp
+++ b/librecad/src/ui/forms/qg_dlgmtext.cpp
@@ -25,18 +25,26 @@
 **********************************************************************/
 
 #include <vector>
+#include <QTextBlock>
+#include <QTextBlockFormat>
 #include <QTextCodec>
+#include <QTextCursor>
+#include <QTextDocument>
+#include <QTextOption>
 #include <QTextStream>
 #include <QFileDialog>
 #include <QPalette>
 
 #include "qg_dlgmtext.h"
 
+#include "lc_textbidi.h"
 #include "rs_system.h"
 #include "rs_settings.h"
 #include "rs_font.h"
 #include "rs_graphic.h"
 #include "rs_math.h"
+
+using lc::textbidi::mirrorByLine;
 
 /*
  *  Constructs a QG_DlgMText as a child of 'parent', with the
@@ -113,6 +121,13 @@ void QG_DlgMText::init() {
     teText->QFrame::setMidLineWidth(0);
     teText->QFrame::setFrameStyle(QFrame::Box|QFrame::Plain);
     teText->installEventFilter(this);
+
+    // Wire up the LTR/RTL radio buttons. Connecting only rbLeftToRight is
+    // sufficient — the radio buttons are mutually exclusive, so toggling
+    // either fires the off-edge of rbLeftToRight (or its on-edge), and our
+    // slot reads the current state via isChecked().
+    connect(rbLeftToRight, &QRadioButton::toggled,
+            this, &QG_DlgMText::layoutDirectionChanged);
 }
 
 
@@ -148,12 +163,18 @@ void QG_DlgMText::destroy() {
         //RS_SETTINGS->writeEntry("/TextWordSpacing", leWordSpacing->text());
         RS_SETTINGS->writeEntry("/TextLineSpacingFactor",
                                 leLineSpacingFactor->text());
-        RS_SETTINGS->writeEntry("/TextString", teText->toPlainText());
+        // Mirror the buffer back to logical order before persisting, so the
+        // saved string matches the entity's logical text regardless of the
+        // current direction in the editor.
+        const bool ltr = rbLeftToRight->isChecked();
+        const QString visible = teText->toPlainText();
+        RS_SETTINGS->writeEntry("/TextString",
+                                ltr ? visible : mirrorByLine(visible));
         //RS_SETTINGS->writeEntry("/TextShape", getShape());
         RS_SETTINGS->writeEntry("/TextAngle", leAngle->text());
         //RS_SETTINGS->writeEntry("/TextRadius", leRadius->text());
-        const QString leftToRight{rbLeftToRight->isChecked() ? "1" : "0"};
-        RS_SETTINGS->writeEntry("/TextLeftToRight", leftToRight);
+        RS_SETTINGS->writeEntry("/TextLeftToRight",
+                                QString{ltr ? "1" : "0"});
         RS_SETTINGS->endGroup();
     }
 }
@@ -266,15 +287,22 @@ void QG_DlgMText::setText(RS_MText& t, bool isNew) {
         leLineSpacingFactor->setText(
             QString("%1").arg(font->getLineSpacingFactor()));
     }
-    teText->setText(str);
+    teText->setText(leftToRight ? str : mirrorByLine(str));
     //setShape(shape.toInt());
     leAngle->setText(angle);
     //leRadius->setText(radius);
     teText->setFocus();
     teText->selectAll();
     text->setDrawingDirection(leftToRight ? RS_MTextData::LeftToRight : RS_MTextData::RightToLeft);
-    rbLeftToRight->setChecked(leftToRight);
-    rbRightToLeft->setChecked(!leftToRight);
+    // Block the radio buttons: setChecked would fire layoutDirectionChanged
+    // (connected in init()) which would re-mirror the buffer we just set.
+    {
+        QSignalBlocker bL(rbLeftToRight);
+        QSignalBlocker bR(rbRightToLeft);
+        rbLeftToRight->setChecked(leftToRight);
+        rbRightToLeft->setChecked(!leftToRight);
+    }
+    applyDirectionVisuals();
 }
 
 
@@ -295,7 +323,11 @@ void QG_DlgMText::updateText() {
             )
         );
 #else*/
-        text->setText(teText->toPlainText());
+        {
+            const bool ltr = rbLeftToRight->isChecked();
+            const QString visible = teText->toPlainText();
+            text->setText(ltr ? visible : mirrorByLine(visible));
+        }
 //#endif
         //text->setLetterSpacing(leLetterSpacing.toDouble());
         text->setLineSpacingFactor(leLineSpacingFactor->text().toDouble());
@@ -436,6 +468,56 @@ void QG_DlgMText::insertChar() {
     int i1 = t.indexOf(']');
     int c = t.mid(1, i1-1).toInt(nullptr, 16);
     teText->textCursor().insertText( QString("%1").arg(QChar(c)) );
+}
+
+void QG_DlgMText::layoutDirectionChanged() {
+    const bool leftToRight = rbLeftToRight->isChecked();
+    rbRightToLeft->setChecked(!leftToRight);
+
+    // Flip the visible buffer so the same logical text now reads in the
+    // newly-selected direction. The entity's text field is unchanged here;
+    // it gets rewritten in updateText() from the (mirrored-back) buffer.
+    {
+        QSignalBlocker textBlocker(teText);
+        const QString visible = teText->toPlainText();
+        teText->setPlainText(mirrorByLine(visible));
+    }
+
+    if (text != nullptr) {
+        text->setDrawingDirection(
+            leftToRight ? RS_MTextData::LeftToRight
+                        : RS_MTextData::RightToLeft);
+    }
+    applyDirectionVisuals();
+}
+
+void QG_DlgMText::applyDirectionVisuals() {
+    const bool leftToRight = rbLeftToRight->isChecked();
+    const Qt::LayoutDirection direction =
+        leftToRight ? Qt::LeftToRight : Qt::RightToLeft;
+    teText->setLayoutDirection(direction);
+
+    QTextDocument* doc = teText->document();
+    if (doc == nullptr) return;
+
+    QTextOption option = doc->defaultTextOption();
+    option.setTextDirection(direction);
+    doc->setDefaultTextOption(option);
+
+    // Stamp per-block layout direction so already-typed blocks reflow now —
+    // setDefaultTextOption alone only governs future content.
+    QSignalBlocker textBlocker(teText);
+    QTextCursor cursor(doc);
+    cursor.beginEditBlock();
+    cursor.movePosition(QTextCursor::Start);
+    do {
+        QTextBlockFormat fmt = cursor.blockFormat();
+        fmt.setLayoutDirection(direction);
+        cursor.setBlockFormat(fmt);
+    } while (cursor.movePosition(QTextCursor::NextBlock));
+    cursor.endEditBlock();
+
+    teText->update();
 }
 
 /*

--- a/librecad/src/ui/forms/qg_dlgmtext.cpp
+++ b/librecad/src/ui/forms/qg_dlgmtext.cpp
@@ -163,9 +163,9 @@ void QG_DlgMText::destroy() {
         //RS_SETTINGS->writeEntry("/TextWordSpacing", leWordSpacing->text());
         RS_SETTINGS->writeEntry("/TextLineSpacingFactor",
                                 leLineSpacingFactor->text());
-        // Mirror the buffer back to logical order before persisting, so the
-        // saved string matches the entity's logical text regardless of the
-        // current direction in the editor.
+        // The textedit holds the visually-mirrored buffer in RTL mode;
+        // mirror back to logical order so the saved string is portable
+        // and matches what the entity stores.
         const bool ltr = rbLeftToRight->isChecked();
         const QString visible = teText->toPlainText();
         RS_SETTINGS->writeEntry("/TextString",
@@ -287,22 +287,26 @@ void QG_DlgMText::setText(RS_MText& t, bool isNew) {
         leLineSpacingFactor->setText(
             QString("%1").arg(font->getLineSpacingFactor()));
     }
-    teText->setText(leftToRight ? str : mirrorByLine(str));
     //setShape(shape.toInt());
     leAngle->setText(angle);
     //leRadius->setText(radius);
-    teText->setFocus();
-    teText->selectAll();
     text->setDrawingDirection(leftToRight ? RS_MTextData::LeftToRight : RS_MTextData::RightToLeft);
-    // Block the radio buttons: setChecked would fire layoutDirectionChanged
-    // (connected in init()) which would re-mirror the buffer we just set.
     {
         QSignalBlocker bL(rbLeftToRight);
         QSignalBlocker bR(rbRightToLeft);
         rbLeftToRight->setChecked(leftToRight);
         rbRightToLeft->setChecked(!leftToRight);
     }
+    // Apply direction before loading text so freshly created blocks inherit
+    // the correct direction from the document's default text option. In RTL
+    // mode the visible buffer is mirrored by code point so all runs
+    // (including Latin/digits) display reversed — matching the canvas
+    // renderer, which uses the same positional mirror.
     applyDirectionVisuals();
+    teText->setPlainText(leftToRight ? str : mirrorByLine(str));
+    applyDirectionVisuals();
+    teText->setFocus();
+    teText->selectAll();
 }
 
 
@@ -428,7 +432,10 @@ void QG_DlgMText::load(const QString& fn) {
     }
 
     QTextStream ts(&f);
-    teText->setText(ts.readAll());
+    const QString loaded = ts.readAll();
+    const bool ltr = rbLeftToRight->isChecked();
+    teText->setPlainText(ltr ? loaded : mirrorByLine(loaded));
+    applyDirectionVisuals();
 }
 
 void QG_DlgMText::saveText() {
@@ -439,7 +446,9 @@ void QG_DlgMText::saveText() {
 }
 
 void QG_DlgMText::save(const QString& fn) {
-    QString text = teText->toPlainText();
+    const bool ltr = rbLeftToRight->isChecked();
+    const QString visible = teText->toPlainText();
+    const QString text = ltr ? visible : mirrorByLine(visible);
     QFile f(fn);
     if (f.open(QIODevice::WriteOnly)) {
         QTextStream t(&f);
@@ -475,8 +484,10 @@ void QG_DlgMText::layoutDirectionChanged() {
     rbRightToLeft->setChecked(!leftToRight);
 
     // Flip the visible buffer so the same logical text now reads in the
-    // newly-selected direction. The entity's text field is unchanged here;
-    // it gets rewritten in updateText() from the (mirrored-back) buffer.
+    // newly-selected direction. mirrorByLine is involutive, so toggling
+    // back and forth restores the original buffer. The entity's text
+    // field is unchanged here; updateText() rewrites it from the
+    // (mirrored-back) buffer when the user accepts the dialog.
     {
         QSignalBlocker textBlocker(teText);
         const QString visible = teText->toPlainText();

--- a/librecad/src/ui/forms/qg_dlgmtext.h
+++ b/librecad/src/ui/forms/qg_dlgmtext.h
@@ -66,8 +66,10 @@ public slots:
 
 protected slots:
     virtual void languageChange();
+    void layoutDirectionChanged();
 
 private:
+    void applyDirectionVisuals();
     bool isNew = false;
     bool saveSettings = true;
     RS_MText* text = nullptr;


### PR DESCRIPTION
issue #1859 : support for Right-to-left languages in MText

Backported from the master branch, as part of internationalization improvement of the 2.2.1 branch.

Minimum-change backport of MText right-to-left support from the dwg branch so toggling RTL in the MText edit dialog flips the visible characters (1234 -> 4321), the DWG load path no longer silently discards the drawing-direction byte (was DRW_UNUSED in libdxfrw), and the RTL flag round-trips through DXF via XDATA (app id "LibreCad", code 1071) since group 72 has no RTL value.