### PR TITLE
Avoid stale layer tree item use while editing layers

### DIFF
--- a/librecad/src/ui/dock_widgets/layers_tree/lc_layerdialog_ex.cpp
+++ b/librecad/src/ui/dock_widgets/layers_tree/lc_layerdialog_ex.cpp
@@ -41,6 +41,11 @@ LC_LayerDialogEx::LC_LayerDialogEx(QWidget* parent, const QString& name, LC_Laye
     m_layerTreeModel = model;
     m_layerList = ll;
     m_editedTreeItem = treeItem;
+    if (treeItem != nullptr) {
+        m_editedLayer = treeItem->getLayer();
+        m_originalLayerName = treeItem->getName();
+        m_originalLayerType = treeItem->getLayerType();
+    }
 }
 
 void LC_LayerDialogEx::languageChange(){
@@ -250,14 +255,20 @@ void LC_LayerDialogEx::validate() {
                 break;
             }
             case MODE_EDIT_LAYER: {
-                QString originalName = m_editedTreeItem->getName();
-                int originalLayerType = m_editedTreeItem->getLayerType();
-                bool typeChanged = newLayerType != originalLayerType;
-                bool nameChanged = originalName != layerName;
+                LC_LayerTreeItem *editedTreeItem = m_layerTreeModel->getItemForLayer(m_editedLayer);
+                if (editedTreeItem == nullptr) {
+                    QMessageBox::information(parentWidget(),
+                                             QMessageBox::tr("Layer Properties"),
+                                             QMessageBox::tr("The edited layer is no longer available."),
+                                             QMessageBox::Ok);
+                    return;
+                }
+                bool typeChanged = newLayerType != m_originalLayerType;
+                bool nameChanged = m_originalLayerName != layerName;
                 if (nameChanged || typeChanged) {
                     // inner name should be changed - so we have to check for possible duplicates.
                     newLayerNamesList = m_layerTreeModel->getLayersListForRenamedPrimary(
-                        m_editedTreeItem, layerName, newLayerType);
+                        editedTreeItem, layerName, newLayerType);
                 }
                 break;
             }

--- a/librecad/src/ui/dock_widgets/layers_tree/lc_layerdialog_ex.cpp
+++ b/librecad/src/ui/dock_widgets/layers_tree/lc_layerdialog_ex.cpp
@@ -45,7 +45,7 @@ LC_LayerDialogEx::LC_LayerDialogEx(QWidget* parent, const QString& name, LC_Laye
         m_editedLayer = treeItem->getLayer();
         if (m_editedLayer != nullptr) {
             m_originalLayerName = treeItem->getName();
-            m_originalLayerType = treeItem->getLayerType();
+            m_originalLayerType = static_cast<LC_LayerTreeItem::LayerType>(treeItem->getLayerType());
         }
     }
 }
@@ -265,7 +265,7 @@ void LC_LayerDialogEx::validate() {
                                              QMessageBox::Ok);
                     return;
                 }
-                bool typeChanged = newLayerType != m_originalLayerType;
+                bool typeChanged = newLayerType != static_cast<int>(m_originalLayerType);
                 bool nameChanged = m_originalLayerName != layerName;
                 if (nameChanged || typeChanged) {
                     // inner name should be changed - so we have to check for possible duplicates.

--- a/librecad/src/ui/dock_widgets/layers_tree/lc_layerdialog_ex.cpp
+++ b/librecad/src/ui/dock_widgets/layers_tree/lc_layerdialog_ex.cpp
@@ -43,8 +43,10 @@ LC_LayerDialogEx::LC_LayerDialogEx(QWidget* parent, const QString& name, LC_Laye
     m_editedTreeItem = treeItem;
     if (treeItem != nullptr) {
         m_editedLayer = treeItem->getLayer();
-        m_originalLayerName = treeItem->getName();
-        m_originalLayerType = treeItem->getLayerType();
+        if (m_editedLayer != nullptr) {
+            m_originalLayerName = treeItem->getName();
+            m_originalLayerType = treeItem->getLayerType();
+        }
     }
 }
 

--- a/librecad/src/ui/dock_widgets/layers_tree/lc_layerdialog_ex.h
+++ b/librecad/src/ui/dock_widgets/layers_tree/lc_layerdialog_ex.h
@@ -74,6 +74,9 @@ private:
     int m_mode;
     LC_LayerTreeModel* m_layerTreeModel;
     LC_LayerTreeItem *m_editedTreeItem {nullptr};
+    RS_Layer *m_editedLayer {nullptr};
+    QString m_originalLayerName;
+    int m_originalLayerType {-1};
     RS_LayerList* m_layerList;
     bool checkForDuplicatedNames(const QStringList &newLayerNamesList) const;
 };

--- a/librecad/src/ui/dock_widgets/layers_tree/lc_layerdialog_ex.h
+++ b/librecad/src/ui/dock_widgets/layers_tree/lc_layerdialog_ex.h
@@ -76,7 +76,7 @@ private:
     LC_LayerTreeItem *m_editedTreeItem {nullptr};
     RS_Layer *m_editedLayer {nullptr};
     QString m_originalLayerName;
