### PR TITLE
Issue #2670: avoid getNearestEntity() infinite loop crashing

### DIFF
--- a/librecad/src/lib/engine/rs_entitycontainer.cpp
+++ b/librecad/src/lib/engine/rs_entitycontainer.cpp
@@ -1254,7 +1254,12 @@ RS_Vector RS_EntityContainer::getNearestPointOnEntity(const RS_Vector& coord,
 
     RS_Entity* en = getNearestEntity(coord, dist, RS2::ResolveNone);
 
-    if (en && en->isVisible()
+    // Issue #2670: A container that overrides getDistanceToPoint() for
+    // hit-testing (e.g. RS_Hatch reporting a solid-fill hit) can return itself
+    // as the nearest entity. Recursing into such a self-reference loops forever
+    // and overflows the stack (crash observed when snapping inside a filled
+    // hatch), so only descend into a genuine child entity.
+    if (en && en != this && en->isVisible()
             && !en->getParent()->ignoredSnap()
             ){
         point = en->getNearestPointOnEntity(coord, onEntity, dist, entity);


### PR DESCRIPTION
RS_Hatch inherits RS_EntityContainer::getNearestPointOnEntity(), which descends into the nearest entity returned by getNearestEntity(). For a solid hatch, RS_Hatch::getDistanceToPoint() reports the hatch itself as the nearest entity when the cursor is inside the fill, so the container recursed into the same hatch forever and overflowed the stack (crash on snap-on-entity while hovering inside a filled hatch).

Guard the descent with 'en != this' so it only recurses into a genuine child entity. Port of the master fix (f6b905301) to the 2.2.1 branch.