### PR TITLE
Issue2590

### DIFF
--- a/librecad/src/main/main.cpp
+++ b/librecad/src/main/main.cpp
@@ -39,6 +39,7 @@
 #include <QByteArray>
 #include <QDebug>
 #include <QFileInfo>
+#include <QGuiApplication>
 #include <QMessageBox>
 #include <QPainter>
 #include <QPixmap>
@@ -292,6 +293,17 @@ int main(int argc, char** argv) {
     }
 
     RS_DEBUG->setLevel(RS_Debug::D_WARNING);
+
+    // Per-monitor DPI rounding policy must be set BEFORE QGuiApplication
+    // construction. Qt6's default is PassThrough (full fractional scales
+    // honoured); on Windows with 125% / 150% scaling that leaks subpixel
+    // metrics into widget layouts and can grow a window 1-2 logical pixels
+    // larger than the screen edge would otherwise allow. RoundPreferFloor
+    // gives stable integer scales and is the conventional Qt6 hardening.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(
+        Qt::HighDpiScaleFactorRoundingPolicy::RoundPreferFloor);
+#endif
 
     LC_Application app(argc, argv);
     QCoreApplication::setOrganizationName("LibreCAD");

--- a/librecad/src/ui/dialogs/settings/options_widget/lc_iconcolorsoptions.cpp
+++ b/librecad/src/ui/dialogs/settings/options_widget/lc_iconcolorsoptions.cpp
@@ -21,7 +21,10 @@
  ******************************************************************************/
 
 #include <QFile>
+#include <QGuiApplication>
+#include <QPalette>
 #include <QRegularExpression>
+#include <QStyleHints>
 #include <QJsonObject>
 #include <QJsonDocument>
 #include <QJsonArray>
@@ -32,6 +35,43 @@
 #include "rs_settings.h"
 #include "rs_debug.h"
 
+namespace {
+    // Light-scheme template defaults — match the SVG template colors so that
+    // the icon engine's replaceColor() short-circuits and the SVG renders
+    // exactly as authored.
+    constexpr const char* DEFAULT_MAIN_LIGHT       = "#000";
+    constexpr const char* DEFAULT_ACCENT           = "#00ff7f";
+    constexpr const char* DEFAULT_BACKGROUND_LIGHT = "#fff";
+
+    // Dark-scheme defaults — picked to avoid substring collisions in the
+    // engine's naive three-pass QString::replace() at lc_svgiconengine.cpp:368.
+    // Main must not contain "#fff" (would be clobbered by the BG pass);
+    // Background must not contain "#000" (would be clobbered by the Main pass).
+    constexpr const char* DEFAULT_MAIN_DARK       = "#e6e6e6";
+    constexpr const char* DEFAULT_BACKGROUND_DARK = "#1e1e1e";
+
+    inline const char* defaultMain() {
+        return LC_IconColorsOptions::isDarkColorScheme()
+            ? DEFAULT_MAIN_DARK : DEFAULT_MAIN_LIGHT;
+    }
+    inline const char* defaultBackground() {
+        return LC_IconColorsOptions::isDarkColorScheme()
+            ? DEFAULT_BACKGROUND_DARK : DEFAULT_BACKGROUND_LIGHT;
+    }
+}
+
+bool LC_IconColorsOptions::isDarkColorScheme() {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    auto scheme = QGuiApplication::styleHints()->colorScheme();
+    if (scheme != Qt::ColorScheme::Unknown) {
+        return scheme == Qt::ColorScheme::Dark;
+    }
+    // Fall through when Qt can't tell us (some Linux platform themes,
+    // headless builds) — use palette luminance as a fallback.
+#endif
+    return QGuiApplication::palette().color(QPalette::Window).lightnessF() < 0.5;
+}
+
 LC_IconColorsOptions::LC_IconColorsOptions() {
 }
 
