### PR TITLE
Fix #2681: Dimension line doesn't change layer

### DIFF
--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -351,6 +351,17 @@ bool RS_Modification::changeAttributes(
 
         if (data.changeLayer==true) {
             cl->setLayer(data.layer);
+            if (RS_Information::isDimension(cl->rtti())) {
+                if (!data.changeColor) {
+                    pen.setColor(RS_Color(RS2::FlagByLayer));
+                }
+                if (!data.changeWidth) {
+                    pen.setWidth(RS2::WidthByLayer);
+                }
+                if (!data.changeLineType) {
+                    pen.setLineType(RS2::LineByLayer);
+                }
+            }
         }
 
         if (data.changeColor==true) {


### PR DESCRIPTION
## Summary
Fix for issue #2681: The main line inside a Dimension element does not change of layer.

## Root Cause
When changing the layer of a Dimension entity, the dimension line and arrow heads did not change color to match the new layer's color.

The root cause is that dimension child entities (dimension lines, arrows, text) have ByBlock pens and nullptr layers. When resolving ByBlock colors at draw time, the code uses parent->getPen().getColor() (unresolved). If the dimension entity had an explicit color from setPenToActive(), ByBlock children would resolve to that explicit color instead of the new layer's color.

## Fix
Set dimension pen to ByLayer when changing layer, similar to the fix for issue #2522 for Insert entities. This ensures ByBlock children resolve to the parent's layer color at draw time.

The fix is located in RS_Modification::changeAttributes() in rs_modification.cpp and only sets ByLayer for attributes the user isn't explicitly changing.