### PR TITLE
Fix proposal for build fails with Qt 6.4

### DIFF
--- a/librecad/src/lib/engine/document/variables/rs_variable.h
+++ b/librecad/src/lib/engine/document/variables/rs_variable.h
@@ -28,6 +28,7 @@
 #define RS_VARIABLE_H
 
 #include <QString>
+#include <QStringBuilder>
 
 #include "rs.h"
 #include "rs_vector.h"

--- a/librecad/src/lib/engine/undo/rs_undo.cpp
+++ b/librecad/src/lib/engine/undo/rs_undo.cpp
@@ -27,9 +27,10 @@
 
 #include "rs_undo.h"
 
-#include<iostream>
-#include <qassert.h>
+#include <iostream>
 #include <unordered_set>
+
+#include <QtGlobal>
 
 #include "rs_debug.h"
 #include "rs_undocycle.h"

--- a/librecad/src/lib/math/lc_formatter.cpp
+++ b/librecad/src/lib/math/lc_formatter.cpp
@@ -23,6 +23,8 @@
 
 #include "lc_formatter.h"
 
+#include <QStringBuilder>
+
 #include "lc_graphicviewport.h"
 #include "lc_linemath.h"
 #include "rs_graphic.h"

--- a/librecad/src/ui/dialogs/actions/quick_selection/lc_dlgquickselection.cpp
+++ b/librecad/src/ui/dialogs/actions/quick_selection/lc_dlgquickselection.cpp
@@ -57,7 +57,7 @@ LC_DlgQuickSelection::LC_DlgQuickSelection(QWidget* parent, LC_ActionContext* ac
     connect(ui->cbEntityType, &QComboBox::currentIndexChanged, this, &LC_DlgQuickSelection::onEntityTypeIndexChanged);
     connect(ui->lvProperties, &QListWidget::currentRowChanged, this, &LC_DlgQuickSelection::onPropertyListRowChanged);
 
-    connect(ui->cbAppendToCurrentSelectionSet, &QCheckBox::checkStateChanged, this, &LC_DlgQuickSelection::onAppendToCurrentSetClicked);
+    connect(ui->cbAppendToCurrentSelectionSet, &QCheckBox::toggled, this, &LC_DlgQuickSelection::onAppendToCurrentSetClicked);
     connect(ui->rbExcludeFromSelectionSet, &QRadioButton::toggled, this, &LC_DlgQuickSelection::onAppendToCurrentSetClicked);
     connect(ui->cbOperator, &QComboBox::currentIndexChanged, this, &LC_DlgQuickSelection::onOperatorChanged);
 

--- a/librecad/src/ui/dialogs/settings/options_drawing/lc_dlgnewdimstyle.cpp
+++ b/librecad/src/ui/dialogs/settings/options_drawing/lc_dlgnewdimstyle.cpp
@@ -27,7 +27,6 @@
 #include <QMessageBox>
 
 #include "lc_dimstyle.h"
-#include "lc_dimstyleitem.h"
 #include "lc_dimstyleslistmodel.h"
 #include "ui_lc_dlgnewdimstyle.h"
 

--- a/librecad/src/ui/dialogs/settings/options_drawing/lc_dlgnewdimstyle.h
+++ b/librecad/src/ui/dialogs/settings/options_drawing/lc_dlgnewdimstyle.h
@@ -25,11 +25,11 @@
 #define LC_DLGNEWDIMSTYLE_H
 
 #include "lc_dialog.h"
+#include "lc_dimstyleitem.h"
 #include "rs.h"
 
 class LC_StylesListModel;
 class QListModel;
-class LC_DimStyleItem;
 
 namespace Ui{
     class LC_DlgNewDimStyle;

--- a/librecad/src/ui/dock_widgets/property_sheet/lib/view/edit/lc_property_editor_utils.cpp
+++ b/librecad/src/ui/dock_widgets/property_sheet/lib/view/edit/lc_property_editor_utils.cpp
@@ -24,7 +24,9 @@
 #include "lc_property_editor_utils.h"
 
 #include <QCompleter>
+#include <QCoreApplication>
 #include <QKeyEvent>
+#include <QLocale>
 #include <QWidget>
 
 #include "lc_property_view_editable.h"

--- a/librecad/src/ui/main/lc_mdiapplicationwindow.cpp
+++ b/librecad/src/ui/main/lc_mdiapplicationwindow.cpp
@@ -28,6 +28,7 @@
 #include <QDockWidget>
 #include <QMdiArea>
 #include <QMenu>
+#include <QStringBuilder>
 #include <QStyle>
 #include <qtabbar.h>
 


### PR DESCRIPTION
Hello,

When trying to build master with Qt 6.4 (Qt version available on Debian 12), I've noticed that the build fails on some points.

Here is the system config I've tested:

Version: 2.2.2_alpha1-594-g430d423af
Compiler: GNU GCC 12.2.0
Compiled on: Jul 25 2026
Qt Version: 6.4.2
Boost Version: 1.74.0
System: Debian GNU/Linux 12 (bookworm)

I needed to perform some changes on the code in order to build:
- add ```#include <QStringBuilder>``` in files where the syntax ```QString % QString``` is used.
- replace ```QCheckBox::checkStateChanged``` (added in Qt 6.7) by ```QCheckBox::toggled```
- use ```#include <QtGlobal>``` instead of ```#include <qassert.h>``` where ```Q_ASSERT``` is used, since ```<QtAssert>``` seems to have been added in Qt 6.5.
- replace ```class LC_DimStyleItem;``` by ```#include "lc_dimstyleitem.h"``` (not sure if this one is related to Qt, or maybe to GCC)

I've tested those changes with Qt 6.11 and it builds with no problem:
Version: 2.2.2_alpha1-595-g8ee7f32e4
Compiler: GNU GCC 16.1.1
Compiled on: Jul 25 2026
Qt Version: 6.11.1
Boost Version: 1.91.0
System: Arch Linux

Perhaps it is no longer necessary to continue supporting Qt 6.4, but since the project README says that the branch 2.2.2 should build with Qt 6.4, and the changes made here are very minimal, I suppose that it wouldn’t be good to lose that compatibility.

Best regards,

qwilvove