### PR TITLE
CMake: fix the macOS bundle (name, Info.plist, icon)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2238,11 +2238,38 @@ qt_add_executable (librecad
                    ${MAIN_SOURCES}
 )
 
-# On macOS, make it a bundle and set info.plist
+# On macOS, produce a proper bundle: the capitalized name (LibreCAD.app with
+# Contents/MacOS/LibreCAD) used by the qmake release build, a filled-in
+# Info.plist and the app icon. The Linux binary stays lowercase "librecad".
 if(APPLE)
+    # Info.plist.app is shared with the qmake build and uses @TOKEN@
+    # placeholders. Fill them here (configure_file @ONLY) so the bundle gets a
+    # valid identifier, name, version and icon instead of empty values.
+    set(ICON "librecad.icns")
+    set(EXECUTABLE "LibreCAD")
+    set(BUNDLEIDENTIFIER "org.librecad.librecad")
+    set(FULL_VERSION "${PROJECT_VERSION}")
+    set(TYPEINFO "????")
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/librecad/src/Info.plist.app"
+        "${CMAKE_CURRENT_BINARY_DIR}/Info.plist"
+        @ONLY)
+    unset(ICON)
+    unset(EXECUTABLE)
+    unset(BUNDLEIDENTIFIER)
+    unset(FULL_VERSION)
+    unset(TYPEINFO)
+
+    # Copy the application icon into the bundle's Resources.
+    set(LIBRECAD_ICNS "${CMAKE_CURRENT_SOURCE_DIR}/librecad/res/images/librecad.icns")
+    set_source_files_properties("${LIBRECAD_ICNS}" PROPERTIES
+        MACOSX_PACKAGE_LOCATION "Resources")
+    target_sources(librecad PRIVATE "${LIBRECAD_ICNS}")
+
     set_target_properties(librecad PROPERTIES
         MACOSX_BUNDLE TRUE
-        MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/librecad/src/Info.plist.app"
+        MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_BINARY_DIR}/Info.plist"
+        OUTPUT_NAME LibreCAD
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2244,10 +2244,10 @@ qt_add_executable (librecad
 if(APPLE)
     # Info.plist.app is shared with the qmake build and uses @TOKEN@
     # placeholders. Fill them here (configure_file @ONLY) so the bundle gets a
-    # valid identifier, name, version and icon instead of empty values.
+    # valid name, version and icon instead of empty values. The bundle
+    # identifier is spelled out in the template itself.
     set(ICON "librecad.icns")
     set(EXECUTABLE "LibreCAD")
-    set(BUNDLEIDENTIFIER "org.librecad.librecad")
     set(FULL_VERSION "${PROJECT_VERSION}")
     set(TYPEINFO "????")
     configure_file(
@@ -2256,7 +2256,6 @@ if(APPLE)
         @ONLY)
     unset(ICON)
     unset(EXECUTABLE)
-    unset(BUNDLEIDENTIFIER)
     unset(FULL_VERSION)
     unset(TYPEINFO)
 

--- a/librecad/src/Info.plist.app
+++ b/librecad/src/Info.plist.app
@@ -20,8 +20,11 @@
 	<string>@TYPEINFO@</string>
 	<key>CFBundleExecutable</key>
 	<string>@EXECUTABLE@</string>
+	<!-- Not a @TOKEN@: qmake derives the identifier from TARGET, which would
+	     give org.librecad.LibreCAD, while the CMake build sets it directly.
+	     Spelling it out here keeps both builds on one identifier. -->
 	<key>CFBundleIdentifier</key>
-	<string>@BUNDLEIDENTIFIER@</string>
+	<string>org.librecad.librecad</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/librecad/src/src.pro
+++ b/librecad/src/src.pro
@@ -65,13 +65,19 @@ unix {
             QMAKE_CXXFLAGS += -include $$PWD/mac_arm_acle_prefix.h
         }
         TARGET = LibreCAD
-        VERSION=$$system(echo "$${LC_VERSION}" | sed -e 's/\-.*//g')
+        # CFBundleShortVersionString/CFBundleVersion must be numeric x.y.z, so
+        # reduce LC_VERSION to that ("2.2.2_alpha1-618-g27add5380" -> "2.2.2"),
+        # matching what the CMake build derives from PROJECT_VERSION. Uses cut
+        # rather than a sed regex because qmake eats the backslashes.
+        VERSION=$$system(echo "$${LC_VERSION}" | sed -e 's/^v//' | cut -d- -f1 | cut -d_ -f1 | cut -d. -f1-3)
         QMAKE_INFO_PLIST = Info.plist.app
         DEFINES += QC_APPDIR=\\\"LibreCAD\\\"
         ICON = ../res/images/librecad.icns
         contains(DISABLE_POSTSCRIPT, false) {
             QMAKE_POST_LINK = /bin/sh $$_PRO_FILE_PWD_/../../scripts/postprocess-osx.sh $$OUT_PWD/$${DESTDIR}/$${TARGET}.app/ $$[QT_INSTALL_BINS];
-            QMAKE_POST_LINK += /usr/libexec/PlistBuddy -c \"Set :CFBundleGetInfoString string $${TARGET} $${LC_VERSION}\" $$OUT_PWD/$${DESTDIR}/$${TARGET}.app/Contents/Info.plist;
+            # PlistBuddy's Set takes no type argument (only Add does), so a
+            # literal "string" here ended up in the value.
+            QMAKE_POST_LINK += /usr/libexec/PlistBuddy -c \"Set :CFBundleGetInfoString $${TARGET} $${LC_VERSION}\" $$OUT_PWD/$${DESTDIR}/$${TARGET}.app/Contents/Info.plist;
         }
     }
     else {


### PR DESCRIPTION
## Summary

Makes a local CMake (e.g. CLion) macOS build produce a proper application bundle that matches the qmake release build: the capitalized name `LibreCAD.app`, a filled-in `Info.plist`, and the application icon.

## Background

The CMake target is named `librecad`, so the build produced `librecad.app` / `Contents/MacOS/librecad`, whereas the qmake release build (`src.pro` sets `TARGET = LibreCAD`) ships `LibreCAD.app`. It also pointed `MACOSX_BUNDLE_INFO_PLIST` at `Info.plist.app`, which uses qmake-style `@TOKEN@` placeholders (`@ICON@`, `@EXECUTABLE@`, `@BUNDLEIDENTIFIER@`, `@FULL_VERSION@`, `@TYPEINFO@`). CMake doesn't define those, so they were substituted to empty — the bundle ended up with no identifier, executable name, version or icon, and the `.icns` was never copied. (That empty plist also made the bundle fail `codesign --verify` with "invalid Info.plist".)

## Changes (macOS only; the Linux `librecad` binary is unchanged)

- Set `OUTPUT_NAME LibreCAD` so the bundle is `LibreCAD.app` with `Contents/MacOS/LibreCAD`.
- Fill the shared `Info.plist.app` template via `configure_file(@ONLY)` with the icon, executable name, bundle identifier (`org.librecad.librecad`) and version.
- Copy `librecad/res/images/librecad.icns` into `Contents/Resources` and reference it as `CFBundleIconFile`.

## Testing

A local CMake build now produces `LibreCAD.app` with `Contents/Resources/librecad.icns`, a valid `Info.plist` (`plutil -lint` OK) carrying the correct `CFBundleIdentifier` / `CFBundleExecutable` / `CFBundleIconFile` / version, and the application icon shows in Finder.
