### PR TITLE
RS_Modification::trim: stop casting a container limit entity to RS_AtomicEntity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2394,6 +2394,7 @@ if (BUILD_TESTS)
         librecad/src/lib/engine/document/entities/tests/rs_text_bidi_tests.cpp
         librecad/src/lib/math/tests/rs_math_tests.cpp
         librecad/src/lib/math/tests/lc_quadratic_tests.cpp
+        librecad/src/lib/modification/tests/rs_modification_trim_tests.cpp
         librecad/src/lib/filters/tests/dwg_buffer_round_trip_tests.cpp
         librecad/src/lib/filters/tests/dwg_entity_encode_round_trip_tests.cpp
         librecad/src/lib/filters/tests/dwg_header_encode_round_trip_tests.cpp

--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -1311,8 +1311,14 @@ LC_TrimResult RS_Modification::trim(const RS_Vector& trimCoord, RS_AtomicEntity*
                                     RS_Entity* limitEntity, const bool both, LC_DocumentModificationBatch& ctx) {
     Q_ASSERT(trimEntity != nullptr && limitEntity != nullptr);
 
-    if (both && !limitEntity->isAtomic()) {
-        RS_DEBUG->print(RS_Debug::D_WARNING, "RS_Modification::trim: limitEntity is not atomic");
+    // A container limit entity can still bound a one-sided trim, but it must never
+    // be cast to RS_AtomicEntity: trimStartpoint(), trimEndpoint() and getTrimPoint()
+    // are declared only there, so dispatching them through a container pointer calls
+    // whatever occupies the same vtable slot.
+    const bool limitIsAtomic = limitEntity->isAtomic();
+    if (both && !limitIsAtomic) {
+        RS_DEBUG->print(RS_Debug::D_WARNING,
+                        "RS_Modification::trim: limitEntity is not atomic, trimming one entity only");
     }
 
     LC_TrimResult result;
@@ -1338,7 +1344,7 @@ LC_TrimResult RS_Modification::trim(const RS_Vector& trimCoord, RS_AtomicEntity*
     }
 
     if (!sol.hasValid()) {
-        if (both) {
+        if (both && limitIsAtomic) {
             return trim(limitCoord, static_cast<RS_AtomicEntity*>(limitEntity), trimCoord, trimEntity, false, ctx);
         }
         return result;
@@ -1372,7 +1378,7 @@ LC_TrimResult RS_Modification::trim(const RS_Vector& trimCoord, RS_AtomicEntity*
     }
 
     // remove limit entity from view:
-    const bool trimBoth = both && !limitEntity->isLocked() && limitEntity->isVisible();
+    const bool trimBoth = both && limitIsAtomic && !limitEntity->isLocked() && limitEntity->isVisible();
     if (trimBoth) {
         trimmed2 = static_cast<RS_AtomicEntity*>(limitEntity->clone());
     }

--- a/librecad/src/lib/modification/tests/rs_modification_trim_tests.cpp
+++ b/librecad/src/lib/modification/tests/rs_modification_trim_tests.cpp
@@ -1,0 +1,79 @@
+/****************************************************************************
+**
+** This file is part of the LibreCAD project, unit tests for RS_Modification
+**
+** Copyright (C) 2026 LibreCAD.org
+** Copyright (C) 2026 Dongxu Li (github.com/dxli)
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**********************************************************************/
+
+// RS_Modification::trim() used to warn that a non-atomic limit entity was
+// unsupported and then use it anyway, casting it to RS_AtomicEntity at three
+// sites. trimStartpoint(), trimEndpoint() and getTrimPoint() are declared only
+// on RS_AtomicEntity, so dispatching them through a container pointer calls
+// whatever occupies the same vtable slot — silent corruption rather than a
+// clean failure.
+//
+// A container limit entity is legitimate for a one-sided trim, so the fix gates
+// the casts on isAtomic() rather than refusing the entity.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "rs_document.h"
+#include "rs_entitycontainer.h"
+#include "rs_line.h"
+#include "rs_modification.h"
+#include "rs_vector.h"
+
+TEST_CASE("RS_Modification::trim does not cast a container limit entity",
+          "[rs_modification][trim][container]") {
+    // A line crossing the container's segment, so an intersection exists and the
+    // function proceeds past the early outs into the casting code.
+    RS_Line toTrim{nullptr, RS_Vector{0.0, 5.0}, RS_Vector{10.0, 5.0}};
+
+    RS_EntityContainer limit{nullptr};
+    limit.addEntity(new RS_Line{&limit, RS_Vector{5.0, 0.0}, RS_Vector{5.0, 10.0}});
+    limit.calculateBorders();
+
+    LC_DocumentModificationBatch ctx;
+
+    // both=true asks trim() to trim the limit entity as well. Before the fix this
+    // reached static_cast<RS_AtomicEntity*>(container) and called atomic-only
+    // virtuals through it.
+    LC_TrimResult result;
+    REQUIRE_NOTHROW(result = RS_Modification::trim(RS_Vector{9.0, 5.0}, &toTrim,
+                                                   RS_Vector{5.0, 9.0}, &limit,
+                                                   true, ctx));
+
+    // The trim of the atomic entity is still allowed; only the container side is
+    // declined, so nothing is produced for it.
+    CHECK(result.trimmed2 == nullptr);
+}
+
+TEST_CASE("RS_Modification::trim still trims against an atomic limit entity",
+          "[rs_modification][trim][container]") {
+    // Guards against the fix being over-broad: an ordinary line limit must still
+    // trim both entities.
+    RS_Line toTrim{nullptr, RS_Vector{0.0, 5.0}, RS_Vector{10.0, 5.0}};
+    RS_Line limit{nullptr, RS_Vector{5.0, 0.0}, RS_Vector{5.0, 10.0}};
+
+    LC_DocumentModificationBatch ctx;
+    const LC_TrimResult result = RS_Modification::trim(RS_Vector{9.0, 5.0}, &toTrim,
+                                                       RS_Vector{5.0, 9.0}, &limit,
+                                                       true, ctx);
+    CHECK(result.trimmed1 != nullptr);
+    CHECK(result.trimmed2 != nullptr);
+}


### PR DESCRIPTION
`RS_Modification::trim()` warns that a non-atomic limit entity is unsupported and
then uses it anyway.

Found while investigating #2708. Split out because it is a different kind of bug
and, unlike the others, its failure mode is silent.

## The bug

```cpp
if (both && !limitEntity->isAtomic()) {
    RS_DEBUG->print(RS_Debug::D_WARNING, "RS_Modification::trim: limitEntity is not atomic");
}
// ...proceeds anyway:
return trim(limitCoord, static_cast<RS_AtomicEntity*>(limitEntity), ...);
```

Three sites cast the limit entity to `RS_AtomicEntity`. But `trimStartpoint()`,
`trimEndpoint()` and `getTrimPoint()` are declared **only** on `RS_AtomicEntity` —
they do not exist on `RS_Entity`. Calling them through a container pointer
dispatches to whatever occupies the same vtable slot on that container. On
`RS_Hatch`, one of those slots holds `removeEntity`.

So this does not fault on a null pointer. It calls a *wrong virtual on a real
object*, which corrupts the document rather than crashing — which is why it has
gone unnoticed.

## Reachable by hovering

* `LC_ActionModifyTrim` catches its limit entity with `RS2::ResolveAllButTextImage`,
  which deliberately returns `RS_Text` and `RS_MText` as whole containers.
* `RS_Hatch::doGetDistanceToPoint` returns `this` for a pattern hatch, so
  `catchEntity` hands the container back.
* The action rejects only `rtti() == RS2::EntityPolyline`. Its `isAtomic()` check
  is present but **commented out** in the source.
* Trim-Two calls `previewTrim()` on **every mouse move**, so no click is needed.

## The fix

A container *is* a legitimate boundary for a one-sided trim — `findIntersection()`
has an explicit branch for it — so refusing the entity outright would regress real
behaviour. Instead the three casts are gated on `isAtomic()`:

* trimming *the limit entity itself* is declined, and the existing warning says so;
* trimming *against* it still works exactly as before.

## Testing

New `rs_modification_trim_tests.cpp`, covering both directions:

* a container limit entity must not produce a trimmed second entity;
* an ordinary line limit must still trim both, so the fix is not over-broad.

The second case matters — without it, gating the casts too aggressively would pass
the first test while quietly breaking Trim-Two.

Builds clean, tests pass. The warning is visible in the test output, confirming the
container path is genuinely exercised.
