### PR TITLE
Fix #2679: SIGSEGV on quit from stale mouse-move during teardown

### DIFF
--- a/librecad/src/ui/dock_widgets/entity_info/lc_quickinfobasedata.cpp
+++ b/librecad/src/ui/dock_widgets/entity_info/lc_quickinfobasedata.cpp
@@ -250,5 +250,11 @@ QString LC_QuickInfoBaseData::formatInt(const int &x) const{
 }
 
 const RS_Vector &LC_QuickInfoBaseData::getRelativeZero() const {
+    if (m_viewport == nullptr){
+        // No active viewport (e.g. during teardown, see issue #2679): return a
+        // safe default instead of dereferencing a null pointer.
+        static const RS_Vector zero{0.0, 0.0};
+        return zero;
+    }
     return m_viewport->getRelativeZero();
 }

--- a/librecad/src/ui/dock_widgets/entity_info/lc_quickinfowidget.cpp
+++ b/librecad/src/ui/dock_widgets/entity_info/lc_quickinfowidget.cpp
@@ -149,6 +149,14 @@ LC_QuickInfoWidget::~LC_QuickInfoWidget(){
  * @param en entity
  */
 void LC_QuickInfoWidget::processEntity(RS_Entity *en){
+    // During application/document teardown the active view is detached via
+    // setGraphicView(nullptr), leaving the entity data with a null viewport.
+    // Guard against a stale mouse-move being processed then, which would
+    // dereference the null viewport in getRelativeZero() (issue #2679). With no
+    // active view there is nothing to display anyway.
+    if (m_graphicView == nullptr){
+        return;
+    }
     setWidgetMode(MODE_ENTITY_INFO);
     if (en == nullptr){
         clearEntityInfo();

--- a/librecad/src/ui/main/qc_applicationwindow.cpp
+++ b/librecad/src/ui/main/qc_applicationwindow.cpp
@@ -1324,7 +1324,11 @@ bool QC_ApplicationWindow::doCloseAllFiles(){
             }
             doArrangeWindows(RS2::CurrentMode);
         }
-        qApp->processEvents(QEventLoop::AllEvents, 1000);
+        // Exclude user-input events while closing: doClose() has already detached
+        // the active view, so dispatching a stale queued mouse-move here would run
+        // hover/Quick Info against a torn-down viewport and crash (issue #2679).
+        // Repaints and deferred deletions still need to be processed.
+        qApp->processEvents(QEventLoop::ExcludeUserInputEvents, 1000);
     }
     return false;
 }


### PR DESCRIPTION
## Problem

LibreCAD can SIGSEGV on quit (exit 139). Closes #2679.

When closing, `QC_ApplicationWindow::doCloseAllFiles()` calls `qApp->processEvents(QEventLoop::AllEvents, 1000)` *after* `doClose()` has already detached the active view via `setupWidgetsByWindow(nullptr)` — which nulls the Quick Info widget's viewport. A stale queued **mouse-move** is then dispatched during teardown and flows through the still-active hover path:

```
processEvents → RS_ActionDefault::onMouseMoveEvent → highlightHoveredEntities
  → LC_QuickInfoWidget::processEntity → collectGenericProperties → addVectorProperty
  → LC_QuickInfoBaseData::getRelativeZero() → m_viewport->getRelativeZero()   // m_viewport == nullptr
```

`getRelativeZero()` dereferences the null viewport (fault at offset `0x118`), crashing on quit.

## Fix

Defense in depth, from root cause to leaf:

- **Root** — `doCloseAllFiles()` now processes events with `QEventLoop::ExcludeUserInputEvents`, so queued mouse/keyboard events are not dispatched during teardown. Repaints and deferred deletions still run.
- **Guards** — `LC_QuickInfoWidget::processEntity()` returns early when there is no active view, and `LC_QuickInfoBaseData::getRelativeZero()` null-guards the viewport, so the hover/Quick Info path can never dereference a detached viewport.

## Testing

macOS (Apple Silicon), Qt 6, debug build: reproduced the pre-fix crash (open a drawing, hover an entity, quit → SIGSEGV / exit 139), then confirmed it exits cleanly after the fix. Normal Quick Info hover behavior during editing is unchanged.