-    int m_originalLayerType {LC_LayerTreeItem::NOT_DEFINED_LAYER_TYPE};
+    LC_LayerTreeItem::LayerType m_originalLayerType {LC_LayerTreeItem::NOT_DEFINED_LAYER_TYPE};
     RS_LayerList* m_layerList;
     bool checkForDuplicatedNames(const QStringList &newLayerNamesList) const;
 };

--- a/librecad/src/ui/dock_widgets/layers_tree/lc_layerdialog_ex.h
+++ b/librecad/src/ui/dock_widgets/layers_tree/lc_layerdialog_ex.h
@@ -28,11 +28,11 @@
 #include <QString>
 
 #include "rs_pen.h"
+#include "lc_layertreeitem.h"
 #include "ui_lc_layerdialog_ex.h"
 
 class RS_LayerList;
 class RS_Layer;
-class LC_LayerTreeItem;
 class LC_LayerTreeModel;
 
 class LC_LayerDialogEx :public QDialog, public Ui::LC_LayerDialogEx
@@ -76,7 +76,7 @@ private:
     LC_LayerTreeItem *m_editedTreeItem {nullptr};
     RS_Layer *m_editedLayer {nullptr};
     QString m_originalLayerName;
-    int m_originalLayerType {-1};
+    int m_originalLayerType {LC_LayerTreeItem::NOT_DEFINED_LAYER_TYPE};
     RS_LayerList* m_layerList;
     bool checkForDuplicatedNames(const QStringList &newLayerNamesList) const;
 };

--- a/librecad/src/ui/dock_widgets/layers_tree/lc_layertreeitem.h
+++ b/librecad/src/ui/dock_widgets/layers_tree/lc_layertreeitem.h
@@ -47,9 +47,9 @@ public:
 class LC_LayerTreeItem{
 public:
 
-    static constexpr int NOT_DEFINED_LAYER_TYPE = -1;
     // Layer types
-    enum {
+    enum LayerType {
+        NOT_DEFINED_LAYER_TYPE = -1,
         VIRTUAL,
         NORMAL,
         DIMENSIONAL,

--- a/librecad/src/ui/dock_widgets/layers_tree/lc_layertreewidget.cpp
+++ b/librecad/src/ui/dock_widgets/layers_tree/lc_layertreewidget.cpp
@@ -1794,10 +1794,12 @@ void LC_LayerTreeWidget::invokeLayerEditOrRenameDialog(LC_LayerTreeItem *pItem, 
     LC_LayerDialogEx dlg = LC_LayerDialogEx(this, QMessageBox::tr("Layer DialogEx"), m_layerTreeModel, pItem, m_layerList);
 
     RS_Layer* layer = nullptr;
+    int originalLayerType = LC_LayerTreeItem::NOT_DEFINED_LAYER_TYPE;
     if (edit){
         dlg.setMode(LC_LayerDialogEx::MODE_EDIT_LAYER);
         layer = pItem->getLayer();
-        dlg.setLayerType(pItem->getLayerType());
+        originalLayerType = pItem->getLayerType();
+        dlg.setLayerType(originalLayerType);
         dlg.setConstruction(layer->isConstruction());
     }
     else{
@@ -1822,8 +1824,11 @@ void LC_LayerTreeWidget::invokeLayerEditOrRenameDialog(LC_LayerTreeItem *pItem, 
           // handle rename
           QString layerName = dlg.getLayerName();
           int editedLayerType = dlg.getEditedLayerType();
-          if (originalName != layerName || editedLayerType != pItem->getLayerType()){ // layer is also renamed
-              m_layerTreeModel -> renamePrimaryLayer(pItem, layerName, editedLayerType);
+          if (originalName != layerName || editedLayerType != originalLayerType){ // layer is also renamed
+              LC_LayerTreeItem *currentLayerItem = m_layerTreeModel->getItemForLayer(layer);
+              if (currentLayerItem != nullptr){
+                  m_layerTreeModel -> renamePrimaryLayer(currentLayerItem, layerName, editedLayerType);
+              }
           }
           m_layerList->fireEdit(nullptr);
       }


### PR DESCRIPTION
## Summary
- Keep stable original layer data in LC_LayerDialogEx instead of relying on a raw LC_LayerTreeItem pointer remaining valid while the dialog is open.
- Re-resolve the edited tree item from the stable RS_Layer pointer after the dialog is accepted before applying rename/type changes.
- Fail gracefully if the layer disappears while the dialog is open.

## Why
The layer edit dialog stores an LC_LayerTreeItem pointer. That item can become stale if the layer tree is rebuilt while the dialog is open, for example while changing layer type or construction/informational attributes. Validation then reads through the stale item and can crash before changes are applied.

## Tests
- `git diff --check origin/master..HEAD`
- `qmake6 -r <checkout>/librecad.pro`
- `make -j24`
- `<build>/unix/librecad -h`
- Manual local reproduction flow on a patched LibreCAD build: edit a reference layer, change construction/informational state and line type, accept the dialog. The pre-patch build crashed in LC_LayerDialogEx::validate; the patched build no longer crashed.
