### PR TITLE
dxf2png: add missing RS_FONTLIST->init() call

### DIFF
--- a/librecad/src/main/console_dxf2png.cpp
+++ b/librecad/src/main/console_dxf2png.cpp
@@ -176,8 +176,10 @@ int console_dxf2png(int argc, char* argv[])
     if (outFile.isEmpty()) {
         outFile = dxfFileInfo.path() + "/" + fn + "." + args[0].mid(args[0].size()-3);
     } else {
-        outFile = dxfFileInfo.path() + "/" + outFile;
+        outFile = QFileInfo(outFile).isAbsolute() ? outFile : dxfFileInfo.path() + "/" + outFile;
     }
+
+    RS_FONTLIST->init();
 
     // Open the file and process the graphics
 


### PR DESCRIPTION
Text entities were not rendered in dxf2png CLI export because RS_FONTLIST->init() was never called, leaving the font list empty when openDocAndSetGraphic() processes the DXF file.

Also fixes absolute output path handling with -o flag.