### PR TITLE
Fix proposal for #2604 - Circle center-point error

### DIFF
--- a/librecad/src/actions/rs_actiondrawcircle.cpp
+++ b/librecad/src/actions/rs_actiondrawcircle.cpp
@@ -109,7 +109,7 @@ void RS_ActionDrawCircle::mouseMoveEvent(QMouseEvent* e) {
         }
         break;
 
-    case SetRadius:
+    case SetPoint:
 		if (data->center.valid) {
 			data->radius = data->center.distanceTo(mouse);
             deletePreview();
@@ -148,10 +148,10 @@ void RS_ActionDrawCircle::coordinateEvent(RS_CoordinateEvent* e) {
     case SetCenter:
 		data->center = mouse;
         graphicView->moveRelativeZero(mouse);
-        setStatus(SetRadius);
+        setStatus(SetPoint);
         break;
 
-    case SetRadius:
+    case SetPoint:
 		if (data->center.valid) {
             graphicView->moveRelativeZero(mouse);
 			data->radius = data->center.distanceTo(mouse);
@@ -167,40 +167,12 @@ void RS_ActionDrawCircle::coordinateEvent(RS_CoordinateEvent* e) {
 
 
 
-void RS_ActionDrawCircle::commandEvent(RS_CommandEvent* e) {
-    QString c = e->getCommand().toLower();
-
-	if (checkCommand("help", c)) {
-		RS_DIALOGFACTORY->commandMessage(msgAvailableCommands()
-										 + getAvailableCommands().join(", "));
-		return;
-	}
-
-    switch (getStatus()) {
-
-    case SetRadius: {
-            bool ok = false;
-            double r = RS_Math::eval(c, &ok);
-            if (ok && r > RS_TOLERANCE) {
-                data->radius = r;
-                e->accept();
-                trigger();
-            } else
-                RS_DIALOGFACTORY->commandMessage(tr("Not a valid expression"));
-        }
-
-    default:
-        break;
-    }
-}
-
-
 void RS_ActionDrawCircle::updateMouseButtonHints() {
     switch (getStatus()) {
     case SetCenter:
         RS_DIALOGFACTORY->updateMouseWidget(tr("Specify center"), tr("Cancel"));
         break;
-    case SetRadius:
+    case SetPoint:
         RS_DIALOGFACTORY->updateMouseWidget(tr("Specify point on circle"), tr("Back"));
         break;
     default:

--- a/librecad/src/actions/rs_actiondrawcircle.h
+++ b/librecad/src/actions/rs_actiondrawcircle.h
@@ -47,7 +47,7 @@ public:
      */
     enum Status {
         SetCenter,       /**< Setting the center point. */
-        SetRadius        /**< Setting the radius. */
+        SetPoint         /**< Setting the point on the circle. */
     };
 
 public:
@@ -64,8 +64,7 @@ public:
 	void mouseMoveEvent(QMouseEvent* e) override;
 	void mouseReleaseEvent(QMouseEvent* e) override;
 	
-	void coordinateEvent(RS_CoordinateEvent* e) override;
-	void commandEvent(RS_CommandEvent* e) override;
+    void coordinateEvent(RS_CoordinateEvent* e) override;
 	
 	void hideOptions() override;
 	void showOptions() override;


### PR DESCRIPTION
Hello,

Here is a fix proposal for #2604.

The idea is to remove the function commandEvent() from RS_ActionDrawCircle to align with other circle actions which need coordinates (such as RS_ActionDrawCircle2P or RS_ActionDrawCircle3P). This function currently overrides the intended behaviour.

I suggest to rename status "SetRadius" to "SetPoint" to avoid confusion.

Best regards,

qwilvove