### PR TITLE
[OLD] Fix proposal for #2578 - Library block factor scale

### DIFF
--- a/librecad/src/lib/creation/rs_creation.cpp
+++ b/librecad/src/lib/creation/rs_creation.cpp
@@ -929,29 +929,49 @@ RS_Insert* RS_Creation::createLibraryInsert(RS_LibraryInsertData& data) {
     RS_Graphic g;
     if (!g.open(data.file, RS2::FormatUnknown)) {
         RS_DEBUG->print(RS_Debug::D_WARNING,
-                        "RS_Creation::createLibraryInsert: Cannot open file: %s", data.file.toStdString().c_str());
+                        "RS_Creation::createLibraryInsert: Cannot open file: %s",
+                        data.file.toStdString().c_str());
         return nullptr;
     }
 
-    // unit conversion:
-    if (graphic) {
-        double uf = RS_Units::convert(1.0, g.getUnit(),
-                                      graphic->getUnit());
-        g.scale(RS_Vector(0.0, 0.0), RS_Vector(uf, uf));
+    QString blockName = QFileInfo(data.file).completeBaseName();
+    RS_BlockData blockData = RS_BlockData(blockName, RS_Vector(0.0, 0.0), false);
+
+    // Add all entities to a block, except insert entities
+    RS_Block* block = new RS_Block(container, blockData);
+    int numberOfEntities = 0;
+    for(auto e: g.getEntityList()) {
+        if (e) {
+            RS_Entity* c = e->clone();
+            if (c->rtti() != RS2::EntityInsert) {
+                block->addEntity(c);
+                numberOfEntities++;
+            }
+        }
+    }
+    // The block is not added nor inserted if empty
+    // (e.g. library file was empty or only made of inserts)
+    if (numberOfEntities == 0) {
+        delete block;
+        return nullptr;
     }
 
-    //g.scale(RS_Vector(data.factor, data.factor));
-    //g.rotate(data.angle);
+    // Add the block if it does not already exist
+    if (graphic) {
+        graphic->addBlock(block);
+    }
 
-    QString s = QFileInfo(data.file).completeBaseName();
-
-    RS_Modification m(*container, graphicView);
-    m.paste(
-                RS_PasteData(
-                    data.insertionPoint,
-                    data.factor, data.angle, true,
-                    s),
-                &g);
+    // Insert the block with provided data
+    RS_InsertData id(
+        blockName,
+        data.insertionPoint,
+        RS_Vector(data.factor, data.factor),
+        data.angle,
+        1,
+        1,
+        RS_Vector(0.0, 0.0)
+    );
+    createInsert(&id);
 
     RS_DEBUG->print("RS_Creation::createLibraryInsert: OK");
 


### PR DESCRIPTION
Hello,

Here is a fix proposal for #2578.

The idea here is to drop the use of RS_Modification::paste(), and use another process instead : 

1. create a block which contains all entities from the library item.
2. add the block to the document if it does not already exist.
3. insert the block with properties based on the values entered by the user.

This code still contains some points that would benefit from clarification (which are present in current code) :

- If a library item contains blocks, they are skipped. (Is that the intended behaviour ? Should those blocks be decomposed into atomic entities before being inserted as parts of the main block ? Maybe trying to preserve the block/insert structure of the library item during the insert is another idea, but this would result in the creation of numerous blocks within the document, which might not suit the user needs.)
- If the operation is undone afterwards, the inserted block remains in the document block list (which could be complicated to manage since the block may exist in the document before the insert attempt).
- If a block with a same name as the library item already exist in the document, the operation results in inserting this block instead.

I point this PR to 2.2.1. Maybe pointing it to master is the way to go. What is the current dev policy between master and 2.2.1 ?

P.S. : I drop the use of RS_Units::convert() in this proposal, but maybe it is needed to keep it here.

I hope this proposal will help us find ways to resolve the initial issue.

Thanks in advance.

Best regards,

qwlvove