### PR TITLE
Complement for #2666 (Fix proposal for #2013 - fix cancel action on MDIWindow close event)

### DIFF
--- a/librecad/src/main/qc_mdiwindow.cpp
+++ b/librecad/src/main/qc_mdiwindow.cpp
@@ -252,9 +252,8 @@ void QC_MDIWindow::closeEvent(QCloseEvent* ce) {
             cancel = false;
             break;
         case QG_ExitDialog::Cancel:
-            cancel = true;
-            break;
         default:
+            cancel = true;
             break;
         }
     }


### PR DESCRIPTION
Hello,

Here is a complement for my previous PR #2666.

The idea is to process default case the same way as Cancel on QC_MDIWindow::closeEvent. As a result, if default is reached, the drawing will not be closed without saving, but keeped open and autosaved instead.

Processing Cancel and default as the same case was done that way before my previous PR and is done that way in master as well.

Sorry for this bis PR, but I prefer to assure that my previous PR will not introduce an unwanted behaviour in the future.

Best regards,

qwilvove