### PR TITLE
Fix proposal for library items being listed twice in library widget

### DIFF
--- a/librecad/src/lib/engine/rs_system.cpp
+++ b/librecad/src/lib/engine/rs_system.cpp
@@ -686,7 +686,7 @@ QStringList RS_System::getDirectoryList(const QString& _subDirectory) {
     for (QStringList::Iterator it = dirList.begin();
          it != dirList.end();
          ++it ) {
-        if (QFileInfo( *it).isDir()) {
+        if (QFileInfo(*it).isDir() && !ret.contains(*it)) {
             ret += (*it);
             RS_DEBUG->print(*it);
         }


### PR DESCRIPTION
Hello,

Here is a fix proposal for an issue that I've noticed on stable release with library widget. All items from library resources packed with LibreCAD are listed twice in library widget. Library resources accessed using the application custom library path set by the user are not affected by this issue.

After some investigation, I've noticed that ```RS_System::getDirectoryList``` (called from ```QG_LibraryWidget::updatePreview``` as ```RS_SYSTEM->getDirectoryList("library")```) can return a QStringList with duplicated values. Since the path to library default resources is listed twice in ```RS_System::getDirectoryList```'s return QStringList, all DXF files in the path are displayed twice in library widget.

The idea of the fix is to avoid those duplicated values in path list by checking if a path is not already listed in return value before adding it.

Since the fix also affects other path lists such as fonts or patterns, I'm not sure if avoiding duplicates in path lists is always intended.

Best regards,

qwilvove