### PR TITLE
ttf2lff: -t implies -d 2, and enforce the documented -d minimum

### DIFF
--- a/tools/ttf2lff/main.cpp
+++ b/tools/ttf2lff/main.cpp
@@ -1266,7 +1266,7 @@ static void usage(int eval) {
     std::cout << "  -l, --letterspacing N  Letter spacing (default: 3.0)\n";
     std::cout << "  -w, --wordspacing N    Word spacing (default: 6.75)\n";
     std::cout << "  -f, --linespacing N    Line spacing factor (default: 1.0)\n";
-    std::cout << "  -d, --precision N      Decimal precision (default: 6)\n";
+    std::cout << "  -d, --precision N      Decimal digits after the point (default: 6, min: 1)\n";
     std::cout << "  -L, --license TEXT     Font license\n";
     std::cout << "\n";
     std::cout << "Tuning options (from python-lff):\n";
@@ -1276,7 +1276,7 @@ static void usage(int eval) {
     std::cout << "  -m, --mergepath        Merge paths with same start/end vertex\n";
     std::cout << "  -e, --nestedchar       Analyze for nested characters\n";
     std::cout << "  -c, --nocomment        Remove comments from glyphs\n";
-    std::cout << "  -t, --tuning           Apply all tuning options\n";
+    std::cout << "  -t, --tuning           Apply all tuning options (implies -d 2)\n";
     std::cout << "\n";
     std::cout << "  -h, --help             Show this help message\n";
     std::cout << "\n";
@@ -1303,6 +1303,7 @@ int main(int argc, char* argv[]) {
     std::string author = "Unknown";
     std::string license = "Unknown";
     int precision = 6;
+    bool precisionExplicit = false;
 
     // Parse command line arguments
     for (int i = 1; i < argc; ++i) {
@@ -1334,6 +1335,10 @@ int main(int argc, char* argv[]) {
         else if (arg == "-d" || arg == "--precision") {
             if (++i >= argc) { std::cerr << "Error: -d requires an argument\n"; return 1; }
             precision = std::atoi(argv[i]);
+            if (precision < 1) {
+                std::cerr << "Error: -d/--precision requires a value >= 1\n"; return 1;
+            }
+            precisionExplicit = true;
         }
         else if (arg == "-L" || arg == "--license") {
             if (++i >= argc) { std::cerr << "Error: -L requires an argument\n"; return 1; }
@@ -1365,6 +1370,10 @@ int main(int argc, char* argv[]) {
             tuningOptions.mergePath = true;
             tuningOptions.nestedChar = true;
             tuningOptions.noComment = true;
+            // Reduce coordinates to 2 decimals, unless -d/--precision was given
+            if (!precisionExplicit) {
+                precision = 2;
+            }
         }
         else if (arg[0] != '-') {
             // Assume first non-option is TTF file, second is LFF file
@@ -1392,6 +1401,7 @@ int main(int argc, char* argv[]) {
     if (tuningOptions.mergePath) std::cout << "Tuning: MergePath enabled\n";
     if (tuningOptions.nestedChar) std::cout << "Tuning: NestedChar enabled\n";
     if (tuningOptions.noComment) std::cout << "Tuning: NoComment enabled\n";
+    std::cout << "Precision: " << precision << " decimal digit(s)\n";
 
     // Create converter with RAII
     TTF2LFFConverter converter;

--- a/tools/ttf2lff/ttf2lff.1
+++ b/tools/ttf2lff/ttf2lff.1
@@ -27,7 +27,8 @@ Word spacing (default: 6.75)
 Line spacing factor (default: 1.0)
 .TP
 .BR \-d ", " \-\-precision " \fIN\fR"
-Number of decimal digits (default: 6)
+Number of decimal digits kept after the point in coordinates (default: 6, minimum: 1).
+Lowering this is the main size-reduction lever; e.g. \fB\-d 2\fR emits values like \fI1.11\fR.
 .TP
 .BR \-L ", " \-\-license " \fITEXT\fR"
 Font license
@@ -53,7 +54,8 @@ Analyze for nested characters (glyphs that could reference other glyphs).
 Remove comments from glyph definitions.
 .TP
 .BR \-t ", " \-\-tuning
-Apply all tuning options at once.
+Apply all tuning options at once. This also sets the coordinate precision to 2
+decimals (equivalent to \fB\-d 2\fR) unless an explicit \fB\-d\fR is given.
 
 .TP
 .BR \-h ", " \-\-help


### PR DESCRIPTION
Part of #2636 — the size half of the CJK-font discussion.

Independent of #2711: that PR changes how glyph *codes* are written, this one
changes coordinate *precision*. The two touch different parts of `main.cpp` and
merge cleanly in either order.

## `-t/--tuning` implies `-d 2`

Coordinate precision is the dominant size lever for large CJK fonts, and @siwf
noted that the `wqy-unicode.lff` on the wiki uses 2-digit precision. `-t` now sets
`-d/--precision` to 2 unless an explicit `-d` is given — in either flag order, so
`-t -d 6` and `-d 6 -t` both keep 6.

On a 34,600-glyph WenQuanYi font:

| | size |
|---|---|
| default (precision 6) | 63.9 MB |
| `-t` | 35.1 MB |

## `-d` rejects values below 1

`--help` and the man page both documented a minimum of 1, but nothing enforced it:
`-d 0` was accepted and produced integer-only coordinates and an unusable font.
It now errors out, so the documented contract holds.

The selected precision is echoed at startup next to the tuning flags, since it is
now something `-t` can change implicitly.

## A note on the option set

An earlier draft added a separate `-p/--points` flag for the decimal limit. It was
dropped before submitting: `-d/--precision` already caps coordinate decimals, and
measuring both on the 34,600-glyph font showed the separate flag saving only 708
bytes (0.002%, 2 vertices out of 3.26M) over plain `-d 2`. One lever is clearer
than two overlapping ones.

## Testing

* `ttf2lff` builds clean against current master.
* Default → precision 6; `-t` → precision 2; `-t -d 6` and `-d 6 -t` → both 6.
* `-d 0` and `-d -3` rejected with a clear message.
* Confirmed on converted output that `-t` caps coordinates at 2 decimals while the
  default keeps 6 (checked on coordinate lines only — the `# Tuning:` header
  legitimately prints `grid=0.000100`).
