### PR TITLE
Fix proposal for polyline trim action

### DIFF
--- a/librecad/src/actions/drawing/draw/polyline/lc_action_polyline_trim.cpp
+++ b/librecad/src/actions/drawing/draw/polyline/lc_action_polyline_trim.cpp
@@ -55,6 +55,7 @@ bool LC_ActionPolylineTrim::doTriggerModifications(LC_DocumentModificationBatch&
         m_polylineToModify = newPolyline;
         ctx.dontSetActiveLayerAndPen();
         select(m_polylineToModify);
+        return true;
     }
     return false;
 }


### PR DESCRIPTION
Hello,

I've noticed that polyline trim action is not taken into account after being performed.
The missing of ```return true;``` in ```LC_ActionPolylineTrim::doTriggerModifications``` seems to be the root of the problem.

Here is a PR to fix it.

Best regards,

qwilvove