### PR TITLE
Guard MakerCam SVG export against inserts with missing blocks

### DIFF
--- a/librecad/src/lib/generators/makercamsvg/lc_makercamsvg.cpp
+++ b/librecad/src/lib/generators/makercamsvg/lc_makercamsvg.cpp
@@ -281,6 +281,10 @@ void LC_MakerCamSVG::writeEntity(RS_Entity* entity) {
 void LC_MakerCamSVG::writeInsert(RS_Insert* insert) {
 
     RS_Block* block = insert->getBlockForInsert();
+    if (block == nullptr) {
+        RS_DEBUG->print("RS_MakerCamSVG::writeInsert: Insert references missing block, skipping");
+        return;
+    }
 
     RS_Vector insertionpoint = insert->getInsertionPoint();
     // The conversion from drawing space to the svg space (column major) transform matrix(M):


### PR DESCRIPTION
## Summary
- Add a null guard after resolving the block referenced by an insert during MakerCam SVG export.
- Log the unresolved insert and skip it instead of dereferencing a missing RS_Block.

## Why
Malformed or incomplete drawings can contain an RS_Insert whose referenced block cannot be found. The exporter currently assumes the block lookup always succeeds, then dereferences the result while writing the insert. That turns bad input data into a hard crash during dxf2svg or SVG export.

## Tests
- `git diff --check origin/master..HEAD`
- `qmake6 -r <checkout>/librecad.pro`
- `make -j24`
- `<build>/unix/librecad dxf2svg -o <output>.svg <local-dxf-that-previously-crashed>`
- Verified the generated SVG starts with valid XML and SVG elements.
