### PR TITLE
Fix the dangling initializer_list that segfaults the test suite in CI

### DIFF
--- a/librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
+++ b/librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
@@ -535,8 +535,8 @@ TEST_CASE("DXF filter normalizes reflected planar curves once",
 
   // The first export is normalized WCS, so reading it again must not reflect
   // centers, axes, or curve parameters a second time.
-  for (const auto &[record, codes] : std::initializer_list<
-           std::pair<const char *, std::initializer_list<const char *>>>{
+  for (const auto &[record, codes] : std::vector<
+           std::pair<const char *, std::vector<const char *>>>{
            {"CIRCLE", {"10", "20", "40"}},
            {"ARC", {"10", "20", "40", "50", "51"}},
            {"ELLIPSE", {"10", "20", "11", "21", "40", "41", "42"}}}) {
@@ -582,8 +582,8 @@ TEST_CASE("DXF filter preserves WCS POINT and LINE extrusion fields",
                               RS2::FormatDXFRW));
   }
 
-  for (const auto &[record, values] : std::initializer_list<
-           std::pair<const char *, std::initializer_list<std::pair<const char *, const char *>>>>{
+  for (const auto &[record, values] : std::vector<
+           std::pair<const char *, std::vector<std::pair<const char *, const char *>>>>{
            {"POINT", {{"30", "3"}, {"39", "0.5"}, {"50", "30"}, {"210", "0.2"},
                       {"220", "0.3"}, {"230", "0.9327379053088815"}}},
            {"LINE", {{"30", "6"}, {"31", "9"}, {"39", "2.5"},
@@ -603,8 +603,8 @@ TEST_CASE("DXF filter preserves WCS POINT and LINE extrusion fields",
     REQUIRE(filter.fileExport(graphic2, QString::fromStdString(out2),
                               RS2::FormatDXFRW));
   }
-  for (const auto &[record, codes] : std::initializer_list<
-           std::pair<const char *, std::initializer_list<const char *>>>{
+  for (const auto &[record, codes] : std::vector<
+           std::pair<const char *, std::vector<const char *>>>{
            {"POINT", {"10", "20", "30", "39", "50", "210", "220", "230"}},
            {"LINE", {"10", "20", "30", "11", "21", "31", "39", "210", "220", "230"}}}) {
     for (const char *code : codes)
@@ -1009,8 +1009,8 @@ TEST_CASE("DXF filter normalizes TRACE and SOLID extrusion once",
     REQUIRE(filter.fileExport(graphic2, QString::fromStdString(out2),
                               RS2::FormatDXFRW));
   }
-  for (const auto &[record, codes] : std::initializer_list<
-           std::pair<const char *, std::initializer_list<const char *>>>{
+  for (const auto &[record, codes] : std::vector<
+           std::pair<const char *, std::vector<const char *>>>{
            {"TRACE", {"10", "20", "30", "11", "21", "31", "12", "22", "32", "13", "23", "33", "39"}},
            {"SOLID", {"10", "20", "30", "11", "21", "31", "12", "22", "32", "13", "23", "33", "39"}}}) {
     for (const char *code : codes)


### PR DESCRIPTION
`librecad_tests` segfaults on the Linux CI runner, so most of the suite never runs
and master's test signal is unreliable.

## Symptom

From the latest master run:

```
dxf_roundtrip_tests.cpp:544: FAILED:
  SIGSEGV - Segmentation violation signal
test cases:  160 |  158 passed | 2 failed
...
Segmentation fault (core dumped) ./librecad_tests
##[error]Process completed with exit code 139
```

The process dies at test case **160 of 730**, so roughly three quarters of the
suite never executes. It does not reproduce on macOS/clang — the full suite passes
there — which is why it went unnoticed.

## Cause

Four loops iterate a **nested** `std::initializer_list`:

```cpp
for (const auto &[record, codes] : std::initializer_list<
         std::pair<const char *, std::initializer_list<const char *>>>{
         {"CIRCLE", {"10", "20", "40"}},
         {"ARC", {"10", "20", "40", "50", "51"}},
         {"ELLIPSE", {"10", "20", "11", "21", "40", "41", "42"}}}) {
  for (const char *code : codes)          // <-- codes dangles
    CHECK(recordGroupValues(out2, record, code) == ...);   // line 544
```

A range-based `for` extends the lifetime of the *outer* range. It does not extend
the temporary arrays backing the **inner** `initializer_list`s — those die at the
end of the full-expression that created them.

So reading `codes` in the loop body is a stack-use-after-scope. `code` is whatever
now occupies that stack slot, and constructing a `std::string` from it faults. On
macOS the slot happened to still contain the literals; on Linux it does not.

Line 544 is exactly that inner loop body, matching the CI trace.

## Fix

Use `std::vector`, which owns its elements for the life of the range. Same data,
same assertions — only the container type changes.

All four loops are converted, not just the one that faulted. They are the identical
pattern, all four execute, so all four are live undefined behaviour in the same
binary; which one faults depends on what happens to be on the stack. Fixing one and
leaving three would not make the suite safe.

The remaining `std::initializer_list` uses in this file are flat
(`initializer_list<std::pair<const char *, const char *>>`) and are unaffected — a
flat list's backing array *is* lifetime-extended by the range-for.

## Verification

Reproduced and fixed under the repository's existing AddressSanitizer
configuration (`-fsanitize=address,undefined`) — same build, same tests, only the
loop headers differing:

| | result |
|---|---|
| current master | `AddressSanitizer: stack-use-after-scope`, **exit 134** |
| with this change | clean, **exit 0**, 35 test cases, 820 assertions |

ASan pins it precisely: `READ of size 8` inside the Catch2 test body, into a frame
slot named `ref.tmp` — the compiler-generated `initializer_list` backing array.

The full unfiltered suite also passes locally.

## Related, and deliberately not included

* #2716 fixes the other CI failure visible in that same run
  (`shp_shapelib_tests.cpp:370`), where 26 `.dbf` test fixtures were dropped by an
  over-broad `.gitignore` glob. **Both are needed for a green run** — this PR lets
  the run finish, #2716 clears the failures it then reaches.
* This file also has six `std::stod(recordGroupValues(...).front())` calls.
  `.front()` on an empty vector is undefined, and `REQUIRE(countRecords(...) == 1)`
  proves the *record* exists but not the group inside it — so a regression dropping
  a group code would take down the whole suite rather than fail one assertion. No
  such vector is empty today, so this fixes no current crash and is left for a
  separate hardening change.
* `build-all.yml` triggers only on push to `master` and `2.2.1`, with no
  `pull_request` trigger, so no PR is gated by the suite. A `pull_request` trigger
  would have caught this before it landed.
