### PR TITLE
Issue #2611: duplicated GUI languages in menu

### DIFF
--- a/librecad/src/lib/engine/rs_system.cpp
+++ b/librecad/src/lib/engine/rs_system.cpp
@@ -124,10 +124,21 @@ void RS_System::initLanguageList() {
         }
         QString l = file.mid(i1+1, i2-i1-1);
 
-        if (!(languageList.contains(l, Qt::CaseInsensitive)) ) {
-            RS_DEBUG->print("RS_System::initLanguageList: append language: %s",
+        // Validate language code using Qt Locale
+        QLocale locale(l);
+        if (locale == QLocale::c()) {
+            RS_DEBUG->print("RS_System::initLanguageList: invalid locale: %s",
                             l.toLatin1().data());
-            languageList.append(l);
+            continue;
+        }
+
+        // Use Qt Locale to get the canonical language code
+        QString canonicalCode = locale.name();
+
+        if (!(languageList.contains(canonicalCode, Qt::CaseInsensitive)) ) {
+            RS_DEBUG->print("RS_System::initLanguageList: append language: %s",
+                            canonicalCode.toLatin1().data());
+            languageList.append(canonicalCode);
         }
     }
     RS_DEBUG->print("RS_System::initLanguageList: OK");

--- a/librecad/src/lib/engine/rs_system.cpp
+++ b/librecad/src/lib/engine/rs_system.cpp
@@ -39,8 +39,6 @@
 #include "rs_locale.h"
 #include "rs_settings.h"
 
-class QString;
-
 RS_System* RS_System::instance() {
     static RS_System* uniqueInstance = new RS_System();
     return uniqueInstance;
@@ -103,35 +101,30 @@ void RS_System::init(const QString& appName,
  */
 void RS_System::initLanguageList() {
     RS_DEBUG->print("RS_System::initLanguageList");
+    languageList.clear();
     QStringList lst = getFileList("qm", "qm");
 
     LC_GROUP("Paths"); // fixme settings
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     lst += (LC_GET_STR("Translations", "")).split(";", Qt::SkipEmptyParts);
-#else
-    lst += (RS_SETTINGS->readEntry("/Translations", "")).split(";", QString::SkipEmptyParts);
-#endif
     LC_GROUP_END();
 
-    for (QStringList::Iterator it = lst.begin();
-         it != lst.end();
-         ++it) {
+    for (const QString& file : lst) {
 
         RS_DEBUG->print("RS_System::initLanguageList: qm file: %s",
-                        (*it).toLatin1().data());
+                        file.toLatin1().data());
 
-        int i0 = (*it).lastIndexOf(QString("librecad"),-1,Qt::CaseInsensitive);
+        int i0 = file.lastIndexOf(QString("librecad"),-1,Qt::CaseInsensitive);
         if (i0 == -1)
           continue;
 
-        int i1 = (*it).indexOf('_',i0);
-        int i2 = (*it).indexOf('.', i1);
+        int i1 = file.indexOf('_',i0);
+        int i2 = file.indexOf('.', i1);
         if (i1 == -1 || i2 == -1) {
             continue;
         }
-        QString l = (*it).mid(i1+1, i2-i1-1);
+        QString l = file.mid(i1+1, i2-i1-1);
 
-        if (!(languageList.contains(l)) ) {
+        if (!(languageList.contains(l, Qt::CaseInsensitive)) ) {
             RS_DEBUG->print("RS_System::initLanguageList: append language: %s",
                             l.toLatin1().data());
             languageList.append(l);
@@ -418,11 +411,7 @@ void RS_System::loadTranslation(const QString& lang, const QString& /*langCmd*/)
     QStringList lst = getDirectoryList( "qm");
 
     LC_GROUP( "Paths");
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     lst += (LC_GET_STR("Translations", "")).split(";", Qt::SkipEmptyParts);
-#else
-    lst += (RS_SETTINGS->readEntry( "/Translations", "")).split( ";", QString::SkipEmptyParts);
-#endif
     LC_GROUP_END();
 
     if( tLibreCAD != nullptr) {

--- a/librecad/src/ui/dialogs/main/qg_dlginitial.cpp
+++ b/librecad/src/ui/dialogs/main/qg_dlginitial.cpp
@@ -61,8 +61,10 @@ void QG_DlgInitial::init() {
     QString defaultLanguage=RS_SYSTEM->symbolToLanguage(QString("en"));
     for (QString language: languageList) {
         QString l = RS_SYSTEM->symbolToLanguage(language);
-        cbLanguage->addItem(l, language);
-        cbLanguageCmd->addItem(l, language);
+        if (!l.isEmpty() && cbLanguage->findData(language) == -1) {
+            cbLanguage->addItem(l, language);
+            cbLanguageCmd->addItem(l, language);
+        }
     }
 
 


### PR DESCRIPTION
The root cause: 

1, RS_System::initLanguageList() keeps adding language files found to the language list;
2, when adding a new language the locale name is compared case sensitively.

The fix:

1, initLanguageList() clean up the language list before adding new entries;
2, find the language name by Qt Locale support.

