### PR TITLE
Issue #2670: avoid getNearestEntity() infinite loop crashing

### DIFF
--- a/librecad/src/lib/engine/document/container/rs_entitycontainer.cpp
+++ b/librecad/src/lib/engine/document/container/rs_entitycontainer.cpp
@@ -1374,7 +1374,12 @@ RS_Vector RS_EntityContainer::getNearestEndpoint(const RS_Vector &coord,double *
 RS_Vector RS_EntityContainer::getNearestPointOnEntity(const RS_Vector &coord,bool onEntity, double *dist, RS_Entity **entity) const {
     RS_Vector point(false);
     RS_Entity *en = getNearestEntity(coord, dist, RS2::ResolveNone);
-    if (en && en->isVisible() && !en->getParent()->ignoredSnap() ) {
+    // Issue #2670: A container that overrides getDistanceToPoint() for hit-testing (e.g.
+    // RS_Hatch reporting a solid-fill hit) can return itself as the nearest
+    // entity. Recursing into such a self-reference loops forever and overflows
+    // the stack (crash observed when snapping inside a filled hatch), so only
+    // descend into a genuine child entity.
+    if (en && en != this && en->isVisible() && !en->getParent()->ignoredSnap() ) {
         point = en->getNearestPointOnEntity(coord, onEntity, dist, entity);
     }
     return point;

--- a/librecad/src/lib/engine/document/entities/tests/rs_hatch_tests.cpp
+++ b/librecad/src/lib/engine/document/entities/tests/rs_hatch_tests.cpp
@@ -1297,3 +1297,55 @@ TEST_CASE("snapSplineEdgeEndpoints - tiny gap closes",
   // After the snap, the seam is exactly zero.
   REQUIRE(spline->getEndpoint().distanceTo(line->getStartpoint()) == 0.0);
 }
+
+// ============================================================
+// SNAP RECURSION GUARD
+//
+// Issue #2670: Regression for a stack-overflow crash (SIGSEGV, ~65000 frames deep).
+// RS_Hatch has no getNearestPointOnEntity() of its own, so it inherits
+// RS_EntityContainer::getNearestPointOnEntity(), which finds the nearest child
+// via getNearestEntity() and then descends into it. But RS_Hatch overrides
+// getDistanceToPoint() to report the hatch *itself* as the nearest entity when
+// the cursor is inside the solid fill — so the container kept calling
+// getNearestPointOnEntity() on the same hatch forever. It was hit in the wild
+// by snap-on-entity while hovering inside a filled hatch.
+//
+// The "en != this" guard in getNearestPointOnEntity() breaks the self-
+// reference. These tests must simply RETURN — a regression makes them recurse
+// until the stack overflows.
+// ============================================================
+
+TEST_CASE("RS_Hatch snap - getNearestPointOnEntity inside solid fill terminates",
+          "[rs_hatch][snap]")
+{
+    // Mirror the real snap path: RS_Snapper::snapOnEntity() calls
+    // m_container->getNearestPointOnEntity(). The hatch is a child of the
+    // container (parent set at construction, as for a loaded drawing) so the
+    // container recurses into it exactly as it did when the crash occurred.
+    RS_EntityContainer document{nullptr, true};
+
+    auto* hatch = new RS_Hatch(&document, RS_HatchData(true, 1.0, 0.0, "SOLID"));
+    auto* loop = new RS_EntityContainer(hatch);
+    hatch->addEntity(loop);
+    loop->addEntity(new RS_Line(loop, RS_Vector(0.0,   0.0),   RS_Vector(100.0, 0.0)));
+    loop->addEntity(new RS_Line(loop, RS_Vector(100.0, 0.0),   RS_Vector(100.0, 100.0)));
+    loop->addEntity(new RS_Line(loop, RS_Vector(100.0, 100.0), RS_Vector(0.0,   100.0)));
+    loop->addEntity(new RS_Line(loop, RS_Vector(0.0,   100.0), RS_Vector(0.0,   0.0)));
+    hatch->update();
+    document.addEntity(hatch);   // document owns and will delete the hatch
+    REQUIRE(hatch->getUpdateError() == RS_Hatch::HATCH_OK);
+
+    // Dead centre of the solid fill: getDistanceToPoint() returns 0 and reports
+    // the whole hatch as nearest. Reaching the assertion at all proves the
+    // self-reference guard terminates the descent.
+    const RS_Vector insideFill(50.0, 50.0);
+    RS_Vector p = document.getNearestPointOnEntity(insideFill, true, nullptr, nullptr);
+
+    // A solid-fill hit has no snappable child point to descend to, so the
+    // result is an invalid vector (previously the call never returned).
+    CHECK_FALSE(p.valid);
+
+    // Calling directly on the hatch must likewise terminate.
+    RS_Vector pHatch = hatch->getNearestPointOnEntity(insideFill, true, nullptr, nullptr);
+    CHECK_FALSE(pHatch.valid);
+}


### PR DESCRIPTION
  The root cause: 
    RS_Hatch inherits RS_EntityContainer::getNearestPointOnEntity(), which
    descends into the nearest entity returned by getNearestEntity(). For a
    solid hatch, RS_Hatch::getDistanceToPoint() reports the hatch itself as
    the nearest entity when the cursor is inside the fill, so the container
    recursed into the same hatch forever and overflowed the stack (crash on
    snap-on-entity while hovering inside a filled hatch).

The fix:
    Guard the descent with 'en != this' so it only recurses into a genuine
    child entity. Port of the master fix (f6b905301) to the 2.2.1 branch.