### PR TITLE
Fix proposal for library block insert issues on master

### DIFF
--- a/librecad/src/actions/dock_widgets/library/rs_actionlibraryinsert.cpp
+++ b/librecad/src/actions/dock_widgets/library/rs_actionlibraryinsert.cpp
@@ -62,12 +62,6 @@ void RS_ActionLibraryInsert::setFile(const QString& file) {
     m_actionData->prev = std::make_unique<RS_Graphic>();
     if (!storage.loadDocument(m_actionData->prev.get(), file, RS2::FormatUnknown)) {
         commandMessage(tr("Cannot open file '%1'").arg(file));
-    } else {
-        double factor = RS_Units::convert(1.0, m_actionData->prev->getUnit(), m_graphic->getUnit());
-        if (std::abs(factor - 1.0) > RS_TOLERANCE) {
-            m_actionData->prev->scale(RS_Vector(), RS_Vector(factor, factor));
-            m_actionData->prev->calculateBorders();
-        }
     }
 }
 

--- a/librecad/src/lib/creation/rs_creation.cpp
+++ b/librecad/src/lib/creation/rs_creation.cpp
@@ -1065,30 +1065,30 @@ RS_Block* RS_Creation::createBlock(const RS_BlockData* data,
      */
 RS_Insert* RS_Creation::createLibraryInsert(RS_LibraryInsertData& data)
 {
-  RS_DEBUG->print(RS_Debug::D_DEBUGGING,
-                  "createLibraryInsert: file='%s' angle=%.1f° factor=%.3f",
-                  data.file.toLatin1().data(), RS_Math::rad2deg(data.angle), data.factor);
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING,
+                    "createLibraryInsert: file='%s' angle=%.1f° factor=%.3f",
+                    data.file.toLatin1().data(), RS_Math::rad2deg(data.angle), data.factor);
 
-  if (data.graphic == nullptr || data.graphic->count() == 0) {
-    RS_DEBUG->print(RS_Debug::D_WARNING, "createLibraryInsert: invalid/empty graphic");
-    return nullptr;
-  }
+    if (data.graphic == nullptr || data.graphic->count() == 0) {
+        RS_DEBUG->print(RS_Debug::D_WARNING, "createLibraryInsert: invalid/empty graphic");
+        return nullptr;
+    }
 
-  QString blockName = QFileInfo(data.file).completeBaseName();
-  if (blockName.isEmpty())
-    blockName = "LibPart_" + QString::number(QDateTime::currentMSecsSinceEpoch());
+    QString blockName = QFileInfo(data.file).completeBaseName();
+    if (blockName.isEmpty())
+        blockName = "LibPart_" + QString::number(QDateTime::currentMSecsSinceEpoch());
 
-  RS_PasteData pasteData(data.insertionPoint, data.factor, data.angle, true, blockName);
+    RS_PasteData pasteData(data.insertionPoint, data.factor, data.angle, true, blockName);
 
-  RS_Modification mod(*m_container, m_viewport);
-  RS_Insert* ret = mod.paste(pasteData, data.graphic);  // uses fixed paste() above
+    RS_Modification mod(*m_container, m_viewport);
+    RS_Insert* ret = mod.paste(pasteData, data.graphic);  // uses fixed paste() above
 
-  if (ret != nullptr)
-    RS_DEBUG->print("%s(): pasted RS_Insert %llu done", __func__, ret->getId());
-  else
-    RS_DEBUG->print("%s(): failed to create an RS_Insert", __func__);
+    if (ret != nullptr)
+        RS_DEBUG->print("%s(): pasted RS_Insert %llu done", __func__, ret->getId());
+    else
+        RS_DEBUG->print("%s(): failed to create an RS_Insert", __func__);
 
-  return ret;
+    return ret;
 }
 
 bool RS_Creation::setupAndAddEntity(RS_Entity* en) const{

--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -70,17 +70,19 @@ namespace {
  */
     RS_Vector getPasteScale(const RS_PasteData &data, RS_Graphic *&source, const RS_Graphic &graphic){
 
-        // adjust scaling factor for units conversion in case of clipboard paste
-        double factor = (RS_TOLERANCE < std::abs(data.factor)) ? data.factor : 1.0;
-        // select source for paste
         if (source == nullptr){
-            RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::paste: add graphic source from clipboard");
             source = RS_CLIPBOARD->getGraphic();
-            // graphics from the clipboard need to be scaled. From the part lib not:
-            RS2::Unit sourceUnit = source->getUnit();
-            RS2::Unit targetUnit = graphic.getUnit();
-            factor = RS_Units::convert(factor, sourceUnit, targetUnit);
         }
+        // Always compute unit conversion factor
+        RS2::Unit sourceUnit = source->getUnit();
+        RS2::Unit targetUnit = graphic.getUnit();
+        double factor = RS_Units::convert(1.0, sourceUnit, targetUnit);
+
+        // Compose with user-specified scale factor if provided
+        if (std::abs(data.factor) > RS_TOLERANCE && std::abs(data.factor - 1.0) > RS_TOLERANCE) {
+            factor *= data.factor;
+        }
+
         RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::paste: pasting scale factor: %g", factor);
         // scale factor as vector
         return {factor, factor};
@@ -694,31 +696,20 @@ RS_Insert* RS_Modification::paste(const RS_PasteData& data, RS_Graphic* source) 
       name = m_graphic->newBlockName(name);
       b = addNewBlock(name, *m_graphic);
 
-             // add entities to block:
+      // Add entities to block in raw state - no transformations applied.
+      // All scale/rotation is handled by the outer Insert via its
+      // scaleFactor and angle properties during update().
+      // This ensures correct behavior for nested inserts at any depth,
+      // and safe block reuse across multiple pastes.
       for(RS_Entity* e: std::as_const(*source)){
         RS_Entity* e2 = e->clone();
         e2->reparent(b);
-
-               // For asInsert, if source entity is an insert, preserve its angle and scale
-        if (e2->rtti() == RS2::EntityInsert) {
-          RS_Insert* origInsert = static_cast<RS_Insert*>(e);
-          RS_Insert* newInsert = static_cast<RS_Insert*>(e2);
-          // Preserve and compose
-          newInsert->setAngle(origInsert->getAngle() - data.angle);
-          newInsert->setScale(origInsert->getScale());
-          newInsert->update();
-        } else {
-          if (std::abs(scale.x)>RS_TOLERANCE && std::abs(scale.y)>RS_TOLERANCE) {
-            e2->scale(b->getBasePoint(), scale);
-          }
-        }
-
         b->addEntity(e2);
       }
     }
 
-           // create insert:
-    RS_InsertData d(name, data.insertionPoint, RS_Vector(1.0,1.0), data.angle, 1,1, RS_Vector(0.0,0.0), nullptr, RS2::Update);  // Use data.angle and force update
+           // create insert: outer Insert carries all transformations (scale + angle)
+    RS_InsertData d(name, data.insertionPoint, scale, data.angle, 1,1, RS_Vector(0.0,0.0), nullptr, RS2::Update);  // Use data.angle and force update
     RS_Insert* ret = new RS_Insert(m_graphic, d);
     ret->setLayer(m_graphic->getActiveLayer());
     // Set pen to ByLayer so that inner entities with ByBlock

--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -660,101 +660,101 @@ void RS_Modification::copyBlocks(RS_Entity* e) {
  *      is the clipboard.
  */
 RS_Insert* RS_Modification::paste(const RS_PasteData& data, RS_Graphic* source) {
-  RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::paste:");
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "RS_Modification::paste:");
 
-  if (m_container == nullptr || m_container->isLocked() || !m_container->isVisible()) {
-    RS_DEBUG->print(RS_Debug::D_WARNING, "RS_Modification::paste: invalid container");
-    return nullptr;
-  }
-
-  RS_Graphic* src = (source != nullptr) ? source : RS_CLIPBOARD->getGraphic();
-  if (src == nullptr) {
-    RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::paste: no source");
-    return nullptr;
-  }
-
-  src->calculateBorders();
-
-  // Scale (units)
-  RS_Vector scale = getPasteScale(data, source, *m_graphic);
-
-  LC_UndoSection undo(m_document, m_viewport, handleUndo);
-
-  RS_Insert* ret = nullptr;
-  if (data.asInsert) {
-
-    if (!src || src->count() == 0) {
-      RS_DEBUG->print(RS_Debug::D_WARNING, "paste(asInsert): empty or null source graphic");
-      return nullptr;
+    if (m_container == nullptr || m_container->isLocked() || !m_container->isVisible()) {
+        RS_DEBUG->print(RS_Debug::D_WARNING, "RS_Modification::paste: invalid container");
+        return nullptr;
     }
 
-           // Block name – prefer provided, fallback to auto-generated
-    QString name = data.blockName;
-    RS_Block* b = m_graphic->findBlock(name);
-    if (b == nullptr) {
-      // paste as block: create new block:
-      name = m_graphic->newBlockName(name);
-      b = addNewBlock(name, *m_graphic);
-
-      // Add entities to block in raw state - no transformations applied.
-      // All scale/rotation is handled by the outer Insert via its
-      // scaleFactor and angle properties during update().
-      // This ensures correct behavior for nested inserts at any depth,
-      // and safe block reuse across multiple pastes.
-      for(RS_Entity* e: std::as_const(*source)){
-        RS_Entity* e2 = e->clone();
-        e2->reparent(b);
-        b->addEntity(e2);
-      }
+    RS_Graphic* src = (source != nullptr) ? source : RS_CLIPBOARD->getGraphic();
+    if (src == nullptr) {
+        RS_DEBUG->print(RS_Debug::D_ERROR, "RS_Modification::paste: no source");
+        return nullptr;
     }
 
-           // create insert: outer Insert carries all transformations (scale + angle)
-    RS_InsertData d(name, data.insertionPoint, scale, data.angle, 1,1, RS_Vector(0.0,0.0), nullptr, RS2::Update);  // Use data.angle and force update
-    RS_Insert* ret = new RS_Insert(m_graphic, d);
-    ret->setLayer(m_graphic->getActiveLayer());
-    // Set pen to ByLayer so that inner entities with ByBlock
-    // resolve to the insert's layer color (fixes #2522)
-    ret->setPen(RS_Pen(RS_Color(RS2::FlagByLayer), RS2::WidthByLayer, RS2::LineByLayer));
+    src->calculateBorders();
 
-    ret->update();
-    m_container->addEntity(ret);
-    ret->reparent(m_container);
+    // Scale (units)
+    RS_Vector scale = getPasteScale(data, source, *m_graphic);
 
-    undo.addUndoable(ret);
-  } else {
-    // copy as entities
+    LC_UndoSection undo(m_document, m_viewport, handleUndo);
 
-    for(const RS_Entity* e: *source){
-      RS_Entity* e2 = e->clone();
+    RS_Insert* ret = nullptr;
+    if (data.asInsert) {
 
-      e2->move(data.insertionPoint);
+        if (!src || src->count() == 0) {
+            RS_DEBUG->print(RS_Debug::D_WARNING, "paste(asInsert): empty or null source graphic");
+            return nullptr;
+        }
 
-             // Apply rotation (adds paste angle, rotates position around new point)
-      e2->rotate(data.insertionPoint, data.angle);
+        // Block name – prefer provided, fallback to auto-generated
+        QString name = data.blockName;
+        RS_Block* b = m_graphic->findBlock(name);
+        if (b == nullptr) {
+            // paste as block: create new block:
+            name = m_graphic->newBlockName(name);
+            b = addNewBlock(name, *m_graphic);
 
-             // Apply scale if valid (multiplies for inserts, scales position around new point)
-      if (std::abs(scale.x) > RS_TOLERANCE && std::abs(scale.y) > RS_TOLERANCE) {
-        e2->scale(data.insertionPoint, scale);
-      }
+            // Add entities to block in raw state - no transformations applied.
+            // All scale/rotation is handled by the outer Insert via its
+            // scaleFactor and angle properties during update().
+            // This ensures correct behavior for nested inserts at any depth,
+            // and safe block reuse across multiple pastes.
+            for(RS_Entity* e: std::as_const(*source)){
+                RS_Entity* e2 = e->clone();
+                e2->reparent(b);
+                b->addEntity(e2);
+            }
+        }
 
-      e2->setLayer(m_graphic->getActiveLayer());
+        // create insert: outer Insert carries all transformations (scale + angle)
+        RS_InsertData d(name, data.insertionPoint, scale, data.angle, 1,1, RS_Vector(0.0,0.0), nullptr, RS2::Update);  // Use data.angle and force update
+        RS_Insert* ret = new RS_Insert(m_graphic, d);
+        ret->setLayer(m_graphic->getActiveLayer());
+        // Set pen to ByLayer so that inner entities with ByBlock
+        // resolve to the insert's layer color (fixes #2522)
+        ret->setPen(RS_Pen(RS_Color(RS2::FlagByLayer), RS2::WidthByLayer, RS2::LineByLayer));
 
-             // Force early update to apply composed angle
-      if (e2->rtti() == RS2::EntityInsert) {
-        static_cast<RS_Insert*>(e2)->update();
-      }
+        ret->update();
+        m_container->addEntity(ret);
+        ret->reparent(m_container);
 
-      m_container->addEntity(e2);
-      e2->reparent(m_container);
-      undo.addUndoable(e2);
+        undo.addUndoable(ret);
+    } else {
+        // copy as entities
+
+        for(const RS_Entity* e: *source){
+            RS_Entity* e2 = e->clone();
+
+            e2->move(data.insertionPoint);
+
+            // Apply rotation (adds paste angle, rotates position around new point)
+            e2->rotate(data.insertionPoint, data.angle);
+
+            // Apply scale if valid (multiplies for inserts, scales position around new point)
+            if (std::abs(scale.x) > RS_TOLERANCE && std::abs(scale.y) > RS_TOLERANCE) {
+                e2->scale(data.insertionPoint, scale);
+            }
+
+            e2->setLayer(m_graphic->getActiveLayer());
+
+            // Force early update to apply composed angle
+            if (e2->rtti() == RS2::EntityInsert) {
+                static_cast<RS_Insert*>(e2)->update();
+            }
+
+            m_container->addEntity(e2);
+            e2->reparent(m_container);
+            undo.addUndoable(e2);
+        }
     }
-  }
 
-  m_container->calculateBorders();
-  m_graphic->updateInserts();
-  m_viewport->notifyChanged();
-  RS_DEBUG->print(RS_Debug::D_DEBUGGING, "paste: OK ✅");
-  return ret;
+    m_container->calculateBorders();
+    m_graphic->updateInserts();
+    m_viewport->notifyChanged();
+    RS_DEBUG->print(RS_Debug::D_DEBUGGING, "paste: OK ✅");
+    return ret;
 }
 
 /**


### PR DESCRIPTION
Hello,

Here is a fix proposal for library block insert issues on master.

This is based on commit 7046ed6 by @dxli.

It fixes 2 issues:
- Issue 2578, which is fixed on 2.2.1 but not on master.
- Scale disparities between preview and inserted block (due to unit conversion being performed twice in RS_ActionLibraryInsert).

Best regards,

qwilvove