### PR TITLE
Null-check the polyline segment resolved from a context entity

### DIFF
--- a/librecad/src/actions/drawing/draw/line/lc_action_draw_line_parallel_through.cpp
+++ b/librecad/src/actions/drawing/draw/line/lc_action_draw_line_parallel_through.cpp
@@ -77,6 +77,11 @@ void LC_ActionDrawLineParallelThrough::doInitWithContextEntity(RS_Entity* contex
         const auto polyline = static_cast<RS_Polyline*>(contextEntity);
         entity = polyline->getNearestEntity(clickPos);
     }
+    // getNearestEntity() returns null when the polyline offers no candidate
+    // segment, or when the nearest one is invisible.
+    if (entity == nullptr) {
+        return;
+    }
     const RS2::EntityType rtti = entity->rtti();
     if (g_supportedEntityTypes.contains(rtti)) {
         m_entity = entity;

--- a/librecad/src/actions/drawing/draw/line/lc_action_draw_line_rel_angle.cpp
+++ b/librecad/src/actions/drawing/draw/line/lc_action_draw_line_rel_angle.cpp
@@ -66,6 +66,11 @@ void LC_ActionDrawLineRelAngle::doInitWithContextEntity(RS_Entity* contextEntity
         const auto polyline = static_cast<RS_Polyline*>(contextEntity);
         entity = polyline->getNearestEntity(clickPos);
     }
+    // getNearestEntity() returns null when the polyline offers no candidate
+    // segment, or when the nearest one is invisible.
+    if (entity == nullptr) {
+        return;
+    }
     const RS2::EntityType rtti = entity->rtti();
     if (g_enTypeList.contains(rtti)) {
         setEntity(entity);

--- a/librecad/src/actions/drawing/draw/line/rs_actiondrawlineorthtan.cpp
+++ b/librecad/src/actions/drawing/draw/line/rs_actiondrawlineorthtan.cpp
@@ -68,6 +68,11 @@ void RS_ActionDrawLineOrthTan::doInitWithContextEntity(RS_Entity* contextEntity,
         const auto polyline = static_cast<RS_Polyline*>(contextEntity);
         entity = polyline->getNearestEntity(clickPos);
     }
+    // getNearestEntity() returns null when the polyline offers no candidate
+    // segment, or when the nearest one is invisible.
+    if (entity == nullptr) {
+        return;
+    }
     if (isLine(entity)) {
         // fixme - support of polyline
         setLine(entity);

--- a/librecad/src/actions/drawing/draw/line/rs_actiondrawlinetangent1.cpp
+++ b/librecad/src/actions/drawing/draw/line/rs_actiondrawlinetangent1.cpp
@@ -57,6 +57,11 @@ void RS_ActionDrawLineTangent1::doInitWithContextEntity(RS_Entity* contextEntity
         const auto polyline = static_cast<RS_Polyline*>(contextEntity);
         entity = polyline->getNearestEntity(clickPos);
     }
+    // getNearestEntity() returns null when the polyline offers no candidate
+    // segment, or when the nearest one is invisible.
+    if (entity == nullptr) {
+        return;
+    }
     const RS2::EntityType rtti = entity->rtti();
     if (g_supportedEntityTypes.contains(rtti)) {
         m_setCircleFirst = true;

--- a/librecad/src/actions/drawing/draw/line/rs_actiondrawlinetangent2.cpp
+++ b/librecad/src/actions/drawing/draw/line/rs_actiondrawlinetangent2.cpp
@@ -73,6 +73,11 @@ void RS_ActionDrawLineTangent2::doInitWithContextEntity(RS_Entity* contextEntity
         const auto polyline = static_cast<RS_Polyline*>(contextEntity);
         entity = polyline->getNearestEntity(clickPos);
     }
+    // getNearestEntity() returns null when the polyline offers no candidate
+    // segment, or when the nearest one is invisible.
+    if (entity == nullptr) {
+        return;
+    }
     const RS2::EntityType rtti = entity->rtti();
     if (g_circleType.contains(rtti)) {
         m_actionData->circle1 = entity;


### PR DESCRIPTION
Five actions dereference a pointer that can legitimately be null.

Found while investigating #2708 — same crash class, reached from the polyline
context menu instead of the parallel tool.

## The bug

`RS_ActionInterface::init()` null-checks the context entity before dispatching, so
every `doInitWithContextEntity()` override is written on the assumption that its
argument is valid. Twelve of them need a *segment* rather than the polyline, and
each hand-copied the same block:

```cpp
auto entity = contextEntity;
if (isPolyline(contextEntity)) {
    entity = static_cast<RS_Polyline*>(contextEntity)->getNearestEntity(clickPos);
}
```

`getNearestEntity()` returns null when the container holds no candidate segment,
and `RS_EntityContainer` also drops a nearest segment that is invisible. So the
copied block silently replaces a pointer the framework guaranteed with one that
can be null — and the code after it still assumes the guarantee holds.

**Five of the twelve then dereference it:**

| Action | Deref |
|---|---|
| `RS_ActionDrawLineTangent1` | `entity->rtti()` |
| `RS_ActionDrawLineTangent2` | `entity->rtti()` |
| `LC_ActionDrawLineRelAngle` | `entity->rtti()` |
| `LC_ActionDrawLineParallelThrough` | `entity->rtti()` |
| `RS_ActionDrawLineOrthTan` | `entity->rtti()` in the branch `isLine()` does not cover |

All five appear on the polyline context menu, so a degenerate polyline reaches
them directly.

The other seven route the result through `isLine()` / `isArc()`, which null-test
internally via `RS_PreviewActionInterface::is()`, and are unaffected.

## Scope

One guard per site. Deduplicating the copied block behind a shared resolver is a
worthwhile follow-up — twelve copies of the same five lines is how this happened —
but it touches every action implementing the callback and adds API surface, so it
should be judged on its own merits rather than inherited from a crash fix.

Builds clean.