@@ -41,9 +81,9 @@ LC_IconColorsOptions::LC_IconColorsOptions(LC_IconColorsOptions &other){
 
 void LC_IconColorsOptions::resetToDefaults() {
     colors.clear();
-    setColor(LC_SVGIconEngineAPI::AnyMode, LC_SVGIconEngineAPI::AnyState, LC_SVGIconEngineAPI::ColorType::Main, "#000");
-    setColor(LC_SVGIconEngineAPI::AnyMode, LC_SVGIconEngineAPI::AnyState, LC_SVGIconEngineAPI::ColorType::Accent, "#00ff7f");
-    setColor(LC_SVGIconEngineAPI::AnyMode, LC_SVGIconEngineAPI::AnyState, LC_SVGIconEngineAPI::ColorType::Background, "#fff");
+    setColor(LC_SVGIconEngineAPI::AnyMode, LC_SVGIconEngineAPI::AnyState, LC_SVGIconEngineAPI::ColorType::Main, defaultMain());
+    setColor(LC_SVGIconEngineAPI::AnyMode, LC_SVGIconEngineAPI::AnyState, LC_SVGIconEngineAPI::ColorType::Accent, DEFAULT_ACCENT);
+    setColor(LC_SVGIconEngineAPI::AnyMode, LC_SVGIconEngineAPI::AnyState, LC_SVGIconEngineAPI::ColorType::Background, defaultBackground());
 }
 
 void LC_IconColorsOptions::apply(LC_IconColorsOptions &other) {
@@ -95,9 +135,9 @@ void LC_IconColorsOptions::applyColor(LC_SVGIconEngineAPI::IconMode mode, LC_SVG
 void LC_IconColorsOptions::loadSettings() {
     LC_GROUP("UiIconsStyling");
     {
-        loadColor(LC_SVGIconEngineAPI::AnyMode, LC_SVGIconEngineAPI::AnyState, LC_SVGIconEngineAPI::ColorType::Main, "#000");
-        loadColor(LC_SVGIconEngineAPI::AnyMode, LC_SVGIconEngineAPI::AnyState, LC_SVGIconEngineAPI::ColorType::Accent, "#00ff7f");
-        loadColor(LC_SVGIconEngineAPI::AnyMode, LC_SVGIconEngineAPI::AnyState, LC_SVGIconEngineAPI::ColorType::Background, "#fff");
+        loadColor(LC_SVGIconEngineAPI::AnyMode, LC_SVGIconEngineAPI::AnyState, LC_SVGIconEngineAPI::ColorType::Main, defaultMain());
+        loadColor(LC_SVGIconEngineAPI::AnyMode, LC_SVGIconEngineAPI::AnyState, LC_SVGIconEngineAPI::ColorType::Accent, DEFAULT_ACCENT);
+        loadColor(LC_SVGIconEngineAPI::AnyMode, LC_SVGIconEngineAPI::AnyState, LC_SVGIconEngineAPI::ColorType::Background, defaultBackground());
 
         loadColor(LC_SVGIconEngineAPI::Active, LC_SVGIconEngineAPI::On, LC_SVGIconEngineAPI::ColorType::Main, "");
         loadColor(LC_SVGIconEngineAPI::Active, LC_SVGIconEngineAPI::On, LC_SVGIconEngineAPI::ColorType::Accent, "");

--- a/librecad/src/ui/dialogs/settings/options_widget/lc_iconcolorsoptions.h
+++ b/librecad/src/ui/dialogs/settings/options_widget/lc_iconcolorsoptions.h
@@ -43,6 +43,10 @@ public:
     void getAvailableStyles(QStringList &list);
     void resetToDefaults();
     void apply(LC_IconColorsOptions &other);
+    // Returns true if the active Qt color scheme (or, on Qt < 6.5, the
+    // current QPalette) indicates dark mode. Used to seed icon defaults
+    // so #000 strokes don't disappear against a dark toolbar.
+    static bool isDarkColorScheme();
     void setIconsOverridesDir(QString path) {iconOverridesDir = path;};
     QString getIconsOverridesDir() {return iconOverridesDir;};
     bool loadFromFile(QString styleName);

--- a/librecad/src/ui/main/qc_applicationwindow.cpp
+++ b/librecad/src/ui/main/qc_applicationwindow.cpp
@@ -31,13 +31,17 @@
 
 
 #include <QCloseEvent>
+#include <QGuiApplication>
 #include <QMdiArea>
 #include <QMessageBox>
 #include <QMimeData>
 #include <QPushButton>
 #include <QStatusBar>
+#include <QStyleHints>
 #include <QTimer>
 #include <QDockWidget>
+
+#include "lc_iconcolorsoptions.h"
 
 #include "lc_actiongroupmanager.h"
 #include "lc_actionoptionsmanager.h"
@@ -125,6 +129,21 @@ QC_ApplicationWindow::QC_ApplicationWindow(){
 
     LC_ApplicationWindowInitializer initializer(this);
     initializer.initApplication();
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    // Re-apply icon styling defaults when the OS color scheme flips so the
+    // toolbar icons don't go invisible on a newly-dark palette. Stored user
+    // overrides are preserved because loadColor() returns the stored value
+    // when present and falls back to the (now theme-aware) default only
+    // when the key is absent.
+    connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged,
+            this, [this](Qt::ColorScheme) {
+                LC_IconColorsOptions opts;
+                opts.loadSettings();
+                opts.applyOptions();
+                fireIconsRefresh();
+            });
+#endif
 }
 /**
  * Destructor.

--- a/librecad/src/ui/main/qc_applicationwindow.cpp
+++ b/librecad/src/ui/main/qc_applicationwindow.cpp
@@ -144,6 +144,17 @@ QC_ApplicationWindow::QC_ApplicationWindow(){
                 fireIconsRefresh();
             });
 #endif
+
+    // Re-paint toolbars when the OS-level primary screen changes (e.g. the
+    // user swaps which monitor is primary while LibreCAD is running). The
+    // canvas's own m_isHiDpi state is computed once at LC_GraphicViewRenderer
+    // construction and currently does NOT re-evaluate here — see the
+    // // fixme - sand comment at lc_graphicviewrenderer.cpp:43. Tracking that
+    // through to the per-MDI-window renderer is follow-up work documented in
+    // Task D of the plan; this connect at least refreshes icons and any
+    // listener wired to iconsRefreshed().
+    connect(qApp, &QGuiApplication::primaryScreenChanged,
+            this, [this](QScreen*) { fireIconsRefresh(); });
 }
 /**
  * Destructor.

--- a/librecad/src/ui/main/workspaces/lc_workspacesmanager.cpp
+++ b/librecad/src/ui/main/workspaces/lc_workspacesmanager.cpp
@@ -21,10 +21,12 @@
  * ********************************************************************************
  */
 
+#include <QGuiApplication>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMessageBox>
+#include <QScreen>
 
 #include "lc_workspacesmanager.h"
 
@@ -34,6 +36,53 @@
 #include "rs_debug.h"
 #include "rs_settings.h"
 #include "rs_system.h"
+
+namespace {
+    // Re-place an already-positioned QWidget so its frame geometry fits
+    // within an available screen. Picks the screen that contains the
+    // saved frame's centre when one exists, falling back to the primary.
+    // If the saved size exceeds the chosen screen's available area, the
+    // window is shrunk to fit; otherwise position-only is corrected.
+    // No-op when the frame is already fully contained.
+    //
+    // Mitigates the Qt6 "re-center keeping saved size" fallback path in
+    // QWidget::restoreGeometry, which on a topology change can land the
+    // window centred on a screen narrower than itself — overflowing
+    // visibly onto a horizontally adjacent secondary.
+    void clampWidgetToScreen(QWidget& w) {
+        const auto screens = QGuiApplication::screens();
+        if (screens.isEmpty()) {
+            return; // headless / not yet realised
+        }
+        const QRect frame = w.frameGeometry();
+
+        // Already fully on some screen? Leave it alone.
+        for (const QScreen* s : screens) {
+            if (s->availableGeometry().contains(frame)) {
+                return;
+            }
+        }
+
+        const QScreen* target = QGuiApplication::screenAt(frame.center());
+        if (target == nullptr) {
+            target = QGuiApplication::primaryScreen();
+        }
+        const QRect available = target->availableGeometry();
+        const int width = qMin(frame.width(), available.width());
+        const int height = qMin(frame.height(), available.height());
+
+        // Centre the resized rect on the chosen screen.
+        QRect dst(0, 0, width, height);
+        dst.moveCenter(available.center());
+
+        // setGeometry sets the *client* rect, not the frame rect. Account
+        // for the frame inset Qt already knows about.
+        const QPoint frameInset = w.geometry().topLeft() - frame.topLeft();
+        const QSize  frameSize  = frame.size() - w.size();
+        w.setGeometry(QRect(dst.topLeft() + frameInset,
+                            QSize(width, height) - frameSize));
+    }
+}
 LC_WorkspacesManager::LC_WorkspacesManager() = default;
 
 LC_WorkspacesManager::~LC_WorkspacesManager() {
@@ -246,6 +295,13 @@ void LC_WorkspacesManager::restoreGeometryAndState(const LC_WorkspacesManager::L
         appWin.resize(windowWidth, windowHeight);
         appWin.move(windowX, windowY);
     }
+
+    // Post-restore clamp. Qt6's restoreGeometry re-centres on the chosen
+    // screen but keeps the saved width/height, so a wide saved window
+    // restored on a narrower primary overflows onto an adjacent secondary.
+    // The raw move/resize branch above doesn't validate at all. Apply a
+    // common clamp so both paths produce a window fully on some screen.
+    clampWidgetToScreen(appWin);
 
     appWin.slotViewStatusBar(workspace.showStatusBar);
     appWin.setUpdatesEnabled(true);


### PR DESCRIPTION
The issue: UI scales up and partially extends onto the second screen
One underneath bug: A wide window saved on a wide monitor and restored on a narrower primary therefore overflows
onto an adjacent secondary
The fix: geometry clamp in LC_WorkspacesManager when restoring window geometry
Another underneath bug: toolbar SVG icons re-paint when the OS-level primary monitor changes. The canvas's per-renderer m_isHiDpi flag at lc_graphicviewrenderer.cpp:43 is only computed once at construction.

a dark toolbar the black Main strokes is invisible
The root cause: LibreCAD's SVG icon engine recolors templates from QApplication properties seeded by LC_IconColorsOptions. Defaults were pinned to 000 / 00ff7f / fff regardless of the OS color scheme, so on a dark
toolbar the black Main strokes became invisible.
The fix: Adds LC_IconColorsOptions::isDarkColorScheme() and uses it to seed Main and Background in both loadSettings() and resetToDefaults()