### PR TITLE
Fix SIGABRT from NaN quartic coefficients at a hyperbola vertex (#2722)

### DIFF
--- a/librecad/src/lib/engine/document/entities/lc_hyperbola.cpp
+++ b/librecad/src/lib/engine/document/entities/lc_hyperbola.cpp
@@ -1301,22 +1301,31 @@ RS_Vector LC_Hyperbola::doGetNearestPointOnEntity(const RS_Vector &coord,
   double dx = cx + A - px;
   double dy = cy + C - py;
 
-  double p = 4.0 * (A * dx + C * dy) / (B * dx + D * dy);
-  double q = (dx * dx + dy * dy - aa * aa + bb * bb) / (B * dx + D * dy) * 2.0 -
-             p * p / 2.0 - 3.0;
-  double r = -p * (q + 5.0);
-  double s = -(dx * dx + dy * dy - aa * aa - bb * bb) / (B * dx + D * dy) - q;
+  // Every coefficient below divides by this. It is zero when coord lies on a
+  // vertex: the vertex is at (cx + A, cy + C), so dx and dy are both zero
+  // there, and the divisions yield NaN. The loop below already declined to use
+  // any root in that case, but only after the solver had run - and a NaN
+  // coefficient reaches std::polar() with a NaN modulus inside the complex
+  // cubic step, which aborts when the standard library is built with
+  // _GLIBCXX_ASSERTIONS. Leave the roots empty instead; the endpoint and
+  // initial-guess candidates already computed above remain the answer.
+  const double denom = B * dx + D * dy;
 
-  std::vector<double> ce = {s, r, q, p,
-                            1.0}; // t^4 + p t^3 + q t^2 + r t + s = 0
+  std::vector<double> roots;
+  if (std::abs(denom) >= RS_TOLERANCE) {
+    double p = 4.0 * (A * dx + C * dy) / denom;
+    double q = (dx * dx + dy * dy - aa * aa + bb * bb) / denom * 2.0 -
+               p * p / 2.0 - 3.0;
+    double r = -p * (q + 5.0);
+    double s = -(dx * dx + dy * dy - aa * aa - bb * bb) / denom - q;
 
-  std::vector<double> roots = RS_Math::quarticSolverFull(ce);
+    std::vector<double> ce = {s, r, q, p,
+                              1.0}; // t^4 + p t^3 + q t^2 + r t + s = 0
+    roots = RS_Math::quarticSolverFull(ce);
+  }
 
   // Evaluate all valid real roots
   for (double t : roots) {
-    if (std::abs(B * dx + D * dy) < RS_TOLERANCE)
-      continue; // degenerate case skipped
-
     double phi = std::atanh(t);
     if (std::isnan(phi) || std::isinf(phi))
       continue;

--- a/librecad/src/lib/engine/document/entities/tests/lc_hyperbola_tests.cpp
+++ b/librecad/src/lib/engine/document/entities/tests/lc_hyperbola_tests.cpp
@@ -973,6 +973,41 @@ TEST_CASE("LC_Hyperbola: getParamFromPoint round-trips on both branches (A17)",
   }
 }
 
+TEST_CASE("LC_Hyperbola: nearest point at a vertex does not produce NaN (#2722)",
+          "[hyperbola][nearest][regression]") {
+  // At a vertex the coordinate coincides with (cx + A, cy + C), so the quartic
+  // denominator (B*dx + D*dy) is exactly zero. The coefficients were computed
+  // before that was checked, so all four came out NaN and reached
+  // RS_Math::quarticSolverFull. Inside the complex branch of the cubic solver
+  // that becomes std::pow(complex, 1./3), which libstdc++ evaluates as
+  // std::polar(abs(x), ...) - and a NaN modulus trips the library's own
+  // assertion, aborting the process where the standard library is built with
+  // _GLIBCXX_ASSERTIONS (Arch Linux ships that by default).
+  //
+  // libc++ has no such assertion, so this asserts the observable consequence
+  // rather than the abort: the vertex must come back exactly, finite, and with
+  // a finite distance.
+  auto hb = makeCanonicalHyperbola(2.0, 1.0, -1.0, 1.0);
+  const RS_Vector vertex = hb.getPoint(0.0, false);
+  REQUIRE(vertex.valid);
+
+  double dist = -1.0;
+  const RS_Vector nearest = hb.getNearestPointOnEntity(vertex, true, &dist);
+
+  REQUIRE(nearest.valid);
+  CHECK_FALSE(std::isnan(nearest.x));
+  CHECK_FALSE(std::isnan(nearest.y));
+  CHECK(nearest.x == Approx(vertex.x).margin(1e-9));
+  CHECK(nearest.y == Approx(vertex.y).margin(1e-9));
+  CHECK_FALSE(std::isnan(dist));
+  CHECK(dist == Approx(0.0).margin(1e-9));
+
+  // The parameter recovered from the vertex must also be usable.
+  const double phi = hb.getParamFromPoint(nearest, false);
+  CHECK_FALSE(std::isnan(phi));
+  CHECK(phi == Approx(0.0).margin(1e-6));
+}
+
 TEST_CASE("LC_Hyperbola: moveStartpoint is trim, not drag (A6)",
           "[hyperbola][trim][regression]") {
   auto hb = makeCanonicalHyperbola(2.0, 1.0, -1.0, 1.0);

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -48,6 +48,23 @@
 namespace {
     constexpr double g_twoPi = M_PI * 2; //2*PI
 
+    // Polynomial solvers reject non-finite coefficients rather than carrying
+    // them into the algebra. A NaN or an infinity has no roots to report, and
+    // in the complex branch of cubicSolver it reaches
+    // std::pow(std::complex, 1./3) - which libstdc++ evaluates as
+    // std::polar(std::abs(x), ...). std::abs of a non-finite complex is not
+    // finite, and std::polar asserts a non-negative modulus, so the process
+    // aborts where the standard library is built with _GLIBCXX_ASSERTIONS
+    // instead of merely producing a non-finite root. See issue #2722.
+    bool isFiniteCoefficients(const std::vector<double>& ce) {
+        for (double c : ce) {
+            if (!std::isfinite(c)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     const QRegularExpression REGEXP_UNIT(R"((?P<sign>^-?))" R"((?:(?:(?:(?P<degrees>\d+\.?\d*)(?:degree[s]?|deg|[Dd]|°)))" // DMS
         R"((?:(?P<minutes>\d+\.?\d*)(?:minute[s]?|min|[Mm]|'))?)" R"((?:(?P<seconds>\d+\.?\d*)(?:second[s]?|sec|[Ss]|"))?$)|)"
         R"((?:(?:(?P<meters>\d+\.?\d*)(?:meter[s]?|m(?![m])))?)" // Metric
@@ -526,6 +543,9 @@ std::vector<double> RS_Math::quadraticSolver(const std::vector<double>& ce)
     if (ce.size() != 2) {
         return ans;
     }
+    if (!isFiniteCoefficients(ce)) {
+        return ans;
+    }
     using LDouble = long double;
     const LDouble b = -0.5L * ce[0];
     const LDouble c = ce[1];
@@ -589,13 +609,7 @@ std::vector<double> RS_Math::cubicSolver(const std::vector<double>& ce)
     if (ce.size() != 3) {
         return {};
     }
-    // A non-finite coefficient has no roots to report, and carrying one into
-    // the complex branch below reaches std::pow(std::complex, 1./3) - which
-    // libstdc++ evaluates as std::polar(std::abs(x), ...). std::abs of a NaN
-    // complex is NaN, and std::polar asserts its modulus is non-negative, so a
-    // NaN aborts the process where the standard library is built with
-    // _GLIBCXX_ASSERTIONS rather than merely producing a NaN root.
-    if (!std::isfinite(ce[0]) || !std::isfinite(ce[1]) || !std::isfinite(ce[2])) {
+    if (!isFiniteCoefficients(ce)) {
         return {};
     }
 
@@ -697,6 +711,9 @@ std::vector<double> RS_Math::quarticSolver(const std::vector<double>& ce) {
     std::vector<double> ans(0, 0.);
     if (ce.size() != 4) {
         LC_ERR << "expected array size=4, got " << ce.size();
+        return ans;
+    }
+    if (!isFiniteCoefficients(ce)) {
         return ans;
     }
     //LC_LOG<<"x^4+("<<ce[0]<<")*x^3+("<<ce[1]<<")*x^2+("<<ce[2]<<")*x+("<<ce[3]<<")==0";
@@ -853,13 +870,8 @@ std::vector<double> RS_Math::quarticSolverFull(const std::vector<double>& ce) {
     if (ce.size() != 5) {
         return roots;
     }
-    // Reject non-finite input here too, so a bad coefficient is reported as
-    // "no roots" instead of propagating through the depressed-quartic algebra
-    // and the cubic resolvent (see RS_Math::cubicSolver).
-    for (double c : ce) {
-        if (!std::isfinite(c)) {
-            return roots;
-        }
+    if (!isFiniteCoefficients(ce)) {
+        return roots;
     }
     std::vector<double> ce2(4, 0.);
 

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -589,6 +589,15 @@ std::vector<double> RS_Math::cubicSolver(const std::vector<double>& ce)
     if (ce.size() != 3) {
         return {};
     }
+    // A non-finite coefficient has no roots to report, and carrying one into
+    // the complex branch below reaches std::pow(std::complex, 1./3) - which
+    // libstdc++ evaluates as std::polar(std::abs(x), ...). std::abs of a NaN
+    // complex is NaN, and std::polar asserts its modulus is non-negative, so a
+    // NaN aborts the process where the standard library is built with
+    // _GLIBCXX_ASSERTIONS rather than merely producing a NaN root.
+    if (!std::isfinite(ce[0]) || !std::isfinite(ce[1]) || !std::isfinite(ce[2])) {
+        return {};
+    }
 
     // depressed cubic, Tschirnhaus transformation, x= t - b/(3a)
     // t^3 + p t +q =0
@@ -843,6 +852,14 @@ std::vector<double> RS_Math::quarticSolverFull(const std::vector<double>& ce) {
     std::vector<double> roots(0, 0.);
     if (ce.size() != 5) {
         return roots;
+    }
+    // Reject non-finite input here too, so a bad coefficient is reported as
+    // "no roots" instead of propagating through the depressed-quartic algebra
+    // and the cubic resolvent (see RS_Math::cubicSolver).
+    for (double c : ce) {
+        if (!std::isfinite(c)) {
+            return roots;
+        }
     }
     std::vector<double> ce2(4, 0.);
 

--- a/librecad/src/lib/math/tests/rs_math_tests.cpp
+++ b/librecad/src/lib/math/tests/rs_math_tests.cpp
@@ -198,6 +198,22 @@ TEST_CASE("RS_Math solvers reject non-finite coefficients (#2722)",
     SECTION("quarticSolverFull with a single NaN coefficient") {
         CHECK(RS_Math::quarticSolverFull({1.0, 2.0, nan, 3.0, 1.0}).empty());
     }
+    SECTION("quarticSolverFull with an infinite coefficient") {
+        CHECK(RS_Math::quarticSolverFull({inf, 2.0, 3.0, 4.0, 1.0}).empty());
+        CHECK(RS_Math::quarticSolverFull({1.0, 2.0, -inf, 4.0, 1.0}).empty());
+    }
+    SECTION("quadraticSolver rejects non-finite coefficients") {
+        CHECK(RS_Math::quadraticSolver({nan, 1.0}).empty());
+        CHECK(RS_Math::quadraticSolver({1.0, nan}).empty());
+        CHECK(RS_Math::quadraticSolver({inf, 1.0}).empty());
+        CHECK(RS_Math::quadraticSolver({1.0, -inf}).empty());
+    }
+    SECTION("quarticSolver rejects non-finite coefficients") {
+        CHECK(RS_Math::quarticSolver({nan, 1.0, 2.0, 3.0}).empty());
+        CHECK(RS_Math::quarticSolver({1.0, 2.0, 3.0, nan}).empty());
+        CHECK(RS_Math::quarticSolver({inf, 1.0, 2.0, 3.0}).empty());
+        CHECK(RS_Math::quarticSolver({1.0, -inf, 2.0, 3.0}).empty());
+    }
 
     // Finite input must still solve: without these, returning empty
     // unconditionally would pass every case above while disabling the solvers.
@@ -210,6 +226,15 @@ TEST_CASE("RS_Math solvers reject non-finite coefficients (#2722)",
         CHECK(sorted[0] == Approx(1.0).margin(1e-9));
         CHECK(sorted[1] == Approx(2.0).margin(1e-9));
         CHECK(sorted[2] == Approx(3.0).margin(1e-9));
+    }
+    SECTION("finite quadratic still solves") {
+        // (x-2)(x-3) = x^2 - 5x + 6
+        const std::vector<double> roots = RS_Math::quadraticSolver({-5.0, 6.0});
+        REQUIRE(roots.size() == 2);
+        std::vector<double> sorted = roots;
+        std::sort(sorted.begin(), sorted.end());
+        CHECK(sorted[0] == Approx(2.0).margin(1e-9));
+        CHECK(sorted[1] == Approx(3.0).margin(1e-9));
     }
     SECTION("finite quartic still solves") {
         // (x-1)(x-2)(x-3)(x-4) = x^4 - 10x^3 + 35x^2 - 50x + 24

--- a/librecad/src/lib/math/tests/rs_math_tests.cpp
+++ b/librecad/src/lib/math/tests/rs_math_tests.cpp
@@ -24,12 +24,20 @@
 ** This copyright notice MUST APPEAR in all copies of the script!
 **
 **********************************************************************/
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <vector>
+
 #include <QString>
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include "rs_debug.h"
 #include "rs_math.h"
+
+using Catch::Approx;
 
 namespace {
 constexpr double EPS = 1e-6;
@@ -152,4 +160,64 @@ TEST_CASE("RS_Math::derationalize tests", "[rs_math]") {
         REQUIRE_THAT(result.toDouble(), Catch::Matchers::WithinAbs(2.25, 1e-6));
     }
 */
+}
+
+// Regression for issue #2722.
+//
+// The hyperbola nearest-point search divides every quartic coefficient by a
+// denominator that is exactly zero at a vertex, so it handed the solvers a set
+// of NaN coefficients. Inside the complex branch of the cubic solver that
+// becomes std::pow(std::complex, 1./3), which libstdc++ evaluates as
+// std::polar(std::abs(x), ...). std::abs of a NaN complex is NaN, and
+// std::polar asserts its modulus is non-negative - so the process aborted
+// outright where the standard library is built with _GLIBCXX_ASSERTIONS,
+// as on Arch Linux. libc++ has no such assertion, which is why this was
+// invisible on macOS.
+//
+// The solvers now reject non-finite coefficients up front. Asserting that here
+// rather than in the hyperbola tests keeps the check portable: it fails on any
+// standard library, not only one that aborts.
+TEST_CASE("RS_Math solvers reject non-finite coefficients (#2722)",
+          "[rs_math][solver][regression]") {
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    const double inf = std::numeric_limits<double>::infinity();
+
+    SECTION("cubicSolver with all-NaN coefficients") {
+        CHECK(RS_Math::cubicSolver({nan, nan, nan}).empty());
+    }
+    SECTION("cubicSolver with a single NaN coefficient") {
+        CHECK(RS_Math::cubicSolver({1.0, nan, -2.0}).empty());
+    }
+    SECTION("cubicSolver with an infinite coefficient") {
+        CHECK(RS_Math::cubicSolver({inf, 1.0, 2.0}).empty());
+        CHECK(RS_Math::cubicSolver({1.0, -inf, 2.0}).empty());
+    }
+    SECTION("quarticSolverFull with all-NaN coefficients") {
+        CHECK(RS_Math::quarticSolverFull({nan, nan, nan, nan, 1.0}).empty());
+    }
+    SECTION("quarticSolverFull with a single NaN coefficient") {
+        CHECK(RS_Math::quarticSolverFull({1.0, 2.0, nan, 3.0, 1.0}).empty());
+    }
+
+    // Finite input must still solve: without these, returning empty
+    // unconditionally would pass every case above while disabling the solvers.
+    SECTION("finite cubic still solves") {
+        // (x-1)(x-2)(x-3) = x^3 - 6x^2 + 11x - 6
+        const std::vector<double> roots = RS_Math::cubicSolver({-6.0, 11.0, -6.0});
+        REQUIRE(roots.size() == 3);
+        std::vector<double> sorted = roots;
+        std::sort(sorted.begin(), sorted.end());
+        CHECK(sorted[0] == Approx(1.0).margin(1e-9));
+        CHECK(sorted[1] == Approx(2.0).margin(1e-9));
+        CHECK(sorted[2] == Approx(3.0).margin(1e-9));
+    }
+    SECTION("finite quartic still solves") {
+        // (x-1)(x-2)(x-3)(x-4) = x^4 - 10x^3 + 35x^2 - 50x + 24
+        const std::vector<double> roots =
+            RS_Math::quarticSolverFull({24.0, -50.0, 35.0, -10.0, 1.0});
+        CHECK_FALSE(roots.empty());
+        for (double r : roots) {
+            CHECK(std::isfinite(r));
+        }
+    }
 }


### PR DESCRIPTION
Fixes #2722

## What happens

Moving a hyperbola start/endpoint onto a vertex hands the polynomial solvers a
set of NaN coefficients. Under `-D_GLIBCXX_ASSERTIONS` — which Arch Linux
enables by default — that aborts the process:

```
/usr/include/c++/16.1.1/complex:1041: std::polar(...): Assertion '__rho >= _Tp(0)' failed.
```

## Why

`LC_Hyperbola::doGetNearestPointOnEntity` divides all four quartic coefficients
by `(B*dx + D*dy)`:

```cpp
double dx = cx + A - px;
double dy = cy + C - py;
double p  = 4.0 * (A * dx + C * dy) / (B * dx + D * dy);
```

A vertex lies at exactly `(cx + A, cy + C)`, so when `coord` is the vertex both
`dx` and `dy` are zero, the denominator is zero, and `p`, `q`, `r`, `s` all
evaluate to NaN.

Those flow into `RS_Math::quarticSolverFull` → `RS_Math::cubicSolver`, whose
complex branch computes `std::pow(std::complex, 1./3)`. libstdc++ implements
that as `std::polar(std::abs(x), std::arg(x) * y)`; `std::abs` of a NaN complex
is NaN, and `std::polar` asserts its modulus is non-negative. `NaN >= 0` is
false, so the assertion fires.

The reporter's two failing tests reach this through `moveStartpoint` /
`moveEndpoint`, both of which call `getNearestPointOnEntity` first.

## The fix

**The guard already existed — in the wrong place.** The root loop began:

```cpp
for (double t : roots) {
    if (std::abs(B * dx + D * dy) < RS_TOLERANCE)
        continue;   // degenerate case skipped
```

That condition does not depend on `t`, so in the degenerate case it skipped
*every* root and the loop did nothing — but only after the solver had already
run on NaN. Hoisting it to guard the coefficient computation leaves `roots`
empty, which is exactly what the loop produced before, and the endpoint and
initial-guess candidates computed earlier remain the answer. The post-loop
`onEntity` fallback still runs.

**The solvers are hardened too.** They validated only `ce.size()`, never that
the coefficients were finite. Aborting the caller is not a reasonable response to
a bad coefficient, so all four polynomial solvers — `quadraticSolver`,
`cubicSolver`, `quarticSolver` and `quarticSolverFull` — now report "no roots"
for non-finite input instead of carrying it into the algebra. `std::isfinite` is
false for infinity as much as for NaN, so a coefficient that overflowed is
refused on the same footing as one from a zero denominator.

Note `quarticSolver` is a separate implementation rather than a wrapper around
`quarticSolverFull`, so it needed its own check. The four checks share one
`isFiniteCoefficients()` helper.

`linearSolver` and `simultaneousQuadraticSolver` are deliberately untouched: they
take a matrix and a conic pair rather than polynomial coefficients, and neither
reaches the complex branch that aborts.

This also covers the other callers of these solvers — `RS_Ellipse` and
`LC_SplinePoints`.

## Testing

The regression test asserts the **solver contract**, not the abort. That matters:
libc++ has no such assertion, so on macOS the NaN propagated silently and the two
tests in the issue passed while printing NaN coefficients — a test written
against the crash would only fail on the platforms that already crash.

Verified in both directions on macOS/libc++:

| | `[rs_math][solver]` |
|---|---|
| without the guards | **5 assertions fail**, exit 42 |
| with the guards | pass, 28 assertions |

Removing only the two later-added guards (`quadraticSolver`, `quarticSolver`)
fails four assertions, so those earn their place too.

The positive cases earn their place: the solvers are also checked against
`(x-2)(x-3)`, `(x-1)(x-2)(x-3)` and `(x-1)(x-2)(x-3)(x-4)`, so a guard mutated
into an unconditional `return {}` would fail rather than silently disabling
them.

There is also a hyperbola-level test pinning the vertex case — nearest point
exact, distance zero, recovered parameter finite. It is a behavioural assertion
rather than a crash gate, since on libc++ it passes either way.

Full suite: 735 test cases, 12982 assertions, no failures. Before the fix the
two tests named in the issue printed
`1*y^4+(nan)*y^3+(nan*y^2+(nan)*y+(nan)==0`; they no longer do.

I do not have an Arch/glibc++ machine to confirm the abort is gone directly, so
confirmation from @mkkDr2010 on the original environment would be welcome.
