### PR TITLE
Fix four null-entity crashes, including the parallel-tool segfault (#2708)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2395,6 +2395,7 @@ if (BUILD_TESTS)
         librecad/src/lib/math/tests/rs_math_tests.cpp
         librecad/src/lib/math/tests/lc_quadratic_tests.cpp
         librecad/src/lib/creation/tests/rs_creation_null_entity_tests.cpp
+        librecad/src/lib/modification/tests/rs_modification_trim_tests.cpp
         librecad/src/lib/filters/tests/dwg_buffer_round_trip_tests.cpp
         librecad/src/lib/filters/tests/dwg_entity_encode_round_trip_tests.cpp
         librecad/src/lib/filters/tests/dwg_header_encode_round_trip_tests.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2394,6 +2394,7 @@ if (BUILD_TESTS)
         librecad/src/lib/engine/document/entities/tests/rs_text_bidi_tests.cpp
         librecad/src/lib/math/tests/rs_math_tests.cpp
         librecad/src/lib/math/tests/lc_quadratic_tests.cpp
+        librecad/src/lib/creation/tests/rs_creation_null_entity_tests.cpp
         librecad/src/lib/filters/tests/dwg_buffer_round_trip_tests.cpp
         librecad/src/lib/filters/tests/dwg_entity_encode_round_trip_tests.cpp
         librecad/src/lib/filters/tests/dwg_header_encode_round_trip_tests.cpp

--- a/librecad/src/actions/drawing/draw/dimensions/lc_actioncircledimbase.cpp
+++ b/librecad/src/actions/drawing/draw/dimensions/lc_actioncircledimbase.cpp
@@ -128,6 +128,9 @@ void LC_ActionCircleDimBase::onMouseLeftButtonRelease(const int status, const LC
             break;
         }
         case SetPos: {
+            if (m_entity == nullptr) {
+                break;
+            }
             RS_Vector snap = e->snapPoint;
             snap = getSnapAngleAwarePoint(e, m_entity->getCenter(), snap);
             fireCoordinateEvent(snap);

--- a/librecad/src/actions/drawing/draw/dimensions/rs_actiondimangular.cpp
+++ b/librecad/src/actions/drawing/draw/dimensions/rs_actiondimangular.cpp
@@ -337,6 +337,9 @@ int RS_ActionDimAngular::determineQuadrant(const double angle) const {
  */
 bool RS_ActionDimAngular::setData(const RS_Vector &dimPos, const bool calcCenter /*= false*/){
     bool result = false;
+    if (m_line1 == nullptr || m_line2 == nullptr) {
+        return result;
+    }
     if (m_line1->getStartpoint().valid && m_line2->getStartpoint().valid){
 
         if (!m_center.valid || calcCenter){

--- a/librecad/src/actions/drawing/draw/line/lc_action_draw_line_parallel.cpp
+++ b/librecad/src/actions/drawing/draw/line/lc_action_draw_line_parallel.cpp
@@ -107,9 +107,7 @@ bool LC_ActionDrawLineParallel::doUpdateDistanceByInteractiveInput(const QString
 
 bool LC_ActionDrawLineParallel::doTriggerModifications(LC_DocumentModificationBatch& ctx) {
     RS_Creation::createParallel(*m_coord, m_distance, m_numberToCreate, m_entity, false, ctx.entitiesToAdd);
-    // Nothing to commit when no parallel is possible: no entity under the cursor,
-    // or an inner circle parallel whose distance exceeds the radius.
-    return !ctx.entitiesToAdd.isEmpty();
+    return true;
 }
 
 void LC_ActionDrawLineParallel::onMouseMoveEvent([[maybe_unused]] const int status, const LC_MouseEvent* e) {

--- a/librecad/src/actions/drawing/draw/line/lc_action_draw_line_parallel.cpp
+++ b/librecad/src/actions/drawing/draw/line/lc_action_draw_line_parallel.cpp
@@ -107,7 +107,9 @@ bool LC_ActionDrawLineParallel::doUpdateDistanceByInteractiveInput(const QString
 
 bool LC_ActionDrawLineParallel::doTriggerModifications(LC_DocumentModificationBatch& ctx) {
     RS_Creation::createParallel(*m_coord, m_distance, m_numberToCreate, m_entity, false, ctx.entitiesToAdd);
-    return true;
+    // Nothing to commit when no parallel is possible: no entity under the cursor,
+    // or an inner circle parallel whose distance exceeds the radius.
+    return !ctx.entitiesToAdd.isEmpty();
 }
 
 void LC_ActionDrawLineParallel::onMouseMoveEvent([[maybe_unused]] const int status, const LC_MouseEvent* e) {

--- a/librecad/src/actions/drawing/draw/line/lc_action_draw_line_parallel_through.cpp
+++ b/librecad/src/actions/drawing/draw/line/lc_action_draw_line_parallel_through.cpp
@@ -77,6 +77,11 @@ void LC_ActionDrawLineParallelThrough::doInitWithContextEntity(RS_Entity* contex
         const auto polyline = static_cast<RS_Polyline*>(contextEntity);
         entity = polyline->getNearestEntity(clickPos);
     }
+    // getNearestEntity() returns null when the polyline offers no candidate
+    // segment, or when the nearest one is invisible.
+    if (entity == nullptr) {
+        return;
+    }
     const RS2::EntityType rtti = entity->rtti();
     if (g_supportedEntityTypes.contains(rtti)) {
         m_entity = entity;

--- a/librecad/src/actions/drawing/draw/line/lc_action_draw_line_parallel_through.cpp
+++ b/librecad/src/actions/drawing/draw/line/lc_action_draw_line_parallel_through.cpp
@@ -77,13 +77,7 @@ void LC_ActionDrawLineParallelThrough::doInitWithContextEntity(RS_Entity* contex
         const auto polyline = static_cast<RS_Polyline*>(contextEntity);
         entity = polyline->getNearestEntity(clickPos);
     }
-    // getNearestEntity() returns null when the polyline offers no candidate
-    // segment, or when the nearest one is invisible.
-    if (entity == nullptr) {
-        return;
-    }
-    const RS2::EntityType rtti = entity->rtti();
-    if (g_supportedEntityTypes.contains(rtti)) {
+    if (entity != nullptr && g_supportedEntityTypes.contains(entity->rtti())) {
         m_entity = entity;
         setStatus(SetPos);
     }

--- a/librecad/src/actions/drawing/draw/line/lc_action_draw_line_rel_angle.cpp
+++ b/librecad/src/actions/drawing/draw/line/lc_action_draw_line_rel_angle.cpp
@@ -66,13 +66,7 @@ void LC_ActionDrawLineRelAngle::doInitWithContextEntity(RS_Entity* contextEntity
         const auto polyline = static_cast<RS_Polyline*>(contextEntity);
         entity = polyline->getNearestEntity(clickPos);
     }
-    // getNearestEntity() returns null when the polyline offers no candidate
-    // segment, or when the nearest one is invisible.
-    if (entity == nullptr) {
-        return;
-    }
-    const RS2::EntityType rtti = entity->rtti();
-    if (g_enTypeList.contains(rtti)) {
+    if (entity != nullptr && g_enTypeList.contains(entity->rtti())) {
         setEntity(entity);
     }
 }

--- a/librecad/src/actions/drawing/draw/line/lc_action_draw_line_rel_angle.cpp
+++ b/librecad/src/actions/drawing/draw/line/lc_action_draw_line_rel_angle.cpp
@@ -66,6 +66,11 @@ void LC_ActionDrawLineRelAngle::doInitWithContextEntity(RS_Entity* contextEntity
         const auto polyline = static_cast<RS_Polyline*>(contextEntity);
         entity = polyline->getNearestEntity(clickPos);
     }
+    // getNearestEntity() returns null when the polyline offers no candidate
+    // segment, or when the nearest one is invisible.
+    if (entity == nullptr) {
+        return;
+    }
     const RS2::EntityType rtti = entity->rtti();
     if (g_enTypeList.contains(rtti)) {
         setEntity(entity);

--- a/librecad/src/actions/drawing/draw/line/rs_actiondrawlineorthtan.cpp
+++ b/librecad/src/actions/drawing/draw/line/rs_actiondrawlineorthtan.cpp
@@ -68,6 +68,11 @@ void RS_ActionDrawLineOrthTan::doInitWithContextEntity(RS_Entity* contextEntity,
         const auto polyline = static_cast<RS_Polyline*>(contextEntity);
         entity = polyline->getNearestEntity(clickPos);
     }
+    // getNearestEntity() returns null when the polyline offers no candidate
+    // segment, or when the nearest one is invisible.
+    if (entity == nullptr) {
+        return;
+    }
     if (isLine(entity)) {
         // fixme - support of polyline
         setLine(entity);

--- a/librecad/src/actions/drawing/draw/line/rs_actiondrawlineorthtan.cpp
+++ b/librecad/src/actions/drawing/draw/line/rs_actiondrawlineorthtan.cpp
@@ -68,16 +68,11 @@ void RS_ActionDrawLineOrthTan::doInitWithContextEntity(RS_Entity* contextEntity,
         const auto polyline = static_cast<RS_Polyline*>(contextEntity);
         entity = polyline->getNearestEntity(clickPos);
     }
-    // getNearestEntity() returns null when the polyline offers no candidate
-    // segment, or when the nearest one is invisible.
-    if (entity == nullptr) {
-        return;
-    }
     if (isLine(entity)) {
         // fixme - support of polyline
         setLine(entity);
     }
-    else {
+    else if (entity != nullptr) {
         const RS2::EntityType rtti = entity->rtti();
         if (g_supportedCircleEntityTypes.contains(rtti)) {
             m_actionData->setCircleFirst = true;

--- a/librecad/src/actions/drawing/draw/line/rs_actiondrawlinetangent1.cpp
+++ b/librecad/src/actions/drawing/draw/line/rs_actiondrawlinetangent1.cpp
@@ -57,6 +57,11 @@ void RS_ActionDrawLineTangent1::doInitWithContextEntity(RS_Entity* contextEntity
         const auto polyline = static_cast<RS_Polyline*>(contextEntity);
         entity = polyline->getNearestEntity(clickPos);
     }
+    // getNearestEntity() returns null when the polyline offers no candidate
+    // segment, or when the nearest one is invisible.
+    if (entity == nullptr) {
+        return;
+    }
     const RS2::EntityType rtti = entity->rtti();
     if (g_supportedEntityTypes.contains(rtti)) {
         m_setCircleFirst = true;

--- a/librecad/src/actions/drawing/draw/line/rs_actiondrawlinetangent1.cpp
+++ b/librecad/src/actions/drawing/draw/line/rs_actiondrawlinetangent1.cpp
@@ -57,13 +57,7 @@ void RS_ActionDrawLineTangent1::doInitWithContextEntity(RS_Entity* contextEntity
         const auto polyline = static_cast<RS_Polyline*>(contextEntity);
         entity = polyline->getNearestEntity(clickPos);
     }
-    // getNearestEntity() returns null when the polyline offers no candidate
-    // segment, or when the nearest one is invisible.
-    if (entity == nullptr) {
-        return;
-    }
-    const RS2::EntityType rtti = entity->rtti();
-    if (g_supportedEntityTypes.contains(rtti)) {
+    if (entity != nullptr && g_supportedEntityTypes.contains(entity->rtti())) {
         m_setCircleFirst = true;
         m_entity = entity;
         setStatus(SetPoint);

--- a/librecad/src/actions/drawing/draw/line/rs_actiondrawlinetangent2.cpp
+++ b/librecad/src/actions/drawing/draw/line/rs_actiondrawlinetangent2.cpp
@@ -73,6 +73,11 @@ void RS_ActionDrawLineTangent2::doInitWithContextEntity(RS_Entity* contextEntity
         const auto polyline = static_cast<RS_Polyline*>(contextEntity);
         entity = polyline->getNearestEntity(clickPos);
     }
+    // getNearestEntity() returns null when the polyline offers no candidate
+    // segment, or when the nearest one is invisible.
+    if (entity == nullptr) {
+        return;
+    }
     const RS2::EntityType rtti = entity->rtti();
     if (g_circleType.contains(rtti)) {
         m_actionData->circle1 = entity;

--- a/librecad/src/actions/drawing/draw/line/rs_actiondrawlinetangent2.cpp
+++ b/librecad/src/actions/drawing/draw/line/rs_actiondrawlinetangent2.cpp
@@ -73,13 +73,7 @@ void RS_ActionDrawLineTangent2::doInitWithContextEntity(RS_Entity* contextEntity
         const auto polyline = static_cast<RS_Polyline*>(contextEntity);
         entity = polyline->getNearestEntity(clickPos);
     }
-    // getNearestEntity() returns null when the polyline offers no candidate
-    // segment, or when the nearest one is invisible.
-    if (entity == nullptr) {
-        return;
-    }
-    const RS2::EntityType rtti = entity->rtti();
-    if (g_circleType.contains(rtti)) {
+    if (entity != nullptr && g_circleType.contains(entity->rtti())) {
         m_actionData->circle1 = entity;
         m_actionData->circle2 = nullptr;
         setStatus(SetCircle2);

--- a/librecad/src/lib/creation/rs_creation.cpp
+++ b/librecad/src/lib/creation/rs_creation.cpp
@@ -182,10 +182,7 @@ void RS_Creation::createParallel(const RS_Vector& coord, const double distance, 
  */
 void RS_Creation::createParallelLine(const RS_Vector& coord, double distance, int number, const RS_Line* e, bool symmetric,
                                      QList<RS_Entity*>& createdEntities) {
-    // check given entity:
-    if (e == nullptr) {
-        return;
-    }
+    Q_ASSERT(e != nullptr);
 
     double ang = e->getAngle1() + M_PI_2;
     RS_LineData parallelData;
@@ -245,10 +242,7 @@ void RS_Creation::createParallelLine(const RS_Vector& coord, double distance, in
  *
  */
 void RS_Creation::createParallelArc(const RS_Vector& coord, double distance, const int number, RS_Arc* e, QList<RS_Entity*>& createdEntities) {
-    // check given entity:
-    if (e == nullptr) {
-        return;
-    }
+    Q_ASSERT(e != nullptr);
 
     RS_ArcData parallelData{};
     const bool inside = e->getCenter().distanceTo(coord) < e->getRadius();
@@ -304,10 +298,7 @@ void RS_Creation::createParallelArc(const RS_Vector& coord, double distance, con
  */
 void RS_Creation::createParallelCircle(const RS_Vector& coord, double distance, const int number, const RS_Circle* e,
                                        QList<RS_Entity*>& createdEntities) {
-    // check given entity:
-    if (e == nullptr) {
-        return;
-    }
+    Q_ASSERT(e != nullptr);
 
     RS_CircleData parallelData{};
 
@@ -365,10 +356,7 @@ void RS_Creation::createParallelCircle(const RS_Vector& coord, double distance, 
  */
 void RS_Creation::createParallelSplinePoints(const RS_Vector& coord, const double distance, const int number, const LC_SplinePoints* e,
                                              QList<RS_Entity*>& createdEntities) {
-    // check given entity:
-    if (e == nullptr) {
-        return;
-    }
+    Q_ASSERT(e != nullptr);
 
     LC_SplinePoints* psp = nullptr;
     for (int i = 1; i <= number; ++i) {

--- a/librecad/src/lib/creation/rs_creation.cpp
+++ b/librecad/src/lib/creation/rs_creation.cpp
@@ -99,7 +99,10 @@ namespace {
 void RS_Creation::createParallelThrough(const RS_Vector& coord, const int number, RS_Entity* e, const bool symmetric,
                                         bool distributeWithin,
                                         QList<RS_Entity*>& createdEntities) {
-    Q_ASSERT(e != nullptr);
+    // check given entity:
+    if (e == nullptr) {
+        return;
+    }
 
     double dist = 0.;
     if (e->rtti() == RS2::EntityLine) {
@@ -137,7 +140,10 @@ void RS_Creation::createParallelThrough(const RS_Vector& coord, const int number
  */
 void RS_Creation::createParallel(const RS_Vector& coord, const double distance, const int number, RS_Entity* e, const bool symmetric,
                                  QList<RS_Entity*>& createdEntities) {
-    Q_ASSERT(e != nullptr);
+    // check given entity:
+    if (e == nullptr) {
+        return;
+    }
 
     switch (e->rtti()) {
         case RS2::EntityLine:
@@ -176,7 +182,10 @@ void RS_Creation::createParallel(const RS_Vector& coord, const double distance, 
  */
 void RS_Creation::createParallelLine(const RS_Vector& coord, double distance, int number, const RS_Line* e, bool symmetric,
                                      QList<RS_Entity*>& createdEntities) {
-    Q_ASSERT(e != nullptr);
+    // check given entity:
+    if (e == nullptr) {
+        return;
+    }
 
     double ang = e->getAngle1() + M_PI_2;
     RS_LineData parallelData;
@@ -236,7 +245,10 @@ void RS_Creation::createParallelLine(const RS_Vector& coord, double distance, in
  *
  */
 void RS_Creation::createParallelArc(const RS_Vector& coord, double distance, const int number, RS_Arc* e, QList<RS_Entity*>& createdEntities) {
-    Q_ASSERT(e != nullptr);
+    // check given entity:
+    if (e == nullptr) {
+        return;
+    }
 
     RS_ArcData parallelData{};
     const bool inside = e->getCenter().distanceTo(coord) < e->getRadius();
@@ -292,7 +304,10 @@ void RS_Creation::createParallelArc(const RS_Vector& coord, double distance, con
  */
 void RS_Creation::createParallelCircle(const RS_Vector& coord, double distance, const int number, const RS_Circle* e,
                                        QList<RS_Entity*>& createdEntities) {
-    Q_ASSERT(e != nullptr);
+    // check given entity:
+    if (e == nullptr) {
+        return;
+    }
 
     RS_CircleData parallelData{};
 
@@ -350,7 +365,10 @@ void RS_Creation::createParallelCircle(const RS_Vector& coord, double distance, 
  */
 void RS_Creation::createParallelSplinePoints(const RS_Vector& coord, const double distance, const int number, const LC_SplinePoints* e,
                                              QList<RS_Entity*>& createdEntities) {
-    Q_ASSERT(e != nullptr);
+    // check given entity:
+    if (e == nullptr) {
+        return;
+    }
 
     LC_SplinePoints* psp = nullptr;
     for (int i = 1; i <= number; ++i) {

--- a/librecad/src/lib/creation/tests/rs_creation_null_entity_tests.cpp
+++ b/librecad/src/lib/creation/tests/rs_creation_null_entity_tests.cpp
@@ -1,0 +1,116 @@
+/****************************************************************************
+**
+** This file is part of the LibreCAD project, unit tests for RS_Creation
+**
+** Copyright (C) 2026 LibreCAD.org
+** Copyright (C) 2026 Dongxu Li (github.com/dxli)
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**********************************************************************/
+
+// Regression tests for issue #2708.
+//
+// The parallel tools hand RS_Creation whatever entity the last mouse move caught,
+// which is a null pointer whenever the cursor is not over a supported entity. These
+// entry points used to declare that precondition with Q_ASSERT, which is compiled
+// out in every build the project ships, so a null argument reached a virtual rtti()
+// call and crashed. They must instead return without producing anything.
+//
+// Note this file is deliberately free of any action or document dependency:
+// RS_Creation is a namespace of free functions, so the contract is testable directly.
+//
+// The failure guarded against is a segmentation fault, not an exception, so the calls
+// are made plainly rather than wrapped in a no-throw assertion, which would imply the
+// wrong failure mode. Catch2 installs a fatal-signal handler and reports SIGSEGV as a
+// failed assertion, so a regression fails the test rather than passing silently.
+// Verified: with the guards removed these abort with
+// "SIGSEGV - Segmentation violation signal" and exit 139.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <QList>
+
+#include "rs_creation.h"
+#include "rs_entity.h"
+#include "rs_line.h"
+#include "rs_vector.h"
+
+namespace {
+const RS_Vector g_coord{1.0, 2.0};
+}
+
+TEST_CASE("RS_Creation::createParallel tolerates a null entity", "[rs_creation][null]") {
+    QList<RS_Entity*> created;
+    RS_Creation::createParallel(g_coord, 0.5, 1, nullptr, false, created);
+    CHECK(created.isEmpty());
+}
+
+TEST_CASE("RS_Creation::createParallelThrough tolerates a null entity", "[rs_creation][null]") {
+    QList<RS_Entity*> created;
+    RS_Creation::createParallelThrough(g_coord, 1, nullptr, false, false, created);
+    CHECK(created.isEmpty());
+}
+
+TEST_CASE("RS_Creation parallel helpers tolerate a null entity", "[rs_creation][null]") {
+    QList<RS_Entity*> created;
+
+    SECTION("line") {
+        RS_Creation::createParallelLine(g_coord, 0.5, 1, nullptr, false, created);
+    }
+    SECTION("arc") {
+        RS_Creation::createParallelArc(g_coord, 0.5, 1, nullptr, created);
+    }
+    SECTION("circle") {
+        RS_Creation::createParallelCircle(g_coord, 0.5, 1, nullptr, created);
+    }
+    SECTION("spline points") {
+        RS_Creation::createParallelSplinePoints(g_coord, 0.5, 1, nullptr, created);
+    }
+
+    CHECK(created.isEmpty());
+}
+
+TEST_CASE("RS_Creation::createParallel with a null entity ignores the count", "[rs_creation][null]") {
+    // The crash was on the very first dereference, before the loop, so a count above
+    // one must not change the outcome.
+    QList<RS_Entity*> created;
+    RS_Creation::createParallel(g_coord, 0.5, 25, nullptr, false, created);
+    CHECK(created.isEmpty());
+}
+
+// ---------------------------------------------------------------------------
+// Positive cases. Without these the null-input tests above would still pass if
+// a guard were mutated into an unconditional early return, which would disable
+// the tools rather than fix them.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("RS_Creation::createParallel still produces a parallel for a real line",
+          "[rs_creation][positive]") {
+    RS_Line line{nullptr, RS_Vector{0.0, 0.0}, RS_Vector{10.0, 0.0}};
+    QList<RS_Entity*> created;
+    RS_Creation::createParallel(RS_Vector{5.0, 3.0}, 2.0, 1, &line, false, created);
+    REQUIRE(created.size() == 1);
+    CHECK(created.front()->rtti() == RS2::EntityLine);
+    qDeleteAll(created);
+}
+
+TEST_CASE("RS_Creation::createParallel honours the requested count",
+          "[rs_creation][positive]") {
+    RS_Line line{nullptr, RS_Vector{0.0, 0.0}, RS_Vector{10.0, 0.0}};
+    QList<RS_Entity*> created;
+    RS_Creation::createParallel(RS_Vector{5.0, 3.0}, 1.0, 4, &line, false, created);
+    CHECK(created.size() == 4);
+    qDeleteAll(created);
+}

--- a/librecad/src/lib/creation/tests/rs_creation_null_entity_tests.cpp
+++ b/librecad/src/lib/creation/tests/rs_creation_null_entity_tests.cpp
@@ -63,33 +63,6 @@ TEST_CASE("RS_Creation::createParallelThrough tolerates a null entity", "[rs_cre
     CHECK(created.isEmpty());
 }
 
-TEST_CASE("RS_Creation parallel helpers tolerate a null entity", "[rs_creation][null]") {
-    QList<RS_Entity*> created;
-
-    SECTION("line") {
-        RS_Creation::createParallelLine(g_coord, 0.5, 1, nullptr, false, created);
-    }
-    SECTION("arc") {
-        RS_Creation::createParallelArc(g_coord, 0.5, 1, nullptr, created);
-    }
-    SECTION("circle") {
-        RS_Creation::createParallelCircle(g_coord, 0.5, 1, nullptr, created);
-    }
-    SECTION("spline points") {
-        RS_Creation::createParallelSplinePoints(g_coord, 0.5, 1, nullptr, created);
-    }
-
-    CHECK(created.isEmpty());
-}
-
-TEST_CASE("RS_Creation::createParallel with a null entity ignores the count", "[rs_creation][null]") {
-    // The crash was on the very first dereference, before the loop, so a count above
-    // one must not change the outcome.
-    QList<RS_Entity*> created;
-    RS_Creation::createParallel(g_coord, 0.5, 25, nullptr, false, created);
-    CHECK(created.isEmpty());
-}
-
 // ---------------------------------------------------------------------------
 // Positive cases. Without these the null-input tests above would still pass if
 // a guard were mutated into an unconditional early return, which would disable

--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -1311,8 +1311,14 @@ LC_TrimResult RS_Modification::trim(const RS_Vector& trimCoord, RS_AtomicEntity*
                                     RS_Entity* limitEntity, const bool both, LC_DocumentModificationBatch& ctx) {
     Q_ASSERT(trimEntity != nullptr && limitEntity != nullptr);
 
-    if (both && !limitEntity->isAtomic()) {
-        RS_DEBUG->print(RS_Debug::D_WARNING, "RS_Modification::trim: limitEntity is not atomic");
+    // A container limit entity can still bound a one-sided trim, but it must never
+    // be cast to RS_AtomicEntity: trimStartpoint(), trimEndpoint() and getTrimPoint()
+    // are declared only there, so dispatching them through a container pointer calls
+    // whatever occupies the same vtable slot.
+    const bool limitIsAtomic = limitEntity->isAtomic();
+    if (both && !limitIsAtomic) {
+        RS_DEBUG->print(RS_Debug::D_WARNING,
+                        "RS_Modification::trim: limitEntity is not atomic, trimming one entity only");
     }
 
     LC_TrimResult result;
@@ -1338,7 +1344,7 @@ LC_TrimResult RS_Modification::trim(const RS_Vector& trimCoord, RS_AtomicEntity*
     }
 
     if (!sol.hasValid()) {
-        if (both) {
+        if (both && limitIsAtomic) {
             return trim(limitCoord, static_cast<RS_AtomicEntity*>(limitEntity), trimCoord, trimEntity, false, ctx);
         }
         return result;
@@ -1372,7 +1378,7 @@ LC_TrimResult RS_Modification::trim(const RS_Vector& trimCoord, RS_AtomicEntity*
     }
 
     // remove limit entity from view:
-    const bool trimBoth = both && !limitEntity->isLocked() && limitEntity->isVisible();
+    const bool trimBoth = both && limitIsAtomic && !limitEntity->isLocked() && limitEntity->isVisible();
     if (trimBoth) {
         trimmed2 = static_cast<RS_AtomicEntity*>(limitEntity->clone());
     }

--- a/librecad/src/lib/modification/tests/rs_modification_trim_tests.cpp
+++ b/librecad/src/lib/modification/tests/rs_modification_trim_tests.cpp
@@ -1,0 +1,79 @@
+/****************************************************************************
+**
+** This file is part of the LibreCAD project, unit tests for RS_Modification
+**
+** Copyright (C) 2026 LibreCAD.org
+** Copyright (C) 2026 Dongxu Li (github.com/dxli)
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**********************************************************************/
+
+// RS_Modification::trim() used to warn that a non-atomic limit entity was
+// unsupported and then use it anyway, casting it to RS_AtomicEntity at three
+// sites. trimStartpoint(), trimEndpoint() and getTrimPoint() are declared only
+// on RS_AtomicEntity, so dispatching them through a container pointer calls
+// whatever occupies the same vtable slot — silent corruption rather than a
+// clean failure.
+//
+// A container limit entity is legitimate for a one-sided trim, so the fix gates
+// the casts on isAtomic() rather than refusing the entity.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "rs_document.h"
+#include "rs_entitycontainer.h"
+#include "rs_line.h"
+#include "rs_modification.h"
+#include "rs_vector.h"
+
+TEST_CASE("RS_Modification::trim does not cast a container limit entity",
+          "[rs_modification][trim][container]") {
+    // A line crossing the container's segment, so an intersection exists and the
+    // function proceeds past the early outs into the casting code.
+    RS_Line toTrim{nullptr, RS_Vector{0.0, 5.0}, RS_Vector{10.0, 5.0}};
+
+    RS_EntityContainer limit{nullptr};
+    limit.addEntity(new RS_Line{&limit, RS_Vector{5.0, 0.0}, RS_Vector{5.0, 10.0}});
+    limit.calculateBorders();
+
+    LC_DocumentModificationBatch ctx;
+
+    // both=true asks trim() to trim the limit entity as well. Before the fix this
+    // reached static_cast<RS_AtomicEntity*>(container) and called atomic-only
+    // virtuals through it.
+    LC_TrimResult result;
+    REQUIRE_NOTHROW(result = RS_Modification::trim(RS_Vector{9.0, 5.0}, &toTrim,
+                                                   RS_Vector{5.0, 9.0}, &limit,
+                                                   true, ctx));
+
+    // The trim of the atomic entity is still allowed; only the container side is
+    // declined, so nothing is produced for it.
+    CHECK(result.trimmed2 == nullptr);
+}
+
+TEST_CASE("RS_Modification::trim still trims against an atomic limit entity",
+          "[rs_modification][trim][container]") {
+    // Guards against the fix being over-broad: an ordinary line limit must still
+    // trim both entities.
+    RS_Line toTrim{nullptr, RS_Vector{0.0, 5.0}, RS_Vector{10.0, 5.0}};
+    RS_Line limit{nullptr, RS_Vector{5.0, 0.0}, RS_Vector{5.0, 10.0}};
+
+    LC_DocumentModificationBatch ctx;
+    const LC_TrimResult result = RS_Modification::trim(RS_Vector{9.0, 5.0}, &toTrim,
+                                                       RS_Vector{5.0, 9.0}, &limit,
+                                                       true, ctx);
+    CHECK(result.trimmed1 != nullptr);
+    CHECK(result.trimmed2 != nullptr);
+}


### PR DESCRIPTION
Fixes #2708

Four null-entity crashes, each with a demonstrated path to it. Every hunk here was
checked against two rules: it must fix a reachable crash, and it must be the
smallest change that does. Several earlier changes failed one or the other and
have been removed — see *Removed after validation* at the end.

## 1. The reported crash — `RS_Creation::createParallel`

`LC_ActionDrawLineParallel::onMouseMoveEvent` stores
`m_entity = catchAndDescribe(...)` on every move, which is `nullptr` whenever the
cursor is not within catch distance of an entity. The *preview* use is guarded;
`onMouseLeftButtonRelease` calls `trigger()` unconditionally, and the action does
not override `doCheckMayTrigger()` — whose base returns `true`. So the null reaches
`createParallel` and the virtual `e->rtti()` in its dispatch switch runs on a null
pointer. **Left-click on empty canvas with the Parallel tool active.**

Both triggers described in the issue reduce to this path. A circle that is
genuinely caught but admits no parallel does *not* crash — it produces an empty
batch, and `RS_Undo::endUndoCycle` discards the empty cycle.

## 2. `RS_Creation::createParallelThrough`

Same file, one function up, reachable from the same tool family with no entity ever
picked: in Parallel-through, type `number`, right-click, move the mouse.
`onMouseRightButtonRelease` clears `m_entity`, then `initPrevious()` — which is
`init(status - 1)` — lands on `SetPos`, whose *preview* call is unguarded. (The
*trigger* call at line 89 is guarded; the preview one at line 122 was not.)

## 3. Three dimension-tool SIGSEGVs — six lines

`RS_ActionDimAngular::setData()` reads `m_line1`/`m_line2` unconditionally, and
`LC_ActionCircleDimBase`'s `SetPos` *release* handler reads `m_entity->getCenter()`
where the matching *move* handler was already guarded. Both members default to
`nullptr`; both accessors are virtual, so this is a vtable load from address 0.

Neither action gates its `text` command on a status — and `getAvailableCommands()`
actively **advertises** `text` at those statuses, so this is a documented path.
From a freshly started tool: type `text`, right-click (`initPrevious()` lands on
`SetPos`), then simply move the mouse. Escape reaches it too, since
`RS_EventHandler::back()` synthesises a right-button release. A second variant
exists from `SetLine2`, with the first line picked and the second not.

`LC_ActionCircleDimBase` is the base of both `RS_ActionDimRadial` and
`RS_ActionDimDiametric`, so one missing check crashes three tools.

## 4. `RS_Modification::trim()` casting a container limit entity

`trim()` warned that a non-atomic limit entity was unsupported and then used it
anyway, casting it to `RS_AtomicEntity` at three sites. `trimStartpoint()`,
`trimEndpoint()`, `getTrimPoint()` and `prepareTrim()` are declared **only** on
`RS_AtomicEntity`, so the calls went through foreign vtable slots.

Reachable by hovering: `LC_ActionModifyTrim` resolves its limit entity with
`ResolveAllButTextImage` and filters only `EntityPolyline` — its `isAtomic()` check
is present but **commented out** in the source. `RS_Hatch::doGetDistanceToPoint`
ignores the resolve level and returns `this` whenever the cursor is inside a
boundary loop, and Trim-Two calls `previewTrim()` on every mouse move.

The casts are gated on `isAtomic()` rather than the entity being refused: a
container is a legitimate boundary for a one-sided trim, and `findIntersection()`
walks container children specifically to support that. Replacing the three gates
with a single early return would be smaller but would **regress** — on `master` the
atomic side is trimmed correctly and only the limit side is undefined, so an early
return turns a working one-sided trim into a no-op.

## 5. Five context-entity dereferences — one condition each

Twelve `doInitWithContextEntity` overrides hand-copy a block that replaces the
context entity — which `init()` guarantees non-null — with
`polyline->getNearestEntity()`, which returns null when the container has no
eligible child. Five then dereference the result; the other seven route it through
`isLine()`/`isArc()`, which null-test internally, and are genuinely safe.

**Being precise about reachability, because it is weaker than the others.** Such
polylines do exist — `rs_filterdxfrw.cpp` explicitly adds a vertex-less `POLYLINE`
to the document, and a one-vertex polyline also yields zero children. All five
actions are on the polyline context menu. But a zero-segment polyline reports a
distance of `RS_MAXDOUBLE`, so `catchContextEntity`'s 32-pixel test only admits it
in a document where nothing else is nearer *and* at a zoom factor around 3e-9.
Nothing clamps the factor that low, so it is not impossible — but it is not the
casual path the other four are. Included because the fix is one condition per site
and the dereference is real.

## Testing

Six cases across two files. `RS_Creation` and `RS_Modification` are free functions
and statics, so both are testable with no document or GUI fixture; neither had any
coverage.

The positive cases carry real weight: without them, a guard mutated into an
unconditional early return would pass every null test while silently disabling the
tool, and the trim gate could be made over-broad without anything noticing.

The calls are made plainly rather than wrapped in a no-throw assertion — the
failure is a segmentation fault, not an exception, and Catch2's fatal-signal
handler is what reports it. Verified in both directions: reverting `rs_creation.cpp`
makes the suite abort with `SIGSEGV - Segmentation violation signal`, exit 139;
reverting the `trim()` gates makes the container test do the same.

Full suite: no new failures. (The shapefile tests fail on `master` for an unrelated
reason — #2716.)

## Removed after validation

An earlier revision of this PR was 38 files. Auditing every hunk against
"necessary for a reachable crash, and minimal" removed a good deal of it:

* **Guards in `createParallelLine`/`Arc`/`Circle`/`SplinePoints`.** Each has exactly
  one caller — the switch inside `createParallel`, which dereferences the entity in
  the switch expression before dispatching, and is now guarded itself. Beyond being
  unreachable, replacing `Q_ASSERT` there would trade the only mechanism that flags
  a future contract violation for a silent no-op. They keep their asserts.
* **`doTriggerModifications` returning `!ctx.entitiesToAdd.isEmpty()`.** Tracing
  every consumer, an empty batch behaves identically whether success is true or
  false, and `ctx.success` is never read on that path. It reads better and fixes
  nothing.
* **Deduplicating the twelve copied resolution blocks** behind a shared resolver —
  a refactor that adds a virtual to the base of ~180 action subclasses and fixes
  nothing the five conditions above do not.
* **The action status machines** that permit these states in the first place.
  Correcting them changes right-click behaviour and deserves separate review.
* Assorted `Q_ASSERT` conversions with no reachable null caller, and a
  `getCurrentAction()` guard with no demonstrated repro.
