### PR TITLE
Fix three release SIGSEGVs in the dimension actions

### DIFF
--- a/librecad/src/actions/drawing/draw/dimensions/lc_actioncircledimbase.cpp
+++ b/librecad/src/actions/drawing/draw/dimensions/lc_actioncircledimbase.cpp
@@ -128,6 +128,9 @@ void LC_ActionCircleDimBase::onMouseLeftButtonRelease(const int status, const LC
             break;
         }
         case SetPos: {
+            if (m_entity == nullptr) {
+                break;
+            }
             RS_Vector snap = e->snapPoint;
             snap = getSnapAngleAwarePoint(e, m_entity->getCenter(), snap);
             fireCoordinateEvent(snap);

--- a/librecad/src/actions/drawing/draw/dimensions/rs_actiondimangular.cpp
+++ b/librecad/src/actions/drawing/draw/dimensions/rs_actiondimangular.cpp
@@ -337,6 +337,9 @@ int RS_ActionDimAngular::determineQuadrant(const double angle) const {
  */
 bool RS_ActionDimAngular::setData(const RS_Vector &dimPos, const bool calcCenter /*= false*/){
     bool result = false;
+    if (m_line1 == nullptr || m_line2 == nullptr) {
+        return result;
+    }
     if (m_line1->getStartpoint().valid && m_line2->getStartpoint().valid){
 
         if (!m_center.valid || calcCenter){


### PR DESCRIPTION
Three dimension tools segfault in release builds. Six lines fix all three.

Found while investigating #2708 — same class of bug, different tools. Split out so
it can be reviewed and backported on its own.

## `RS_ActionDimAngular`

`setData()` reads `m_line1` and `m_line2` unconditionally:

```cpp
bool RS_ActionDimAngular::setData(const RS_Vector &dimPos, bool calcCenter) {
    bool result = false;
    if (m_line1->getStartpoint().valid && m_line2->getStartpoint().valid) {   // <-- both may be null
```

`doProcessCommand` accepts the `text` command at **any** status, so from a freshly
started tool with both lines still null:

1. type `text` → `setStatus(SetText)`
2. right-click → `onMouseRightButtonRelease` calls `initPrevious()`, which is
   `init(status - 1)` and therefore lands on **`SetPos`**
3. move the mouse → the `SetPos` arm of `onMouseMoveEvent` calls `setData()` → **crash**

No click is needed on step 3, and Escape reaches the same place because
`RS_EventHandler::back()` synthesises a right-button release.

## `LC_ActionCircleDimBase`

`onMouseLeftButtonRelease` reads `m_entity->getCenter()` in its `SetPos` arm. The
*move* handler for that same status was already guarded with
`if (m_entity != nullptr)`; the *release* handler was not. Reached the same way as
above.

That base class is shared by `RS_ActionDimRadial` and `RS_ActionDimDiametric`, so
this single missing check crashes **three** tools.

## Why release-only

Neither site had even a `Q_ASSERT`, so this would fault in any build. What makes it
a shipped-product crash rather than a developer-visible one is that nothing in the
release build catches it: LibreCAD's CMake is configured with no
`CMAKE_BUILD_TYPE`, and Qt6 stamps `QT_NO_DEBUG` for every non-`Debug`
configuration, so the assertion machinery that might have surfaced this during
development is compiled out.

## Scope

Only the two dereferences are guarded. The status machines that allow an entity-less
`SetPos` in the first place — `initPrevious()` decrementing out of a command-line
detour — are a real defect too, but fixing them changes right-click behaviour and
belongs in its own change. These six lines close all three crashes without touching
interaction semantics anywhere.

Builds clean; no test-suite change.
