### PR TITLE
Name the handle when a duplicate aborts a DWG write

### DIFF
--- a/libraries/libdxfrw/src/intern/dwgwriter15.cpp
+++ b/libraries/libdxfrw/src/intern/dwgwriter15.cpp
@@ -21,6 +21,7 @@
 #include "../drw_base.h"
 #include "../drw_entities.h"
 #include "../drw_objects.h"
+#include "drw_dbg.h"
 #include "dwgbuffer.h"
 #include "dwgbufferw.h"
 #include "dwgutil.h"
@@ -2108,8 +2109,18 @@ bool dwgWriter15::writeDwgHandles() {
     // order, but the sort defends against future out-of-order emit.
     std::sort(m_objectMap.begin(), m_objectMap.end());
     for (size_t i = 1; i < m_objectMap.size(); ++i) {
-        if (m_objectMap[i - 1].first == m_objectMap[i].first)
+        if (m_objectMap[i - 1].first == m_objectMap[i].first) {
+            // Two objects were emitted with the same handle, so the object map
+            // is ambiguous and the file would be unreadable: fail the write.
+            // Naming the handle matters because this is otherwise silent - the
+            // caller sees only BAD_OPEN and a zero-byte file, with nothing to
+            // say which object collided. It is the caller's job to remap or
+            // withhold the colliding object before writing.
+            DRW_DBG("dwgWriter15::writeDwgHandles: duplicate handle ");
+            DRW_DBGH(m_objectMap[i].first);
+            DRW_DBG("\n");
             return false;
+        }
     }
 
     // Page-emit walk.  Each page is bounded at ≤2030 bytes of (size


### PR DESCRIPTION
A diagnostic only — no behaviour change.

`dwgWriter15::writeDwgHandles()` rejects a duplicate object-map handle and
returns `false`. That surfaces to the caller as `DRW::BAD_OPEN` and a zero-byte
file, and nothing anywhere records *which* handle collided. The save fails, the
file is empty, and the log says nothing.

That silence is most of what made #2718 slow to diagnose: a preserved object
from an AC1021 source reusing one of the writer's fixed structural handles
produces exactly this, and locating it meant instrumenting the writer by hand to
print the handle that is already sitting in the comparison.

This adds the `DRW_DBG` line, so the handle is named at
`RS_Debug::D_DEBUGGING`. The return value, the control flow, and the decision to
fail the write are all unchanged — a duplicate handle really does make the file
unreadable, so failing is correct; it just should not be mute about it.

Split out of #2718, where it was cut for being non-functional.
