### PR TITLE
LFF: accept optional '#' and leading zeros in glyph codes

### DIFF
--- a/librecad/src/lib/engine/document/fonts/rs_font.cpp
+++ b/librecad/src/lib/engine/document/fonts/rs_font.cpp
@@ -61,16 +61,18 @@ namespace {
         return (okay) ? QString::fromUcs4(&ucsCode, 1) : QString::fromUcs4(&invalidCode, 1);
     }
 
-    // Extract the unicode char from LFF font line
+    // Extract the unicode char from LFF font line, e.g. "[0041]" or "[#0041]"
+    // (the '#' is optional, so files written by either convention load the same way).
+    // Up to 6 hex digits so the full Unicode range (to U+10FFFF) is accepted.
     std::pair<QString, bool> extractFontChar(const QString& line) {
         // read unicode:
-        static QRegularExpression regexp("[0-9A-Fa-f]{1,5}");
+        static QRegularExpression regexp("^\\[#?([0-9A-Fa-f]{1,6})\\]");
         const QRegularExpressionMatch match = regexp.match(line);
         if (!match.hasMatch()) {
             return {};
         }
 
-        const QString cap = match.captured(0);
+        const QString cap = match.captured(1);
         bool okay = false;
         const std::uint32_t code = cap.toUInt(&okay, 16);
 

--- a/librecad/src/lib/filters/rs_filterlff.cpp
+++ b/librecad/src/lib/filters/rs_filterlff.cpp
@@ -33,6 +33,7 @@
 #include <QTextStream>
 #include <QStringList>
 #include <QDate>
+#include <QRegularExpression>
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <QStringConverter>
 #endif
@@ -207,7 +208,15 @@ bool RS_FilterLFF::fileExport(RS_Graphic& g, const QString& file, RS2::FormatTyp
             if (blk && !blk->isDeleted()) {
                 RS_DEBUG->print("002a: %s", blk->getName().toLocal8Bit().data());
 
-                ts << QString("\n%1\n").arg(blk->getName());
+                // Emit the glyph code compactly: leading zeros are optional in LFF,
+                // so "[0021] !" is written as "[21] !". The block's in-memory name
+                // stays zero-padded (the font viewer and block list rely on that);
+                // only the on-disk file is compacted. Names that do not start with a
+                // bracketed hex code pass through unchanged.
+                QString header = blk->getName();
+                static const QRegularExpression codeRe("^\\[0*([0-9A-Fa-f]+)\\]");
+                header.replace(codeRe, "[\\1]");
+                ts << QString("\n%1\n").arg(header);
 
                 // iterate through entities of this letter:
                 for (RS_Entity* e : lc::LC_ContainerTraverser{*blk, RS2::ResolveNone}.entities()) {
@@ -231,11 +240,10 @@ bool RS_FilterLFF::fileExport(RS_Graphic& g, const QString& file, RS2::FormatTyp
                         }
                         else if (e->rtti() == RS2::EntityBlock) {
                             const auto b = static_cast<RS_Block*>(e);
+                            // Reference codes are written compactly too; leading zeros
+                            // are optional and the reader parses any width.
                             QString uCode;
                             uCode.setNum(b->getName().at(0).unicode(), 16);
-                            if (uCode.length() < 4) {
-                                uCode = uCode.rightJustified(4, '0');
-                            }
                             ts << QString("C%1\n").arg(uCode);
                         }
                         else if (e->rtti() == RS2::EntityPolyline) {

--- a/tools/ttf2lff/main.cpp
+++ b/tools/ttf2lff/main.cpp
@@ -570,18 +570,16 @@ double roundToGrid(double value) {
 
 std::string formatCharCode(unsigned int charCode)
 {
+    // LFF readers treat leading zeros as optional ([0020] == [20]), so
+    // write the minimal hex form to save a byte or two per glyph.
     std::ostringstream stream;
-    stream << std::hex << std::nouppercase << std::setfill('0');
-    if (charCode <= 0xffff) {
-        stream << std::setw(4);
-    }
-    stream << charCode;
+    stream << std::hex << std::nouppercase << charCode;
     return stream.str();
 }
 
 bool canReferenceGlyph(unsigned int charCode)
 {
-    // LibreCAD's LFF header discovery currently extracts four hex digits.
+    // Keep nested-glyph references within the BMP for maximum reader compatibility.
     return charCode <= 0xffff;
 }
 


### PR DESCRIPTION
Part of #2636. Addresses the malformed-glyph-code problem @siwf reported on the
regenerated `wqy-unicode.lff`.

## The problem

`ttf2lff` emitted glyph headers as `[#0020]`, which the LFF reader rejected — the
leading `#` was not accepted, so those glyphs were skipped.

## Reader

Glyph headers are now parsed with an anchored `^\[#?([0-9A-Fa-f]{1,6})\]`, so all
four spellings load to the same character:

```
[0020]   [20]   [#0020]   [#20]
```

Widening the code to 6 hex digits also admits the full Unicode range up to
U+10FFFF. The previous 5-digit cap silently dropped any glyph in planes 15–16.

The regex is anchored and only applied to lines already known to start with `[`
(metadata lines starting with `#` are handled on a separate branch), so `#`
comments are unaffected.

## Writers

Both writers now emit the minimal form, since leading zeros are optional:

* `ttf2lff`'s `formatCharCode` drops the `setw(4)` padding — `[#41]`, not `[#0041]`.
* `RS_FilterLFF::fileExport` strips leading zeros from the `[..]` glyph header and
  from `C..` references.

The in-memory `RS_Block` name keeps its zero-padded `[hhhh] c` form, because the
font viewer (`lc_fontfileviewer.cpp`, `getName().mid(1,4)`) and the block list
depend on that fixed width. Only the on-disk file is compacted. `rs_filtercxf.cpp`
is deliberately untouched — the CXF parser requires exactly 4 hex digits.

## Compatibility

Existing fonts are unaffected: all 47 shipped `.lff` files use the padded `[0020]`
form and still parse identically. The change is additive — it only widens what the
reader accepts.

## Testing

* `librecad_lib` and `ttf2lff` build clean against current master.
* All 47 shipped `.lff` fonts parse unchanged.
* Verified `[0020]` / `[20]` / `[#0020]` / `[#20]` all load to U+0020.
* Converted a 3,381-glyph font: every header emitted compact, zero padded headers
  remaining.
