### PR TITLE
Issue #2570: scaling factor

### DIFF
--- a/librecad/src/actions/rs_actionmodifyscale.cpp
+++ b/librecad/src/actions/rs_actionmodifyscale.cpp
@@ -127,12 +127,9 @@ RS_Vector RS_ActionModifyScale::getTargetPoint(QMouseEvent* e)
 {
     if (!pPoints->data.isotropicScaling)
         return snapPoint(e);
-    RS_Vector mouse = graphicView->toGraph(e->x(), e->y());
-    // project mouse to the line (center, source)
+    RS_Vector mouse = snapPoint(e);
     RS_Line centerSourceLine{nullptr, {pPoints->data.referencePoint, pPoints->sourcePoint}};
-    RS_Vector projected = centerSourceLine.getNearestPointOnEntity(mouse, false);
-    snapPoint(projected, true);
-    return projected;
+    return centerSourceLine.getNearestPointOnEntity(mouse, false);
 }
 
 void RS_ActionModifyScale::showPreview()


### PR DESCRIPTION
Enable snapper for the Scale tool: need to enable point snapping in the Scale tool, when selecting source and target points to define the scaling factor.