### PR TITLE
Issue #2608: fixed a crash by redo

### DIFF
--- a/librecad/src/actions/drawing/draw/line/lc_actiondrawlinesnake.cpp
+++ b/librecad/src/actions/drawing/draw/line/lc_actiondrawlinesnake.cpp
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #include "lc_linemath.h"
 #include "lc_lineoptions.h"
+#include "rs_document.h"
 
 LC_ActionDrawLineSnake::LC_ActionDrawLineSnake(LC_ActionContext *actionContext,RS2::ActionType actionType)
     :LC_AbstractActionDrawLine("Draw line snake",actionContext, actionType)
@@ -337,8 +338,11 @@ bool LC_ActionDrawLineSnake::doProceedCommand([[maybe_unused]]int status, const 
         updateMouseButtonHints();
     } else if (checkCommand("polyline", c) ||
                checkCommand("pl", c)){
-        polyline();
-        updateMouseButtonHints();
+        // Issue #2608: polyline() may switch to another action and destroy *this*;
+        // only touch this/members afterwards when it did NOT switch.
+        if (!polyline()) {
+            updateMouseButtonHints();
+        }
     } else if (checkCommand("redo", c)){
         redo();
         updateMouseButtonHints();
@@ -559,7 +563,13 @@ void LC_ActionDrawLineSnake::undo(){
             case HA_Polyline:
             case HA_SetEndpoint:
             case HA_Close:
-                switchToAction(RS2::ActionEditUndo);
+                // Issue #2608: undo via the document stack directly.
+                // switchToAction() would launch a one-shot ActionEditUndo that
+                // finishes in init() and makes LC_EventHandler destroy *this*
+                // while undo() is still on the stack, so the m_actionData access
+                // below would be a use-after-free.
+                m_document->undo();
+                redrawDrawing();
                 m_actionData->data.startpoint = h.prevPt;
                 setStatus(SetDirection);
                 break;
@@ -597,12 +607,17 @@ void LC_ActionDrawLineSnake::redo(){
 
             case HA_Polyline:
             case HA_SetEndpoint:
-                switchToAction(RS2::ActionEditRedo);
+                // Issue #2608: redo via the document stack directly; see undo()
+                // above for why switchToAction(RS2::ActionEditRedo) is unsafe
+                // here (it destroys *this* while redo() is still on the stack).
+                m_document->redo();
+                redrawDrawing();
                 setStatus(SetDirection);
                 break;
 
             case HA_Close:
-                switchToAction(RS2::ActionEditRedo);
+                m_document->redo();
+                redrawDrawing();
                 setStatus(SetDirection);
                 break;
 
@@ -645,15 +660,23 @@ void LC_ActionDrawLineSnake::close(){
 }
 
 // creation of polyline. This will end line drawing sequence
-void LC_ActionDrawLineSnake::polyline(){
+bool LC_ActionDrawLineSnake::polyline(){
     // fixme - add support of alternative way of polyline based on selected entities (so only drawn lines will be converted to polyline, without others found
     RS_Entity *en = catchEntity(m_actionData->data.endpoint, RS2::EntityLine, RS2::ResolveAllButTextImage);
     if (en != nullptr){
         finishAction();
         addHistory(HA_Polyline, m_actionData->data.startpoint, m_actionData->data.endpoint, m_actionData->startOffset);
         // fixme - sand - files - direct action creation
+        // Issue #2608: switchToAction(ActionPolylineSegment) DESTROYS *this*: the
+        // segment action is a one-shot that finishes inside init() and does not
+        // support a predecessor, so LC_EventHandler resets m_currentAction and the
+        // only remaining ref to this action dies. It must be the LAST statement and
+        // the caller must not touch this/members afterwards (signalled by the true
+        // return).
         switchToAction(RS2::ActionPolylineSegment, en);
+        return true;
     }
+    return false;
 }
 
 bool LC_ActionDrawLineSnake::mayClose(){

--- a/librecad/src/actions/drawing/draw/line/lc_actiondrawlinesnake.h
+++ b/librecad/src/actions/drawing/draw/line/lc_actiondrawlinesnake.h
@@ -35,7 +35,10 @@ public:
     void next();
     void undo();
     void redo();
-    void polyline();
+    /// Converts the drawn lines to a polyline. Returns true if it switched to
+    /// another action (which destroys *this*); the caller must not touch this/
+    /// members afterwards when it returns true (Issue #2608).
+    bool polyline();
     bool mayClose();
     bool mayUndo() const;
     bool mayStart() override;

--- a/librecad/src/actions/drawing/draw/line/rs_actiondrawline.cpp
+++ b/librecad/src/actions/drawing/draw/line/rs_actiondrawline.cpp
@@ -386,12 +386,20 @@ void RS_ActionDrawLine::redo(){
                 break;
             }
             case HA_SetEndpoint: {
-                switchToAction(RS2::ActionEditRedo);
+                // Issue #2608: re-add the entity directly via the document undo
+                // stack. Do NOT use switchToAction(RS2::ActionEditRedo): the redo
+                // action is a one-shot that finishes inside init(), which makes
+                // LC_EventHandler drop back to the default action and destroy
+                // *this* while redo() is still on the stack (use-after-free).
+                // Mirrors how undo() above performs m_document->undo() directly.
+                m_document->redo();
+                m_graphicView->redraw(RS2::RedrawDrawing);
                 setStatus(SetEndpoint);
                 break;
             }
             case HA_Close: {
-                switchToAction(RS2::ActionEditRedo);
+                m_document->redo();
+                m_graphicView->redraw(RS2::RedrawDrawing);
                 setStatus(SetStartpoint);
                 break;
             }

--- a/librecad/src/lib/gui/lc_eventhandler.cpp
+++ b/librecad/src/lib/gui/lc_eventhandler.cpp
@@ -73,7 +73,14 @@ void LC_EventHandler::enter() {
 
 void LC_EventHandler::mousePressEvent(QMouseEvent* e) {
     if (hasAction()) {
-        m_currentAction->mousePressEvent(e);
+        // Issue #2608: hold a strong ref for the duration of the dispatch. The
+        // action may switchToAction() and thereby reset/replace m_currentAction
+        // (the sole owner), which would otherwise destroy it while still on the
+        // stack (use-after-free). The methods below that follow the dispatch with
+        // checkLastActionFinishedAndUncheckQAction() release this ref first so a
+        // normally-finished action is still torn down at its original point.
+        auto current = m_currentAction;
+        current->mousePressEvent(e);
         e->accept();
     }
     else {
@@ -89,7 +96,9 @@ void LC_EventHandler::mousePressEvent(QMouseEvent* e) {
 
 void LC_EventHandler::mouseReleaseEvent(QMouseEvent* e) {
     if (hasAction()) {
-        m_currentAction->mouseReleaseEvent(e);
+        auto current = m_currentAction; // keep alive in case it self-switches mid-dispatch
+        current->mouseReleaseEvent(e);
+        current.reset(); // release before the finished-check to preserve teardown order
         // action may be completed by click. Check this and if it is so, uncheck the action
         checkLastActionFinishedAndUncheckQAction();
         e->accept();
@@ -106,7 +115,9 @@ void LC_EventHandler::mouseReleaseEvent(QMouseEvent* e) {
 
 void LC_EventHandler::mouseMoveEvent(QMouseEvent* e){
     if(hasAction()) {
-        m_currentAction->mouseMoveEvent(e);
+        auto current = m_currentAction; // keep alive in case it self-switches mid-dispatch
+        current->mouseMoveEvent(e);
+        current.reset(); // release before the finished-check to preserve teardown order
         checkLastActionFinishedAndUncheckQAction();
         e->accept();
     }
@@ -137,7 +148,9 @@ void LC_EventHandler::mouseEnterEvent() {
 
 void LC_EventHandler::keyPressEvent(QKeyEvent* e) {
     if(hasAction()){
-        m_currentAction->keyPressEvent(e);
+        auto current = m_currentAction; // keep alive in case it self-switches mid-dispatch
+        current->keyPressEvent(e);
+        current.reset(); // release before the finished-check to preserve teardown order
         checkLastActionFinishedAndUncheckQAction();
     } else {
         if (m_defaultAction) {
@@ -151,7 +164,9 @@ void LC_EventHandler::keyPressEvent(QKeyEvent* e) {
 
 void LC_EventHandler::keyReleaseEvent(QKeyEvent* e) {
     if(hasAction()){
-        m_currentAction->keyReleaseEvent(e);
+        auto current = m_currentAction; // keep alive in case it self-switches mid-dispatch
+        current->keyReleaseEvent(e);
+        current.reset(); // release before the finished-check to preserve teardown order
         checkLastActionFinishedAndUncheckQAction();
     } else {
         if (m_defaultAction) {
@@ -170,12 +185,15 @@ void LC_EventHandler::commandEvent(RS_CommandEvent* e) {
     if (m_coordinateInputEnabled) {
         if (!e->isAccepted()) {
             if (hasAction()) {
+                // keep the action alive across the dispatch: a command (e.g.
+                // "polyline") may switchToAction and reset m_currentAction.
+                auto current = m_currentAction;
                 bool commandContainsCoordinate = false;
                 QString command = e->getCommand();
                 auto coordinateEvent = m_coordinatesParser->parseCoordinate(command, commandContainsCoordinate);
                 if (commandContainsCoordinate) {
                     if (coordinateEvent.isValid()) {
-                        m_currentAction->coordinateEvent(&coordinateEvent);
+                        current->coordinateEvent(&coordinateEvent);
                     }
                     else {
                         RS_DIALOGFACTORY->commandMessage("Expression Syntax Error"); // fixme - sand - remove static
@@ -184,7 +202,8 @@ void LC_EventHandler::commandEvent(RS_CommandEvent* e) {
                 }
                 else {
                     // send command event directly to current action:
-                    m_currentAction->commandEvent(e);
+                    current->commandEvent(e);
+                    current.reset(); // release before the finished-check to preserve teardown order
                     if (e->isAccepted()) {
                         checkLastActionFinishedAndUncheckQAction();
                     }
@@ -204,6 +223,12 @@ void LC_EventHandler::commandEvent(RS_CommandEvent* e) {
 
 
 bool  LC_EventHandler::checkLastActionFinishedAndUncheckQAction() {
+    // Issue #2608: the action that was just dispatched may have switched away
+    // (e.g. via switchToAction) and reset m_currentAction to null. Nothing to
+    // finish then.
+    if (m_currentAction == nullptr) {
+        return false;
+    }
     int lastActionStatus = m_currentAction->getStatus();
     bool result = false;
     if (lastActionStatus < 0 || m_currentAction->isFinished()){
@@ -304,7 +329,10 @@ void LC_EventHandler::resumeAction(const std::shared_ptr<RS_ActionInterface>& ac
 }
 
 void LC_EventHandler::notifyLastActionFinished() {
-    // fixme - sand check that action is not null!!!
+    // Issue #2608: m_currentAction may be null after an action switched away.
+    if (m_currentAction == nullptr) {
+        return;
+    }
     int lastActionStatus = m_currentAction->getStatus();
     if (lastActionStatus < 0 || m_currentAction->isFinished()){
         uncheckQAction();


### PR DESCRIPTION
The root cause of Issue #2608:

    Pointer reuse after being freed:

    case HA_SetEndpoint: {
        switchToAction(RS2::ActionEditRedo);   // <-- destroys *this*
        setStatus(SetEndpoint);                 // <-- use-after-free
        break;
    }

The fix:

    Make redo() mirror the working undo():
    drive the document undo stack directly instead of a self-destroying
     one-shot action: