### PR TITLE
Fix DXF DIMSTYLE import taking the first style's values (#2723)

### DIFF
--- a/libraries/libdxfrw/src/libdxfrw.cpp
+++ b/libraries/libdxfrw/src/libdxfrw.cpp
@@ -4489,7 +4489,11 @@ bool dxfRW::processDimStyle() {
             DRW_DBG(sectionstr); DRW_DBG("\n");
             if (sectionstr == "DIMSTYLE") {
                 reading = true;
-                dimSty.reset();
+                // Start from a pristine record. reset() leaves the $DIM
+                // override map and the optional string codes populated, and
+                // syncStructToVars() keeps whatever the map already holds, so
+                // reusing it imports every style with the first one's values.
+                dimSty = DRW_Dimstyle{};
             } else if (sectionstr == "ENDTAB") {
                 return true;  //found ENDTAB terminate
             }

--- a/librecad/src/lib/filters/tests/dxf_object_tests.cpp
+++ b/librecad/src/lib/filters/tests/dxf_object_tests.cpp
@@ -3446,3 +3446,63 @@ TEST_CASE("DXF LWPolyline conversion retains raw elevation metadata",
   CHECK(converted.m_captured.vertlist[0]->bulge == 0.5);
   CHECK(converted.m_captured.vertlist[1]->bulge == -0.5);
 }
+
+namespace {
+struct CapturedDimStyle {
+  std::string m_name;
+  double m_dimasz = -1.0;
+  double m_dimtxt = -1.0;
+  std::string m_dimblk;
+};
+
+class DimStyleCapture : public StubInterface {
+public:
+  std::vector<CapturedDimStyle> m_captured;
+  void addDimStyle(const DRW_Dimstyle &d) override {
+    CapturedDimStyle style;
+    style.m_name = d.name;
+    // Read through get() exactly like RS_FilterDXFRW::createDimStyle does.
+    if (const DRW_Variant *var = d.get("$DIMASZ")) style.m_dimasz = var->d_val();
+    if (const DRW_Variant *var = d.get("$DIMTXT")) style.m_dimtxt = var->d_val();
+    if (const DRW_Variant *var = d.get("$DIMBLK")) style.m_dimblk = var->c_str();
+    m_captured.push_back(style);
+  }
+};
+} // namespace
+
+// Issue #2723: processDimStyle reuses one DRW_Dimstyle for every record, so each
+// record has to start from a pristine one. reset() leaves the $DIM override map
+// and the optional string codes populated, and syncStructToVars keeps whatever
+// the map already holds, so every style was imported with the first one's values.
+TEST_CASE("DXF DIMSTYLE records keep their own values (issue #2723)",
+          "[dxf][dimstyle]") {
+  DimStyleCapture cap;
+  const char *dxf =
+      "0\nSECTION\n2\nTABLES\n"
+      "0\nTABLE\n2\nDIMSTYLE\n5\n5F\n100\nAcDbSymbolTable\n70\n3\n"
+      "0\nDIMSTYLE\n105\n27\n100\nAcDbDimStyleTableRecord\n2\nStandard\n70\n0\n"
+      "5\nMYARROW\n41\n2.5\n140\n2.5\n"
+      "0\nDIMSTYLE\n105\n28\n100\nAcDbDimStyleTableRecord\n2\nARCH_MM\n70\n0\n"
+      "41\n100.0\n140\n80.0\n"
+      "0\nDIMSTYLE\n105\n29\n100\nAcDbDimStyleTableRecord\n2\nEZ_M_100\n70\n0\n"
+      "41\n0.25\n140\n0.25\n"
+      "0\nENDTAB\n0\nENDSEC\n0\nEOF\n";
+  readDxf(dxf, cap, "lc_dimstyle_multi_read.dxf");
+
+  REQUIRE(cap.m_captured.size() == 3);
+  CHECK(cap.m_captured[0].m_name == "Standard");
+  CHECK(cap.m_captured[0].m_dimasz == 2.5);
+  CHECK(cap.m_captured[0].m_dimtxt == 2.5);
+  CHECK(cap.m_captured[0].m_dimblk == "MYARROW");
+
+  // These came back as Standard's 2.5/2.5/MYARROW before the fix.
+  CHECK(cap.m_captured[1].m_name == "ARCH_MM");
+  CHECK(cap.m_captured[1].m_dimasz == 100.0);
+  CHECK(cap.m_captured[1].m_dimtxt == 80.0);
+  CHECK(cap.m_captured[1].m_dimblk.empty());
+
+  CHECK(cap.m_captured[2].m_name == "EZ_M_100");
+  CHECK(cap.m_captured[2].m_dimasz == 0.25);
+  CHECK(cap.m_captured[2].m_dimtxt == 0.25);
+  CHECK(cap.m_captured[2].m_dimblk.empty());
+}


### PR DESCRIPTION
Fixes #2723.

## Cause

`dxfRW::processDimStyle()` reuses one `DRW_Dimstyle` for every record in the DIMSTYLE table, calling `reset()` between records. `reset()` clears the numeric struct fields but leaves the `$DIM*` override map populated, and `syncStructToVars()` deliberately does not clobber entries already present in that map:

```cpp
auto addDouble = [&](const char* key, int code, double value) {
    if (!get(key)) add(key, code, value);
};
```

`RS_FilterDXFRW::createDimStyle()` reads that map, not the struct fields, so the first record's values were handed to every later style.

On the reporter's sample all thirteen styles resolve to `Standard`'s 2.5/2.5:

```
DIMSTYLE                    $DIMASZ    $DIMTXT
Standard                        2.5        2.5
EZDXF                           2.5        2.5     <- file says 0.175 / 0.25
...
ARCH_MM_TEST                    2.5        2.5     <- file says 100 / 80
```

That matches the report exactly, including the values being wrong for the rendered DIMENSION entity and not only in the dialog — `createDimStyle()` feeds the style that is actually resolved for the entity.

## Fix

One line: start each record from a freshly constructed record rather than a partially-reset one.

```diff
             if (sectionstr == "DIMSTYLE") {
                 reading = true;
-                dimSty.reset();
+                dimSty = DRW_Dimstyle();
```

`reset()` is left alone. It has exactly one other caller — `DRW_Dimstyle`'s own default constructor, where the map and strings are already empty — so nothing else is affected.

Re-constructing is also strictly more complete than patching `reset()` would be. Besides the override map it clears the optional string fields (`dimpost`, `dimapost`, `dimblk`, `dimblk1`, `dimblk2`, `dimldrblk`), which leaked across records the same way — a style that omits an arrowhead block name inherited the previous style's — and the base `name`/`handle`, which `DRW_TableEntry::reset()` does not touch either. `name` is read directly by `createDimStyle()`.

After the fix, on the same sample:

```
DIMSTYLE                    $DIMASZ    $DIMTXT
Standard                        2.5        2.5
EZDXF                         0.175       0.25
EZ_M_100_H25_CM                0.25       0.25
...
ARCH_MM_TEST                    100         80
```

## Tests

One regression case appended to `dxf_object_tests.cpp`, which already hosts the DIMSTYLE table-record coverage and already provides the `DRW_Interface` stub and `readDxf()` helper. A three-record table asserts each style keeps its own `$DIMASZ`/`$DIMTXT` and does not inherit the first record's `$DIMBLK`, read through `get()` exactly as `createDimStyle()` does.

Six assertions in that case fail on master and pass with the fix. `dxf_object_tests.cpp` as a whole is green (729 assertions / 62 cases), as is the wider libdxfrw test set (6484 assertions / 286 cases across the Qt-free filter tests).

## Notes

- The reporter also mentions the imported style appearing grayed out in the property editor's style list. I could not tie that to this defect: a flat DXF style name has no type suffix, so `LC_DimStyle::isBaseStyle()` is true and the entry is added as a normal root item. Worth rechecking now that the values import correctly; if it persists it is a separate UI issue.
- The same incomplete-`reset()` pattern exists in sibling table readers — `DRW_Vport::reset()` leaves `viewTarget`/`lowerLeft`/`snapBase` stale, and `DRW_TableEntry::reset()` never clears `handle`/`parentHandle`/`name` for any of them. Those only bite when a later record omits an optional group code, which no file in the local 188-sample DXF corpus does, so they are latent rather than active. Left out of this PR deliberately; happy to open a separate issue.
