### PR TITLE
Fix Break/Divide leaving degenerate entities behind (#2700)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2395,6 +2395,7 @@ if (BUILD_TESTS)
         librecad/src/lib/math/tests/rs_math_tests.cpp
         librecad/src/lib/math/tests/lc_quadratic_tests.cpp
         librecad/src/lib/creation/tests/rs_creation_null_entity_tests.cpp
+        librecad/src/lib/modification/tests/lc_division_tests.cpp
         librecad/src/lib/modification/tests/rs_modification_trim_tests.cpp
         librecad/src/lib/filters/tests/dwg_buffer_round_trip_tests.cpp
         librecad/src/lib/filters/tests/dwg_entity_encode_round_trip_tests.cpp

--- a/librecad/src/actions/drawing/modify/lc_action_modify_break_divide.cpp
+++ b/librecad/src/actions/drawing/modify/lc_action_modify_break_divide.cpp
@@ -121,6 +121,7 @@ void LC_ActionModifyBreakDivide::doOnLeftMouseButtonRelease(const LC_MouseEvent*
 
 bool LC_ActionModifyBreakDivide::doCheckMayTrigger(){
     bool result = false;
+    bool entireEntityRemoved = false;
     if (m_triggerData != nullptr){
         RS_Entity* en = m_triggerData->entity;
         RS_Vector snap = m_triggerData->snapPoint;
@@ -130,24 +131,24 @@ bool LC_ActionModifyBreakDivide::doCheckMayTrigger(){
             switch (rtti) {
                 case RS2::EntityLine: {
                     const auto *line = dynamic_cast<RS_Line *>(en);
-                    createEntitiesForLine(line, snap, m_triggerData->entitiesToCreate, false);
+                    entireEntityRemoved = createEntitiesForLine(line, snap, m_triggerData->entitiesToCreate, false);
                     break;
                 }
                 case RS2::EntityCircle: {
                     const auto *circle = dynamic_cast<RS_Circle *>(en);
-                    createEntitiesForCircle(circle, snap, m_triggerData->entitiesToCreate, false);
+                    entireEntityRemoved = createEntitiesForCircle(circle, snap, m_triggerData->entitiesToCreate, false);
                     break;
                 }
                 case RS2::EntityArc: {
                     auto *arc = dynamic_cast<RS_Arc *>(en);
-                    createEntitiesForArc(arc, snap, m_triggerData->entitiesToCreate, false);
+                    entireEntityRemoved = createEntitiesForArc(arc, snap, m_triggerData->entitiesToCreate, false);
                     break;
                 }
                 default:
                     break;
             }
         }
-        if (m_triggerData->entitiesToCreate.isEmpty()){
+        if (m_triggerData->entitiesToCreate.isEmpty() && !entireEntityRemoved){
             commandMessage(tr("Invalid entity selected - no segments between intersections to break/divide."));
         }
         else {
@@ -188,7 +189,8 @@ void LC_ActionModifyBreakDivide::doFinish(){
  * @param list list to which entities should be added
  * @param preview true if entities for preview
  */
-void LC_ActionModifyBreakDivide::createEntitiesForLine(const RS_Line *line, const RS_Vector &snap, QList<RS_Entity*> &list, const bool preview) const {
+bool LC_ActionModifyBreakDivide::createEntitiesForLine(const RS_Line *line, const RS_Vector &snap, QList<RS_Entity*> &list, const bool preview) const {
+    bool entireEntityRemoved = false;
     // check whether selection entity may be expanded
     if (checkMayExpandEntity(line, "")){
         // determine snap point projection on line
@@ -222,29 +224,34 @@ void LC_ActionModifyBreakDivide::createEntitiesForLine(const RS_Line *line, cons
                     }
                 }
 
+                const int segmentDisposition = data->segmentDisposition;
+                // the selected segment is the whole entity, so it has no edges to divide it at
+                // and nothing remains of it besides the selected segment itself
+                const bool entireEntity = segmentDisposition == LC_Division::SegmentDisposition::SEGMENT_ENTIRE;
+                entireEntityRemoved = !preview && entireEntity && createNonSnapSegments;
+
                 // attributes of original entity
                 const RS_Pen pen = line->getPen(false);
                 RS_Layer* layer = line->getLayer(true);
 
                 // creating snap segment (where snap was performed)
-                if (createSnapSegment){
+                if (createSnapSegment && !entireEntity){
                     createLineEntity(preview, data->snapSegmentStart, data->snapSegmentEnd, pen, layer, list);
                 }
-                const int segmentDisposition = data->segmentDisposition;
 
                 // in preview mode provide visual indication of division/break points
                 if (preview){
                     // check that start of segment is not line endpoint
-                    if (segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_START){
+                    if (!entireEntity && segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_START){
                         createRefSelectablePoint(data->snapSegmentStart, list);
                     }
 
                     // check that end of segment is not line endpoint
-                    if (segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_END){
+                    if (!entireEntity && segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_END){
                         createRefSelectablePoint(data->snapSegmentEnd, list);
                     }
 
-                    if (isInfoCursorForModificationEnabled()) {
+                    if (!entireEntity && isInfoCursorForModificationEnabled()) {
                         msg(tr("Break/Divide Line"))
                             .vector(tr("Point 1:"), data->snapSegmentStart)
                             .vector(tr("Point 2:"), data->snapSegmentEnd)
@@ -253,7 +260,7 @@ void LC_ActionModifyBreakDivide::createEntitiesForLine(const RS_Line *line, cons
                 }
 
                 // create segments of line that are outside of segment selected by the user
-                if (createNonSnapSegments){
+                if (createNonSnapSegments && !entireEntity){
                     if (segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_START){
                         // we don't need this segment if snap is between line start point and intersection point
                         createLineEntity(preview, line->getStartpoint(), data->snapSegmentStart, pen, layer, list);
@@ -268,6 +275,7 @@ void LC_ActionModifyBreakDivide::createEntitiesForLine(const RS_Line *line, cons
             delete data;
         }
     }
+    return entireEntityRemoved;
 }
 /**
  * Creates individual line for given coordinates. If not for preview, also assigns provided pen and layer attributes
@@ -298,7 +306,8 @@ void LC_ActionModifyBreakDivide::createLineEntity(const bool preview, const RS_V
  * @param list
  * @param preview
  */
-void LC_ActionModifyBreakDivide::createEntitiesForCircle(const RS_Circle* circle, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const {
+bool LC_ActionModifyBreakDivide::createEntitiesForCircle(const RS_Circle* circle, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const {
+    bool entireEntityRemoved = false;
     // check that we may expand the circle
     if (checkMayExpandEntity(circle, "")){
         // determine snap point projection on entity
@@ -340,17 +349,22 @@ void LC_ActionModifyBreakDivide::createEntitiesForCircle(const RS_Circle* circle
                 }
             }
 
+            // the selected segment is the whole circle, so it has no edges to divide it at
+            // and nothing remains of it besides the selected segment itself
+            const bool entireEntity = data->segmentDisposition == LC_Division::SegmentDisposition::SEGMENT_ENTIRE;
+            entireEntityRemoved = !preview && entireEntity && createNonSnapSegments;
+
             // attributes of original circle
             RS_Pen pen = circle->getPen(false);
             RS_Layer* layer = circle->getLayer();
 
             // create snap arc segment
-            if (createSnapSegment){
+            if (createSnapSegment && !entireEntity){
                 createArcEntity(arcData, preview, pen, layer, list);
             }
 
             // create complimentary non-snap arc segment, if needed
-            if (createNonSnapSegments){
+            if (createNonSnapSegments && !entireEntity){
                 RS_ArcData arcData1 = arcData;
                 arcData1.reversed = !arcData.reversed; // that ark wil be in same points, yet reversed
                 createArcEntity(arcData1, preview, pen, layer, list);
@@ -360,12 +374,13 @@ void LC_ActionModifyBreakDivide::createEntitiesForCircle(const RS_Circle* circle
             if (preview){
                 // todo - ignore refpoints visibility for divide?
                  RS_Vector dividePoint1 = center.relative(radius, data->snapSegmentStartAngle);
-                 createRefSelectablePoint(dividePoint1, list);
-
                  RS_Vector dividePoint2 = center.relative(radius, data->snapSegmentEndAngle);
-                 createRefSelectablePoint(dividePoint2, list);
+                 if (!entireEntity){
+                     createRefSelectablePoint(dividePoint1, list);
+                     createRefSelectablePoint(dividePoint2, list);
+                 }
 
-                if (isInfoCursorForModificationEnabled()){
+                if (!entireEntity && isInfoCursorForModificationEnabled()){
                     msg(tr("Break/Divide Circle"))
                         .wcsAngle(tr("Angle 1:"), data->snapSegmentStartAngle)
                         .vector(tr("Point 1:"), dividePoint1)
@@ -378,6 +393,7 @@ void LC_ActionModifyBreakDivide::createEntitiesForCircle(const RS_Circle* circle
         // don't need temporary data, so delete it
         delete data;
     }
+    return entireEntityRemoved;
 }
 /**
  * Creates segment entities for provided arc
@@ -386,7 +402,8 @@ void LC_ActionModifyBreakDivide::createEntitiesForCircle(const RS_Circle* circle
  * @param list list of entities to add
  * @param preview true if we generate entities for preview, false otherwise
  */
-void LC_ActionModifyBreakDivide::createEntitiesForArc(RS_Arc *arc, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const {
+bool LC_ActionModifyBreakDivide::createEntitiesForArc(RS_Arc *arc, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const {
+    bool entireEntityRemoved = false;
     // check that arc is expandable
     if (checkMayExpandEntity(arc, "")){
         // determine snap point
@@ -419,23 +436,27 @@ void LC_ActionModifyBreakDivide::createEntitiesForArc(RS_Arc *arc, RS_Vector &sn
                     }
                 }
 
+                // for preview and arc break/divide mode, add points that highlights places where arc will be divided/broken
+                const int segmentDisposition = data->segmentDisposition;
+                // the selected segment is the whole arc, so it has no edges to divide it at
+                // and nothing remains of it besides the selected segment itself
+                const bool entireEntity = segmentDisposition == LC_Division::SegmentDisposition::SEGMENT_ENTIRE;
+                entireEntityRemoved = !preview && entireEntity && createNonSnapSegments;
+
                 // current arc attributes
                 RS_Pen pen = arc->getPen(false);
                 RS_Layer* layer = arc->getLayer(true);
 
                 // create segment where arc was selected, if necessary
-                if (createSnapSegment){
+                if (createSnapSegment && !entireEntity){
                     RS_ArcData arcData = arc->getData();
                     arcData.angle1 = data->snapSegmentStartAngle;
                     arcData.angle2 = data->snapSegmentEndAngle;
                     createArcEntity(arcData, preview, pen, layer, list);
                 }
 
-                // for preview and arc break/divide mode, add points that highlights places where arc will be divided/broken
-                int segmentDisposition = data->segmentDisposition;
-
                 // create non-snap segments, if necessary
-                if (createNonSnapSegments){
+                if (createNonSnapSegments && !entireEntity){
                     if (segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_START){
                         RS_ArcData arcData1 = arc->getData();
                         arcData1.angle1 = arc->getAngle1();
@@ -455,16 +476,16 @@ void LC_ActionModifyBreakDivide::createEntitiesForArc(RS_Arc *arc, RS_Vector &sn
                     double radius = arc->getRadius();
                     RS_Vector center = arc->getCenter();
                     RS_Vector segmentStart = center.relative(radius, data->snapSegmentStartAngle);
-                    if (segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_START){
+                    if (!entireEntity && segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_START){
                         createRefSelectablePoint(segmentStart, list);
                     }
 
                     RS_Vector segmentEnd = center.relative(radius, data->snapSegmentEndAngle);
-                    if (segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_END){
+                    if (!entireEntity && segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_END){
                         createRefSelectablePoint(segmentEnd, list);
                     }
 
-                    if (isInfoCursorForModificationEnabled()){
+                    if (!entireEntity && isInfoCursorForModificationEnabled()){
                         msg(tr("Break/Divide Arc"))
                             .wcsAngle(tr("Angle 1:"), data->snapSegmentStartAngle)
                             .vector(tr("Point 1:"), segmentStart)
@@ -478,6 +499,7 @@ void LC_ActionModifyBreakDivide::createEntitiesForArc(RS_Arc *arc, RS_Vector &sn
             delete data;
         }
     }
+    return entireEntityRemoved;
 }
 
 /**

--- a/librecad/src/actions/drawing/modify/lc_action_modify_break_divide.cpp
+++ b/librecad/src/actions/drawing/modify/lc_action_modify_break_divide.cpp
@@ -128,6 +128,7 @@ void LC_ActionModifyBreakDivide::doOnLeftMouseButtonRelease(const LC_MouseEvent*
                 case RS2::EntityCircle:
                 case RS2::EntityArc:
                     // store information about entity and snap point and pass to trigger()
+                    delete m_triggerData; // a refused earlier click leaves it set
                     m_triggerData = new TriggerData();
                     m_triggerData->entity = en;
                     m_triggerData->snapPoint = snapPoint;
@@ -143,7 +144,7 @@ void LC_ActionModifyBreakDivide::doOnLeftMouseButtonRelease(const LC_MouseEvent*
 
 bool LC_ActionModifyBreakDivide::doCheckMayTrigger(){
     bool result = false;
-    bool removeOriginalWithoutReplacement = false;
+    SegmentCreation creation = SegmentCreation::Segments;
     if (m_triggerData != nullptr){
         RS_Entity* en = m_triggerData->entity;
         RS_Vector snap = m_triggerData->snapPoint;
@@ -153,31 +154,40 @@ bool LC_ActionModifyBreakDivide::doCheckMayTrigger(){
             switch (rtti) {
                 case RS2::EntityLine: {
                     const auto *line = dynamic_cast<RS_Line *>(en);
-                    removeOriginalWithoutReplacement = createEntitiesForLine(line, snap, m_triggerData->entitiesToCreate, false);
+                    creation = createEntitiesForLine(line, snap, m_triggerData->entitiesToCreate, false);
                     break;
                 }
                 case RS2::EntityCircle: {
                     const auto *circle = dynamic_cast<RS_Circle *>(en);
-                    removeOriginalWithoutReplacement = createEntitiesForCircle(circle, snap, m_triggerData->entitiesToCreate, false);
+                    creation = createEntitiesForCircle(circle, snap, m_triggerData->entitiesToCreate, false);
                     break;
                 }
                 case RS2::EntityArc: {
                     auto *arc = dynamic_cast<RS_Arc *>(en);
-                    removeOriginalWithoutReplacement = createEntitiesForArc(arc, snap, m_triggerData->entitiesToCreate, false);
+                    creation = createEntitiesForArc(arc, snap, m_triggerData->entitiesToCreate, false);
                     break;
                 }
                 default:
                     break;
             }
         }
-        // An empty replacement list normally means no valid split was found.
-        // Whole-entity removal is the deliberate exception: deleting the source
-        // entity is the complete operation, so no replacement can exist.
-        if (m_triggerData->entitiesToCreate.isEmpty() && !removeOriginalWithoutReplacement){
-            commandMessage(tr("Invalid entity selected - no segments between intersections to break/divide."));
-        }
-        else {
-            result = true;
+        switch (creation) {
+            case SegmentCreation::RemoveSource:
+                // Deleting the source entity is the complete operation, so the
+                // empty replacement list is the expected shape, not a refusal.
+                result = true;
+                break;
+            case SegmentCreation::KeepEntire:
+                commandMessage(tr("The selected segment is the whole entity - with \"Remove selected\" off there is nothing to remove."));
+                break;
+            case SegmentCreation::Segments:
+                if (m_triggerData->entitiesToCreate.isEmpty()) {
+                    commandMessage(tr("Invalid entity selected - no segments between intersections to break/divide."));
+                }
+                else {
+                    result = true;
+                }
+                break;
         }
     }
     return result;
@@ -214,16 +224,16 @@ void LC_ActionModifyBreakDivide::doFinish(){
  * @param list list to which entities should be added
  * @param preview true if entities for preview
  */
-bool LC_ActionModifyBreakDivide::createEntitiesForLine(const RS_Line *line, const RS_Vector &snap, QList<RS_Entity*> &list, const bool preview) const {
+LC_ActionModifyBreakDivide::SegmentCreation LC_ActionModifyBreakDivide::createEntitiesForLine(const RS_Line *line, const RS_Vector &snap, QList<RS_Entity*> &list, const bool preview) const {
     if (!checkMayExpandEntity(line, "")) {
-        return false;
+        return SegmentCreation::Segments;
     }
 
     const RS_Vector nearestPoint = LC_LineMath::getNearestPointOnLine(line, snap, false);
     const RS_Vector start = line->getStartpoint();
     const RS_Vector end = line->getEndpoint();
     if (nearestPoint == start || nearestPoint == end) {
-        return false;
+        return SegmentCreation::Segments;
     }
 
     LC_Division division(m_document);
@@ -231,7 +241,7 @@ bool LC_ActionModifyBreakDivide::createEntitiesForLine(const RS_Line *line, cons
     const std::unique_ptr<LC_Division::LineSegmentData> data{
         division.findLineSegmentBetweenIntersections(line, snap, allowEntireLineAsSegment)};
     if (data == nullptr) {
-        return false;
+        return SegmentCreation::Segments;
     }
 
     if (preview) {
@@ -243,7 +253,11 @@ bool LC_ActionModifyBreakDivide::createEntitiesForLine(const RS_Line *line, cons
         // A whole selection has no cut boundaries and no complementary pieces.
         // The only valid trigger is removing that selection, represented by an
         // intentionally empty replacement list.
-        return !preview && creationPlan.createRemainingSegments;
+        if (preview) {
+            return SegmentCreation::Segments;
+        }
+        return creationPlan.createRemainingSegments ? SegmentCreation::RemoveSource
+                                                    : SegmentCreation::KeepEntire;
     }
 
     const RS_Pen pen = line->getPen(false);
@@ -277,7 +291,7 @@ bool LC_ActionModifyBreakDivide::createEntitiesForLine(const RS_Line *line, cons
             createLineEntity(preview, data->snapSegmentEnd, line->getEndpoint(), pen, layer, list);
         }
     }
-    return false;
+    return SegmentCreation::Segments;
 }
 /**
  * Creates individual line for given coordinates. If not for preview, also assigns provided pen and layer attributes
@@ -308,9 +322,9 @@ void LC_ActionModifyBreakDivide::createLineEntity(const bool preview, const RS_V
  * @param list
  * @param preview
  */
-bool LC_ActionModifyBreakDivide::createEntitiesForCircle(const RS_Circle* circle, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const {
+LC_ActionModifyBreakDivide::SegmentCreation LC_ActionModifyBreakDivide::createEntitiesForCircle(const RS_Circle* circle, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const {
     if (!checkMayExpandEntity(circle, "")) {
-        return false;
+        return SegmentCreation::Segments;
     }
 
     const RS_Vector nearestPoint = circle->getNearestPointOnEntity(snap, true);
@@ -319,7 +333,7 @@ bool LC_ActionModifyBreakDivide::createEntitiesForCircle(const RS_Circle* circle
     const std::unique_ptr<LC_Division::CircleSegmentData> data{
         division.findCircleSegmentBetweenIntersections(circle, nearestPoint, allowEntireCircleAsSegment)};
     if (data == nullptr) {
-        return false;
+        return SegmentCreation::Segments;
     }
 
     if (preview) {
@@ -330,7 +344,11 @@ bool LC_ActionModifyBreakDivide::createEntitiesForCircle(const RS_Circle* circle
     if (data->segmentDisposition == LC_Division::SegmentDisposition::SEGMENT_ENTIRE) {
         // See the line case: no synthetic full-turn arc should stand in for
         // intentional removal of the source circle.
-        return !preview && creationPlan.createRemainingSegments;
+        if (preview) {
+            return SegmentCreation::Segments;
+        }
+        return creationPlan.createRemainingSegments ? SegmentCreation::RemoveSource
+                                                    : SegmentCreation::KeepEntire;
     }
 
     const RS_Vector center = circle->getCenter();
@@ -370,7 +388,7 @@ bool LC_ActionModifyBreakDivide::createEntitiesForCircle(const RS_Circle* circle
                 .toInfoCursorZone2(false);
         }
     }
-    return false;
+    return SegmentCreation::Segments;
 }
 /**
  * Creates segment entities for provided arc
@@ -379,16 +397,16 @@ bool LC_ActionModifyBreakDivide::createEntitiesForCircle(const RS_Circle* circle
  * @param list list of entities to add
  * @param preview true if we generate entities for preview, false otherwise
  */
-bool LC_ActionModifyBreakDivide::createEntitiesForArc(RS_Arc *arc, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const {
+LC_ActionModifyBreakDivide::SegmentCreation LC_ActionModifyBreakDivide::createEntitiesForArc(RS_Arc *arc, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const {
     if (!checkMayExpandEntity(arc, "")) {
-        return false;
+        return SegmentCreation::Segments;
     }
 
     const RS_Vector nearestPoint = arc->getNearestPointOnEntity(snap, true);
     const RS_Vector start = arc->getStartpoint();
     const RS_Vector end = arc->getEndpoint();
     if (nearestPoint == start || nearestPoint == end) {
-        return false;
+        return SegmentCreation::Segments;
     }
 
     LC_Division division(m_document);
@@ -396,7 +414,7 @@ bool LC_ActionModifyBreakDivide::createEntitiesForArc(RS_Arc *arc, RS_Vector &sn
     const std::unique_ptr<LC_Division::ArcSegmentData> data{
         division.findArcSegmentBetweenIntersections(arc, snap, allowEntireArcAsSegment)};
     if (data == nullptr) {
-        return false;
+        return SegmentCreation::Segments;
     }
 
     if (preview) {
@@ -407,7 +425,11 @@ bool LC_ActionModifyBreakDivide::createEntitiesForArc(RS_Arc *arc, RS_Vector &sn
     if (data->segmentDisposition == LC_Division::SegmentDisposition::SEGMENT_ENTIRE) {
         // See the line case: endpoint angles describe the source arc, not two
         // valid complementary arcs to recreate.
-        return !preview && creationPlan.createRemainingSegments;
+        if (preview) {
+            return SegmentCreation::Segments;
+        }
+        return creationPlan.createRemainingSegments ? SegmentCreation::RemoveSource
+                                                    : SegmentCreation::KeepEntire;
     }
 
     const RS_Pen pen = arc->getPen(false);
@@ -458,7 +480,7 @@ bool LC_ActionModifyBreakDivide::createEntitiesForArc(RS_Arc *arc, RS_Vector &sn
                 .toInfoCursorZone2(false);
         }
     }
-    return false;
+    return SegmentCreation::Segments;
 }
 
 /**

--- a/librecad/src/actions/drawing/modify/lc_action_modify_break_divide.cpp
+++ b/librecad/src/actions/drawing/modify/lc_action_modify_break_divide.cpp
@@ -98,17 +98,17 @@ void LC_ActionModifyBreakDivide::doPreparePreviewEntities(const LC_MouseEvent* e
             switch (rtti) {
                 case RS2::EntityLine: { // process line
                     const auto *line = dynamic_cast<RS_Line *>(en);
-                    createEntitiesForLine(line, snap, list, true);
+                    (void)createEntitiesForLine(line, snap, list, true); // preview shows the list; the removal verdict is trigger-only
                     break;
                 }
                 case RS2::EntityCircle: { //process circle
                     const auto *circle = dynamic_cast<RS_Circle *>(en);
-                    createEntitiesForCircle(circle, snap, list, true);
+                    (void)createEntitiesForCircle(circle, snap, list, true); // preview shows the list; the removal verdict is trigger-only
                     break;
                 }
                 case RS2::EntityArc: { // process arc
                     auto *arc = dynamic_cast<RS_Arc *>(en);
-                    createEntitiesForArc(arc, snap, list, true);
+                    (void)createEntitiesForArc(arc, snap, list, true); // preview shows the list; the removal verdict is trigger-only
                     break;
                 }
                 default:

--- a/librecad/src/actions/drawing/modify/lc_action_modify_break_divide.cpp
+++ b/librecad/src/actions/drawing/modify/lc_action_modify_break_divide.cpp
@@ -23,6 +23,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #include "lc_action_modify_break_divide.h"
 
+#include <memory>
+
 #include "lc_actioninfomessagebuilder.h"
 #include "lc_break_divide_options_filler.h"
 #include "lc_break_divide_options_widget.h"
@@ -38,6 +40,26 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "rs_pen.h"
 
 namespace {
+    struct SegmentCreationPlan {
+        bool createSelectedSegment;
+        bool createRemainingSegments;
+    };
+
+    SegmentCreationPlan makeSegmentCreationPlan(const bool preview, const bool removeSegments,
+                                                const bool removeSelected) {
+        if (!removeSegments) {
+            // Divide previews show only boundary markers; the trigger creates all pieces.
+            return {!preview, !preview};
+        }
+
+        // Break previews show what will be removed, while trigger data contains
+        // the geometry that will remain in the document.
+        if (preview) {
+            return {removeSelected, !removeSelected};
+        }
+        return {!removeSelected, removeSelected};
+    }
+
     //list of entity types supported by current action - line, arc, circle
     const auto g_enTypeList = EntityTypeList{RS2::EntityLine, RS2::EntityArc, RS2::EntityCircle/*,RS2::EntityEllipse*/};
 }
@@ -121,7 +143,7 @@ void LC_ActionModifyBreakDivide::doOnLeftMouseButtonRelease(const LC_MouseEvent*
 
 bool LC_ActionModifyBreakDivide::doCheckMayTrigger(){
     bool result = false;
-    bool entireEntityRemoved = false;
+    bool removeOriginalWithoutReplacement = false;
     if (m_triggerData != nullptr){
         RS_Entity* en = m_triggerData->entity;
         RS_Vector snap = m_triggerData->snapPoint;
@@ -131,24 +153,27 @@ bool LC_ActionModifyBreakDivide::doCheckMayTrigger(){
             switch (rtti) {
                 case RS2::EntityLine: {
                     const auto *line = dynamic_cast<RS_Line *>(en);
-                    entireEntityRemoved = createEntitiesForLine(line, snap, m_triggerData->entitiesToCreate, false);
+                    removeOriginalWithoutReplacement = createEntitiesForLine(line, snap, m_triggerData->entitiesToCreate, false);
                     break;
                 }
                 case RS2::EntityCircle: {
                     const auto *circle = dynamic_cast<RS_Circle *>(en);
-                    entireEntityRemoved = createEntitiesForCircle(circle, snap, m_triggerData->entitiesToCreate, false);
+                    removeOriginalWithoutReplacement = createEntitiesForCircle(circle, snap, m_triggerData->entitiesToCreate, false);
                     break;
                 }
                 case RS2::EntityArc: {
                     auto *arc = dynamic_cast<RS_Arc *>(en);
-                    entireEntityRemoved = createEntitiesForArc(arc, snap, m_triggerData->entitiesToCreate, false);
+                    removeOriginalWithoutReplacement = createEntitiesForArc(arc, snap, m_triggerData->entitiesToCreate, false);
                     break;
                 }
                 default:
                     break;
             }
         }
-        if (m_triggerData->entitiesToCreate.isEmpty() && !entireEntityRemoved){
+        // An empty replacement list normally means no valid split was found.
+        // Whole-entity removal is the deliberate exception: deleting the source
+        // entity is the complete operation, so no replacement can exist.
+        if (m_triggerData->entitiesToCreate.isEmpty() && !removeOriginalWithoutReplacement){
             commandMessage(tr("Invalid entity selected - no segments between intersections to break/divide."));
         }
         else {
@@ -190,92 +215,69 @@ void LC_ActionModifyBreakDivide::doFinish(){
  * @param preview true if entities for preview
  */
 bool LC_ActionModifyBreakDivide::createEntitiesForLine(const RS_Line *line, const RS_Vector &snap, QList<RS_Entity*> &list, const bool preview) const {
-    bool entireEntityRemoved = false;
-    // check whether selection entity may be expanded
-    if (checkMayExpandEntity(line, "")){
-        // determine snap point projection on line
-        const RS_Vector nearestPoint = LC_LineMath::getNearestPointOnLine(line, snap, false);
-        const RS_Vector start = line->getStartpoint();
-        const RS_Vector end = line->getEndpoint();
+    if (!checkMayExpandEntity(line, "")) {
+        return false;
+    }
 
-        // create segments only if tick snap point is between of original lines endpoints
-        if (nearestPoint != start && nearestPoint != end){
-            // calculate segments data
-            LC_Division division(m_document);
-            const bool allowEntireLineAsSegment = m_alternativeActionMode && m_removeSegments;
-            const LC_Division::LineSegmentData *data = division.findLineSegmentBetweenIntersections(line, snap, allowEntireLineAsSegment);
-            if (data != nullptr){
-                if (preview){
-                    highlightHover(line);
-                }
+    const RS_Vector nearestPoint = LC_LineMath::getNearestPointOnLine(line, snap, false);
+    const RS_Vector start = line->getStartpoint();
+    const RS_Vector end = line->getEndpoint();
+    if (nearestPoint == start || nearestPoint == end) {
+        return false;
+    }
 
-                // determine which segments should be created
-                bool createSnapSegment = !preview;
-                bool createNonSnapSegments = !preview;
+    LC_Division division(m_document);
+    const bool allowEntireLineAsSegment = m_alternativeActionMode && m_removeSegments;
+    const std::unique_ptr<LC_Division::LineSegmentData> data{
+        division.findLineSegmentBetweenIntersections(line, snap, allowEntireLineAsSegment)};
+    if (data == nullptr) {
+        return false;
+    }
 
-                if (m_removeSegments){
-                    if (preview){
-                        createSnapSegment = m_removeSelected;
-                        createNonSnapSegments = !m_removeSelected;
-                    }
-                    else{
-                        createSnapSegment = !m_removeSelected;
-                        createNonSnapSegments = m_removeSelected;
-                    }
-                }
+    if (preview) {
+        highlightHover(line);
+    }
 
-                const int segmentDisposition = data->segmentDisposition;
-                // the selected segment is the whole entity, so it has no edges to divide it at
-                // and nothing remains of it besides the selected segment itself
-                const bool entireEntity = segmentDisposition == LC_Division::SegmentDisposition::SEGMENT_ENTIRE;
-                entireEntityRemoved = !preview && entireEntity && createNonSnapSegments;
+    const SegmentCreationPlan creationPlan = makeSegmentCreationPlan(preview, m_removeSegments, m_removeSelected);
+    if (data->segmentDisposition == LC_Division::SegmentDisposition::SEGMENT_ENTIRE) {
+        // A whole selection has no cut boundaries and no complementary pieces.
+        // The only valid trigger is removing that selection, represented by an
+        // intentionally empty replacement list.
+        return !preview && creationPlan.createRemainingSegments;
+    }
 
-                // attributes of original entity
-                const RS_Pen pen = line->getPen(false);
-                RS_Layer* layer = line->getLayer(true);
+    const RS_Pen pen = line->getPen(false);
+    RS_Layer* layer = line->getLayer(true);
 
-                // creating snap segment (where snap was performed)
-                if (createSnapSegment && !entireEntity){
-                    createLineEntity(preview, data->snapSegmentStart, data->snapSegmentEnd, pen, layer, list);
-                }
+    if (creationPlan.createSelectedSegment) {
+        createLineEntity(preview, data->snapSegmentStart, data->snapSegmentEnd, pen, layer, list);
+    }
 
-                // in preview mode provide visual indication of division/break points
-                if (preview){
-                    // check that start of segment is not line endpoint
-                    if (!entireEntity && segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_START){
-                        createRefSelectablePoint(data->snapSegmentStart, list);
-                    }
+    if (preview) {
+        if (data->segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_START) {
+            createRefSelectablePoint(data->snapSegmentStart, list);
+        }
+        if (data->segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_END) {
+            createRefSelectablePoint(data->snapSegmentEnd, list);
+        }
 
-                    // check that end of segment is not line endpoint
-                    if (!entireEntity && segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_END){
-                        createRefSelectablePoint(data->snapSegmentEnd, list);
-                    }
-
-                    if (!entireEntity && isInfoCursorForModificationEnabled()) {
-                        msg(tr("Break/Divide Line"))
-                            .vector(tr("Point 1:"), data->snapSegmentStart)
-                            .vector(tr("Point 2:"), data->snapSegmentEnd)
-                            .toInfoCursorZone2(false);
-                    }
-                }
-
-                // create segments of line that are outside of segment selected by the user
-                if (createNonSnapSegments && !entireEntity){
-                    if (segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_START){
-                        // we don't need this segment if snap is between line start point and intersection point
-                        createLineEntity(preview, line->getStartpoint(), data->snapSegmentStart, pen, layer, list);
-                    }
-                    if (segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_END){
-                        // we don't need this segment if snap is between line end point and intersection point
-                        createLineEntity(preview, data->snapSegmentEnd, line->getEndpoint(), pen, layer, list);
-                    }
-                }
-            }
-            // don't need temporary data we used anymore, so delete it
-            delete data;
+        if (isInfoCursorForModificationEnabled()) {
+            msg(tr("Break/Divide Line"))
+                .vector(tr("Point 1:"), data->snapSegmentStart)
+                .vector(tr("Point 2:"), data->snapSegmentEnd)
+                .toInfoCursorZone2(false);
         }
     }
-    return entireEntityRemoved;
+
+    if (creationPlan.createRemainingSegments) {
+        if (data->segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_START) {
+            createLineEntity(preview, line->getStartpoint(), data->snapSegmentStart, pen, layer, list);
+        }
+        if (data->segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_END) {
+            createLineEntity(preview, data->snapSegmentEnd, line->getEndpoint(), pen, layer, list);
+        }
+    }
+    return false;
 }
 /**
  * Creates individual line for given coordinates. If not for preview, also assigns provided pen and layer attributes
@@ -307,93 +309,68 @@ void LC_ActionModifyBreakDivide::createLineEntity(const bool preview, const RS_V
  * @param preview
  */
 bool LC_ActionModifyBreakDivide::createEntitiesForCircle(const RS_Circle* circle, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const {
-    bool entireEntityRemoved = false;
-    // check that we may expand the circle
-    if (checkMayExpandEntity(circle, "")){
-        // determine snap point projection on entity
-        RS_Vector nearestPoint = circle->getNearestPointOnEntity(snap, true);
-
-        // compute segment data
-        LC_Division division(m_document);
-        bool allowEntireCircleAsSegment = m_alternativeActionMode && m_removeSegments;
-        LC_Division::CircleSegmentData *data = division.findCircleSegmentBetweenIntersections(circle, nearestPoint, allowEntireCircleAsSegment);
-        if (data != nullptr){
-
-            if (preview){
-                highlightHover(circle);
-            }
-
-            const RS_Vector &center = circle->getCenter();
-            double radius = circle->getRadius();
-
-            // basic arc info
-            RS_ArcData arcData;
-            arcData.radius = radius;
-            arcData.center = center;
-            arcData.angle1 = data->snapSegmentStartAngle;
-            arcData.angle2 = data->snapSegmentEndAngle;
-            arcData.reversed = false;
-
-            // determine which segments should be created of circle
-            bool createSnapSegment = !preview;
-            bool createNonSnapSegments = !preview;
-
-            if (m_removeSegments){
-                if (preview){
-                    createSnapSegment = m_removeSelected;
-                    createNonSnapSegments = !m_removeSelected;
-                }
-                else{
-                    createSnapSegment = !m_removeSelected;
-                    createNonSnapSegments = m_removeSelected;
-                }
-            }
-
-            // the selected segment is the whole circle, so it has no edges to divide it at
-            // and nothing remains of it besides the selected segment itself
-            const bool entireEntity = data->segmentDisposition == LC_Division::SegmentDisposition::SEGMENT_ENTIRE;
-            entireEntityRemoved = !preview && entireEntity && createNonSnapSegments;
-
-            // attributes of original circle
-            RS_Pen pen = circle->getPen(false);
-            RS_Layer* layer = circle->getLayer();
-
-            // create snap arc segment
-            if (createSnapSegment && !entireEntity){
-                createArcEntity(arcData, preview, pen, layer, list);
-            }
-
-            // create complimentary non-snap arc segment, if needed
-            if (createNonSnapSegments && !entireEntity){
-                RS_ArcData arcData1 = arcData;
-                arcData1.reversed = !arcData.reversed; // that ark wil be in same points, yet reversed
-                createArcEntity(arcData1, preview, pen, layer, list);
-             }
-
-            // for circle divide mode, add visual indication of divide points if we're creating preview
-            if (preview){
-                // todo - ignore refpoints visibility for divide?
-                 RS_Vector dividePoint1 = center.relative(radius, data->snapSegmentStartAngle);
-                 RS_Vector dividePoint2 = center.relative(radius, data->snapSegmentEndAngle);
-                 if (!entireEntity){
-                     createRefSelectablePoint(dividePoint1, list);
-                     createRefSelectablePoint(dividePoint2, list);
-                 }
-
-                if (!entireEntity && isInfoCursorForModificationEnabled()){
-                    msg(tr("Break/Divide Circle"))
-                        .wcsAngle(tr("Angle 1:"), data->snapSegmentStartAngle)
-                        .vector(tr("Point 1:"), dividePoint1)
-                        .wcsAngle(tr("Angle 2:"), data->snapSegmentEndAngle)
-                        .vector(tr("Point 2:"), dividePoint2)
-                        .toInfoCursorZone2(false);
-                }
-            }
-        }
-        // don't need temporary data, so delete it
-        delete data;
+    if (!checkMayExpandEntity(circle, "")) {
+        return false;
     }
-    return entireEntityRemoved;
+
+    const RS_Vector nearestPoint = circle->getNearestPointOnEntity(snap, true);
+    LC_Division division(m_document);
+    const bool allowEntireCircleAsSegment = m_alternativeActionMode && m_removeSegments;
+    const std::unique_ptr<LC_Division::CircleSegmentData> data{
+        division.findCircleSegmentBetweenIntersections(circle, nearestPoint, allowEntireCircleAsSegment)};
+    if (data == nullptr) {
+        return false;
+    }
+
+    if (preview) {
+        highlightHover(circle);
+    }
+
+    const SegmentCreationPlan creationPlan = makeSegmentCreationPlan(preview, m_removeSegments, m_removeSelected);
+    if (data->segmentDisposition == LC_Division::SegmentDisposition::SEGMENT_ENTIRE) {
+        // See the line case: no synthetic full-turn arc should stand in for
+        // intentional removal of the source circle.
+        return !preview && creationPlan.createRemainingSegments;
+    }
+
+    const RS_Vector center = circle->getCenter();
+    const double radius = circle->getRadius();
+    RS_ArcData arcData;
+    arcData.radius = radius;
+    arcData.center = center;
+    arcData.angle1 = data->snapSegmentStartAngle;
+    arcData.angle2 = data->snapSegmentEndAngle;
+    arcData.reversed = false;
+
+    const RS_Pen pen = circle->getPen(false);
+    RS_Layer* layer = circle->getLayer();
+
+    if (creationPlan.createSelectedSegment) {
+        createArcEntity(arcData, preview, pen, layer, list);
+    }
+
+    if (creationPlan.createRemainingSegments) {
+        RS_ArcData remainingArcData = arcData;
+        remainingArcData.reversed = !arcData.reversed;
+        createArcEntity(remainingArcData, preview, pen, layer, list);
+    }
+
+    if (preview) {
+        const RS_Vector dividePoint1 = center.relative(radius, data->snapSegmentStartAngle);
+        const RS_Vector dividePoint2 = center.relative(radius, data->snapSegmentEndAngle);
+        createRefSelectablePoint(dividePoint1, list);
+        createRefSelectablePoint(dividePoint2, list);
+
+        if (isInfoCursorForModificationEnabled()) {
+            msg(tr("Break/Divide Circle"))
+                .wcsAngle(tr("Angle 1:"), data->snapSegmentStartAngle)
+                .vector(tr("Point 1:"), dividePoint1)
+                .wcsAngle(tr("Angle 2:"), data->snapSegmentEndAngle)
+                .vector(tr("Point 2:"), dividePoint2)
+                .toInfoCursorZone2(false);
+        }
+    }
+    return false;
 }
 /**
  * Creates segment entities for provided arc
@@ -403,103 +380,85 @@ bool LC_ActionModifyBreakDivide::createEntitiesForCircle(const RS_Circle* circle
  * @param preview true if we generate entities for preview, false otherwise
  */
 bool LC_ActionModifyBreakDivide::createEntitiesForArc(RS_Arc *arc, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const {
-    bool entireEntityRemoved = false;
-    // check that arc is expandable
-    if (checkMayExpandEntity(arc, "")){
-        // determine snap point
-        RS_Vector nearestPoint = arc->getNearestPointOnEntity(snap, true);
-        RS_Vector start = arc->getStartpoint();
-        RS_Vector end = arc->getEndpoint();
+    if (!checkMayExpandEntity(arc, "")) {
+        return false;
+    }
 
-        // create segments only if tick snap point is between of original lines endpoints
-        if (nearestPoint != start && nearestPoint != end){
-            // determine snap segment coordinates
-            LC_Division division(m_document);
-            bool allowEntireArcAsSegment = m_alternativeActionMode && m_removeSegments;
-            LC_Division::ArcSegmentData *data = division.findArcSegmentBetweenIntersections(arc, snap, allowEntireArcAsSegment);
-            if (data != nullptr){
-                if (preview){
-                    highlightHover(arc);
-                }
+    const RS_Vector nearestPoint = arc->getNearestPointOnEntity(snap, true);
+    const RS_Vector start = arc->getStartpoint();
+    const RS_Vector end = arc->getEndpoint();
+    if (nearestPoint == start || nearestPoint == end) {
+        return false;
+    }
 
-                // determine which segment entities should be created
-                bool createSnapSegment = !preview;
-                bool createNonSnapSegments = !preview;
+    LC_Division division(m_document);
+    const bool allowEntireArcAsSegment = m_alternativeActionMode && m_removeSegments;
+    const std::unique_ptr<LC_Division::ArcSegmentData> data{
+        division.findArcSegmentBetweenIntersections(arc, snap, allowEntireArcAsSegment)};
+    if (data == nullptr) {
+        return false;
+    }
 
-                if (m_removeSegments){
-                    if (preview){
-                        createSnapSegment = m_removeSelected;
-                        createNonSnapSegments = !m_removeSelected;
-                    } else {
-                        createSnapSegment = !m_removeSelected;
-                        createNonSnapSegments = m_removeSelected;
-                    }
-                }
+    if (preview) {
+        highlightHover(arc);
+    }
 
-                // for preview and arc break/divide mode, add points that highlights places where arc will be divided/broken
-                const int segmentDisposition = data->segmentDisposition;
-                // the selected segment is the whole arc, so it has no edges to divide it at
-                // and nothing remains of it besides the selected segment itself
-                const bool entireEntity = segmentDisposition == LC_Division::SegmentDisposition::SEGMENT_ENTIRE;
-                entireEntityRemoved = !preview && entireEntity && createNonSnapSegments;
+    const SegmentCreationPlan creationPlan = makeSegmentCreationPlan(preview, m_removeSegments, m_removeSelected);
+    if (data->segmentDisposition == LC_Division::SegmentDisposition::SEGMENT_ENTIRE) {
+        // See the line case: endpoint angles describe the source arc, not two
+        // valid complementary arcs to recreate.
+        return !preview && creationPlan.createRemainingSegments;
+    }
 
-                // current arc attributes
-                RS_Pen pen = arc->getPen(false);
-                RS_Layer* layer = arc->getLayer(true);
+    const RS_Pen pen = arc->getPen(false);
+    RS_Layer* layer = arc->getLayer(true);
 
-                // create segment where arc was selected, if necessary
-                if (createSnapSegment && !entireEntity){
-                    RS_ArcData arcData = arc->getData();
-                    arcData.angle1 = data->snapSegmentStartAngle;
-                    arcData.angle2 = data->snapSegmentEndAngle;
-                    createArcEntity(arcData, preview, pen, layer, list);
-                }
+    if (creationPlan.createSelectedSegment) {
+        RS_ArcData selectedArcData = arc->getData();
+        selectedArcData.angle1 = data->snapSegmentStartAngle;
+        selectedArcData.angle2 = data->snapSegmentEndAngle;
+        createArcEntity(selectedArcData, preview, pen, layer, list);
+    }
 
-                // create non-snap segments, if necessary
-                if (createNonSnapSegments && !entireEntity){
-                    if (segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_START){
-                        RS_ArcData arcData1 = arc->getData();
-                        arcData1.angle1 = arc->getAngle1();
-                        arcData1.angle2 = data->snapSegmentStartAngle;
-                        createArcEntity(arcData1, preview, pen, layer, list);
-                    }
+    if (creationPlan.createRemainingSegments) {
+        if (data->segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_START) {
+            RS_ArcData startArcData = arc->getData();
+            startArcData.angle1 = arc->getAngle1();
+            startArcData.angle2 = data->snapSegmentStartAngle;
+            createArcEntity(startArcData, preview, pen, layer, list);
+        }
 
-                    if (segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_END){
-                        RS_ArcData arcData2 = arc->getData();
-                        arcData2.angle1 = data->snapSegmentEndAngle;
-                        arcData2.angle2 = arc->getAngle2();
-                        createArcEntity(arcData2, preview, pen, layer, list);
-                    }
-                }
-
-                if (preview){
-                    double radius = arc->getRadius();
-                    RS_Vector center = arc->getCenter();
-                    RS_Vector segmentStart = center.relative(radius, data->snapSegmentStartAngle);
-                    if (!entireEntity && segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_START){
-                        createRefSelectablePoint(segmentStart, list);
-                    }
-
-                    RS_Vector segmentEnd = center.relative(radius, data->snapSegmentEndAngle);
-                    if (!entireEntity && segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_END){
-                        createRefSelectablePoint(segmentEnd, list);
-                    }
-
-                    if (!entireEntity && isInfoCursorForModificationEnabled()){
-                        msg(tr("Break/Divide Arc"))
-                            .wcsAngle(tr("Angle 1:"), data->snapSegmentStartAngle)
-                            .vector(tr("Point 1:"), segmentStart)
-                            .wcsAngle(tr("Angle 2:"), data->snapSegmentEndAngle)
-                            .vector(tr("Point 2:"), segmentEnd)
-                            .toInfoCursorZone2(false);
-                    }
-                }
-            }
-            // don't need temporary data, so delete it
-            delete data;
+        if (data->segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_END) {
+            RS_ArcData endArcData = arc->getData();
+            endArcData.angle1 = data->snapSegmentEndAngle;
+            endArcData.angle2 = arc->getAngle2();
+            createArcEntity(endArcData, preview, pen, layer, list);
         }
     }
-    return entireEntityRemoved;
+
+    if (preview) {
+        const double radius = arc->getRadius();
+        const RS_Vector center = arc->getCenter();
+        const RS_Vector segmentStart = center.relative(radius, data->snapSegmentStartAngle);
+        if (data->segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_START) {
+            createRefSelectablePoint(segmentStart, list);
+        }
+
+        const RS_Vector segmentEnd = center.relative(radius, data->snapSegmentEndAngle);
+        if (data->segmentDisposition != LC_Division::SegmentDisposition::SEGMENT_TO_END) {
+            createRefSelectablePoint(segmentEnd, list);
+        }
+
+        if (isInfoCursorForModificationEnabled()) {
+            msg(tr("Break/Divide Arc"))
+                .wcsAngle(tr("Angle 1:"), data->snapSegmentStartAngle)
+                .vector(tr("Point 1:"), segmentStart)
+                .wcsAngle(tr("Angle 2:"), data->snapSegmentEndAngle)
+                .vector(tr("Point 2:"), segmentEnd)
+                .toInfoCursorZone2(false);
+        }
+    }
+    return false;
 }
 
 /**

--- a/librecad/src/actions/drawing/modify/lc_action_modify_break_divide.h
+++ b/librecad/src/actions/drawing/modify/lc_action_modify_break_divide.h
@@ -47,6 +47,13 @@ class LC_ActionModifyBreakDivide:public LC_AbstractActionWithPreview{
     };
 
 public:
+    /** What building the replacement segments concluded for one entity. */
+    enum class SegmentCreation {
+        Segments,     // the list holds the applicable segments; empty means no valid split
+        RemoveSource, // whole entity selected for removal: delete it, create nothing
+        KeepEntire    // whole entity selected but kept: a deliberate no-op
+    };
+
     explicit LC_ActionModifyBreakDivide(LC_ActionContext *actionContext);
 
     bool isRemoveSegment() const{return m_removeSegments;}
@@ -72,12 +79,13 @@ protected:
     LC_ActionOptionsPropertiesFiller* createOptionsFiller() override;
     /**
      * Fill the list with the segments the entity should be replaced by.
-     * @return true only when a trigger should remove the source without creating
-     * replacement geometry. This is not a general success result.
+     * The result distinguishes the two whole-entity outcomes - removal without
+     * replacement, and a deliberate no-op when the selection is kept - from the
+     * ordinary case, where an empty list means no valid split was found.
      */
-    bool createEntitiesForLine(const RS_Line *line, const RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
-    bool createEntitiesForCircle(const RS_Circle* circle, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
-    bool createEntitiesForArc(RS_Arc *arc, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
+    SegmentCreation createEntitiesForLine(const RS_Line *line, const RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
+    SegmentCreation createEntitiesForCircle(const RS_Circle* circle, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
+    SegmentCreation createEntitiesForArc(RS_Arc *arc, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
     void doOnLeftMouseButtonRelease(const LC_MouseEvent* e, int status, const RS_Vector &snapPoint) override;
     bool doCheckMayTrigger() override;
     bool doTriggerEntitiesPrepare(LC_DocumentModificationBatch& ctx) override;

--- a/librecad/src/actions/drawing/modify/lc_action_modify_break_divide.h
+++ b/librecad/src/actions/drawing/modify/lc_action_modify_break_divide.h
@@ -83,9 +83,9 @@ protected:
      * replacement, and a deliberate no-op when the selection is kept - from the
      * ordinary case, where an empty list means no valid split was found.
      */
-    SegmentCreation createEntitiesForLine(const RS_Line *line, const RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
-    SegmentCreation createEntitiesForCircle(const RS_Circle* circle, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
-    SegmentCreation createEntitiesForArc(RS_Arc *arc, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
+    [[nodiscard]] SegmentCreation createEntitiesForLine(const RS_Line *line, const RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
+    [[nodiscard]] SegmentCreation createEntitiesForCircle(const RS_Circle* circle, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
+    [[nodiscard]] SegmentCreation createEntitiesForArc(RS_Arc *arc, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
     void doOnLeftMouseButtonRelease(const LC_MouseEvent* e, int status, const RS_Vector &snapPoint) override;
     bool doCheckMayTrigger() override;
     bool doTriggerEntitiesPrepare(LC_DocumentModificationBatch& ctx) override;

--- a/librecad/src/actions/drawing/modify/lc_action_modify_break_divide.h
+++ b/librecad/src/actions/drawing/modify/lc_action_modify_break_divide.h
@@ -72,8 +72,8 @@ protected:
     LC_ActionOptionsPropertiesFiller* createOptionsFiller() override;
     /**
      * Fill the list with the segments the entity should be replaced by.
-     * @return true if the selected segment covers the entire entity, so that nothing
-     * remains of it and it is just removed. Only meaningful for the trigger.
+     * @return true only when a trigger should remove the source without creating
+     * replacement geometry. This is not a general success result.
      */
     bool createEntitiesForLine(const RS_Line *line, const RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
     bool createEntitiesForCircle(const RS_Circle* circle, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;

--- a/librecad/src/actions/drawing/modify/lc_action_modify_break_divide.h
+++ b/librecad/src/actions/drawing/modify/lc_action_modify_break_divide.h
@@ -70,9 +70,14 @@ protected:
     void doPreparePreviewEntities(const LC_MouseEvent* e, RS_Vector &snap, QList<RS_Entity *> &list, int status) override;
     LC_ActionOptionsWidget* createOptionsWidget() override;
     LC_ActionOptionsPropertiesFiller* createOptionsFiller() override;
-    void createEntitiesForLine(const RS_Line *line, const RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
-    void createEntitiesForCircle(const RS_Circle* circle, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
-    void createEntitiesForArc(RS_Arc *arc, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
+    /**
+     * Fill the list with the segments the entity should be replaced by.
+     * @return true if the selected segment covers the entire entity, so that nothing
+     * remains of it and it is just removed. Only meaningful for the trigger.
+     */
+    bool createEntitiesForLine(const RS_Line *line, const RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
+    bool createEntitiesForCircle(const RS_Circle* circle, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
+    bool createEntitiesForArc(RS_Arc *arc, RS_Vector &snap, QList<RS_Entity *> &list, bool preview) const;
     void doOnLeftMouseButtonRelease(const LC_MouseEvent* e, int status, const RS_Vector &snapPoint) override;
     bool doCheckMayTrigger() override;
     bool doTriggerEntitiesPrepare(LC_DocumentModificationBatch& ctx) override;

--- a/librecad/src/actions/drawing/pick/lc_actioninteractivepickdistance.cpp
+++ b/librecad/src/actions/drawing/pick/lc_actioninteractivepickdistance.cpp
@@ -120,7 +120,7 @@ void LC_ActionInteractivePickDistance::onMouseMoveEvent(const int status, const 
                         highlightHover(entity);
                         const auto line = static_cast<RS_Line*>(entity);
                         LC_Division division(m_document);
-                        const LC_Division::LineSegmentData* data = division.findLineSegmentBetweenIntersections(
+                        const auto data = division.findLineSegmentBetweenIntersections(
                             line, e->graphPoint, true);
 
                         if (data != nullptr) {
@@ -133,7 +133,6 @@ void LC_ActionInteractivePickDistance::onMouseMoveEvent(const int status, const 
                             }
                             updateInfoCursorForPoint2(start, end);
                         }
-                        delete data;
                     }
                 }
             }
@@ -220,10 +219,9 @@ void LC_ActionInteractivePickDistance::onMouseLeftButtonRelease(const int status
                     if (isLine(entity)) {
                         const auto line = static_cast<RS_Line*>(entity);
                         LC_Division division(m_document);
-                        const LC_Division::LineSegmentData *data = division.findLineSegmentBetweenIntersections(line, snap, true);
+                        const auto data = division.findLineSegmentBetweenIntersections(line, snap, true);
                         if (data != nullptr) {
                             m_distance = data->snapSegmentEnd.distanceTo(data->snapSegmentStart);
-                            delete data;
                         }
                     }
                 }

--- a/librecad/src/lib/gui/tests/rs_graphicview_close_tests.cpp
+++ b/librecad/src/lib/gui/tests/rs_graphicview_close_tests.cpp
@@ -40,7 +40,15 @@ QApplication& application() {
     static int argc = 1;
     static char name[] = "librecad-tests";
     static char* argv[] = {name, nullptr};
-    static QApplication app(argc, argv);
+    // Reuse the process-wide QApplication if another test file built it first,
+    // and leak the pointer on the create path: only one QApplication may exist
+    // at a time, and only one ~QApplication may run at exit. The old by-value
+    // static here constructed a second instance whenever another test file ran
+    // first - silently tolerated on release Qt, an abort on assert-enabled Qt.
+    static QApplication* app = [] {
+        auto* existing = qobject_cast<QApplication*>(QCoreApplication::instance());
+        return existing != nullptr ? existing : new QApplication(argc, argv);
+    }();
     static bool settingsReady = [] {
         QCoreApplication::setOrganizationName("LibreCAD");
         QCoreApplication::setApplicationName("LibreCAD-tests");
@@ -48,7 +56,7 @@ QApplication& application() {
         return true;
     }();
     (void)settingsReady;
-    return app;
+    return *app;
 }
 
 class TestGraphicView final : public RS_GraphicView {

--- a/librecad/src/lib/modification/lc_division.cpp
+++ b/librecad/src/lib/modification/lc_division.cpp
@@ -48,7 +48,7 @@ LC_Division::LC_Division(RS_EntityContainer* entityContainer) : m_container{enti
  * @param allowEntireArcAsSegment
  * @return segment information
  */
-LC_Division::ArcSegmentData* LC_Division::findArcSegmentBetweenIntersections(const RS_Arc* arc, const RS_Vector& snap,
+std::unique_ptr<LC_Division::ArcSegmentData> LC_Division::findArcSegmentBetweenIntersections(const RS_Arc* arc, const RS_Vector& snap,
                                                                              const bool allowEntireArcAsSegment) {
     ArcSegmentData* result = nullptr;
     // detect all intersections
@@ -66,7 +66,7 @@ LC_Division::ArcSegmentData* LC_Division::findArcSegmentBetweenIntersections(con
         // determine selected segment edges
         result = findArcSegmentEdges(arc, snap, allIntersections, allowEntireArcAsSegment);
     }
-    return result;
+    return std::unique_ptr<ArcSegmentData>{result};
 }
 
 namespace {
@@ -93,7 +93,7 @@ int countDistinctPoints(const QVector<RS_Vector>& points) {
  * @param allowEntireCircleAsSegment
  * @return segment information
  */
-LC_Division::CircleSegmentData* LC_Division::findCircleSegmentBetweenIntersections(const RS_Circle* circle, const RS_Vector& snap,
+std::unique_ptr<LC_Division::CircleSegmentData> LC_Division::findCircleSegmentBetweenIntersections(const RS_Circle* circle, const RS_Vector& snap,
                                                                                    const bool allowEntireCircleAsSegment) {
     CircleSegmentData* result = nullptr;
     // detect all intersections
@@ -114,7 +114,7 @@ LC_Division::CircleSegmentData* LC_Division::findCircleSegmentBetweenIntersectio
         // determine selected segment edges
         result = findCircleSegmentEdges(circle, snap, allIntersections);
     }
-    return result;
+    return std::unique_ptr<CircleSegmentData>{result};
 }
 
 /**
@@ -124,7 +124,7 @@ LC_Division::CircleSegmentData* LC_Division::findCircleSegmentBetweenIntersectio
  * @param allowEntireLine
  * @return segment information
  */
-LC_Division::LineSegmentData* LC_Division::findLineSegmentBetweenIntersections(const RS_Line* line, const RS_Vector& snap,
+std::unique_ptr<LC_Division::LineSegmentData> LC_Division::findLineSegmentBetweenIntersections(const RS_Line* line, const RS_Vector& snap,
                                                                                const bool allowEntireLine) {
     LineSegmentData* result = nullptr;
     // find all intersection points for line
@@ -136,14 +136,13 @@ LC_Division::LineSegmentData* LC_Division::findLineSegmentBetweenIntersections(c
             result->segmentDisposition = SEGMENT_ENTIRE;
             result->snapSegmentStart = line->getStartpoint();
             result->snapSegmentEnd = line->getEndpoint();
-            result->snap = snap;
         }
     }
     else {
         // determine segments of line that was selected by the user
         result = findLineSegmentEdges(line, snap, allIntersections, allowEntireLine);
     }
-    return result;
+    return std::unique_ptr<LineSegmentData>{result};
 }
 
 /**

--- a/librecad/src/lib/modification/lc_division.cpp
+++ b/librecad/src/lib/modification/lc_division.cpp
@@ -57,7 +57,7 @@ LC_Division::ArcSegmentData* LC_Division::findArcSegmentBetweenIntersections(con
         if (allowEntireArcAsSegment) {
             // allowing deletion of complete arcs
             result = new ArcSegmentData();
-            result->segmentDisposition = SEGMENT_INSIDE;
+            result->segmentDisposition = SEGMENT_ENTIRE;
             result->snapSegmentStartAngle = arc->getAngle1();
             result->snapSegmentEndAngle = arc->getAngle2();
         }
@@ -84,6 +84,7 @@ LC_Division::CircleSegmentData* LC_Division::findCircleSegmentBetweenIntersectio
     if (allIntersections.empty()) {
         if (allowEntireCircleAsSegment) {
             result = new CircleSegmentData();
+            result->segmentDisposition = SEGMENT_ENTIRE;
             result->snapSegmentStartAngle = 0;
             result->snapSegmentEndAngle = M_PI * 2;
         }
@@ -111,7 +112,7 @@ LC_Division::LineSegmentData* LC_Division::findLineSegmentBetweenIntersections(c
         if (allowEntireLine) {
             // allow to delete entire line if SHIFT is pressed
             result = new LineSegmentData();
-            result->segmentDisposition = SEGMENT_INSIDE;
+            result->segmentDisposition = SEGMENT_ENTIRE;
             result->snapSegmentStart = line->getStartpoint();
             result->snapSegmentEnd = line->getEndpoint();
             result->snap = snap;
@@ -272,7 +273,7 @@ LC_Division::LineSegmentData* LC_Division::findLineSegmentEdges(const RS_Line* l
         // there are intersections only on edges. We may return the entire line as segment if SHIFT is pressed and the user would like to delete the entire entity
         if (allowEntireLineAsSegment) {
             result = new LineSegmentData();
-            result->segmentDisposition = SEGMENT_INSIDE;
+            result->segmentDisposition = SEGMENT_ENTIRE;
             result->snapSegmentStart = line->getStartpoint();
             result->snapSegmentEnd = line->getEndpoint();
         }
@@ -394,7 +395,7 @@ LC_Division::ArcSegmentData* LC_Division::findArcSegmentEdges(const RS_Arc* arc,
         // there are intersections only on edges. We may return the entire line as segment if SHIFT is pressed and the user would like to delete the entire entity
         if (allowEntireArcAsSegment) {
             result = new ArcSegmentData();
-            result->segmentDisposition = SEGMENT_INSIDE;
+            result->segmentDisposition = SEGMENT_ENTIRE;
             result->snapSegmentStartAngle = arcStartAngle;
             result->snapSegmentEndAngle = arcEndAngle;
         }

--- a/librecad/src/lib/modification/lc_division.cpp
+++ b/librecad/src/lib/modification/lc_division.cpp
@@ -69,6 +69,23 @@ LC_Division::ArcSegmentData* LC_Division::findArcSegmentBetweenIntersections(con
     return result;
 }
 
+namespace {
+// Number of distinct points in the list, stopping as soon as two are found.
+int countDistinctPoints(const QVector<RS_Vector>& points) {
+    int distinct = 0;
+    for (int i = 0; i < points.size(); ++i) {
+        bool duplicate = false;
+        for (int j = 0; j < i && !duplicate; ++j) {
+            duplicate = points.at(i).distanceTo(points.at(j)) < RS_TOLERANCE;
+        }
+        if (!duplicate && ++distinct >= 2) {
+            break;
+        }
+    }
+    return distinct;
+}
+}
+
 /**
  * determines segment of circle selected by the user
  * @param circle circle
@@ -81,9 +98,12 @@ LC_Division::CircleSegmentData* LC_Division::findCircleSegmentBetweenIntersectio
     CircleSegmentData* result = nullptr;
     // detect all intersections
     const QVector<RS_Vector> allIntersections = collectAllIntersectionsWithEntity(circle);
-    if (allIntersections.empty()) {
+    // A closed curve needs two distinct boundary points before it has segments
+    // at all. A single tangency - which the intersection solver may report once
+    // or as two coincident points - divides the circle no more than no
+    // intersection does, so both cases take the whole-entity branch.
+    if (countDistinctPoints(allIntersections) < 2) {
         if (allowEntireCircleAsSegment) {
-            // With no split boundary, the selected segment is the circle itself.
             result = new CircleSegmentData();
             result->segmentDisposition = SEGMENT_ENTIRE;
             result->snapSegmentStartAngle = 0;

--- a/librecad/src/lib/modification/lc_division.cpp
+++ b/librecad/src/lib/modification/lc_division.cpp
@@ -55,7 +55,7 @@ LC_Division::ArcSegmentData* LC_Division::findArcSegmentBetweenIntersections(con
     const QVector<RS_Vector> allIntersections = collectAllIntersectionsWithEntity(arc);
     if (allIntersections.empty()) {
         if (allowEntireArcAsSegment) {
-            // allowing deletion of complete arcs
+            // With no split boundary, the selected segment is the arc itself.
             result = new ArcSegmentData();
             result->segmentDisposition = SEGMENT_ENTIRE;
             result->snapSegmentStartAngle = arc->getAngle1();
@@ -83,6 +83,7 @@ LC_Division::CircleSegmentData* LC_Division::findCircleSegmentBetweenIntersectio
     const QVector<RS_Vector> allIntersections = collectAllIntersectionsWithEntity(circle);
     if (allIntersections.empty()) {
         if (allowEntireCircleAsSegment) {
+            // With no split boundary, the selected segment is the circle itself.
             result = new CircleSegmentData();
             result->segmentDisposition = SEGMENT_ENTIRE;
             result->snapSegmentStartAngle = 0;
@@ -110,7 +111,7 @@ LC_Division::LineSegmentData* LC_Division::findLineSegmentBetweenIntersections(c
     const QVector<RS_Vector> allIntersections = collectAllIntersectionsWithEntity(line);
     if (allIntersections.empty()) {
         if (allowEntireLine) {
-            // allow to delete entire line if SHIFT is pressed
+            // With no split boundary, the selected segment is the line itself.
             result = new LineSegmentData();
             result->segmentDisposition = SEGMENT_ENTIRE;
             result->snapSegmentStart = line->getStartpoint();
@@ -270,7 +271,8 @@ LC_Division::LineSegmentData* LC_Division::findLineSegmentEdges(const RS_Line* l
         }
     }
     else {
-        // there are intersections only on edges. We may return the entire line as segment if SHIFT is pressed and the user would like to delete the entire entity
+        // Endpoint intersections do not divide the line. Preserve the same
+        // whole-entity disposition as the no-intersection case.
         if (allowEntireLineAsSegment) {
             result = new LineSegmentData();
             result->segmentDisposition = SEGMENT_ENTIRE;
@@ -392,7 +394,8 @@ LC_Division::ArcSegmentData* LC_Division::findArcSegmentEdges(const RS_Arc* arc,
         }
     }
     else {
-        // there are intersections only on edges. We may return the entire line as segment if SHIFT is pressed and the user would like to delete the entire entity
+        // Endpoint intersections do not divide the arc. Preserve the same
+        // whole-entity disposition as the no-intersection case.
         if (allowEntireArcAsSegment) {
             result = new ArcSegmentData();
             result->segmentDisposition = SEGMENT_ENTIRE;

--- a/librecad/src/lib/modification/lc_division.h
+++ b/librecad/src/lib/modification/lc_division.h
@@ -43,14 +43,16 @@ public:
         SEGMENT_INSIDE, // segment is between two intersection points
         SEGMENT_TO_START, // snap is between start point of entity and intersection point
         SEGMENT_TO_END, // snap is between end point of entity and intersection point
-        SEGMENT_ENTIRE // the entire entity is the segment, it has no intersections outside its own endpoints
+        // The selected segment is the source entity itself. This is semantic
+        // operation data; consumers must not infer it from coincident endpoints.
+        SEGMENT_ENTIRE
     };
 
     /**
      * Snap segment info for line
      */
     struct LineSegmentData{
-        SegmentDisposition segmentDisposition;
+        SegmentDisposition segmentDisposition = SEGMENT_INSIDE;
         RS_Vector snap;
         RS_Vector snapSegmentStart;
         RS_Vector snapSegmentEnd;
@@ -60,7 +62,7 @@ public:
      * Snap segment for angle
      */
     struct ArcSegmentData{
-        int segmentDisposition;
+        SegmentDisposition segmentDisposition = SEGMENT_INSIDE;
         double snapSegmentStartAngle;
         double snapSegmentEndAngle;
     };
@@ -69,7 +71,6 @@ public:
      * Snap segment for circle     *
      */
     struct CircleSegmentData{
-        // the circle paths that do not set it leave the circle intact
         SegmentDisposition segmentDisposition = SEGMENT_INSIDE;
         double snapSegmentStartAngle;
         double snapSegmentEndAngle;

--- a/librecad/src/lib/modification/lc_division.h
+++ b/librecad/src/lib/modification/lc_division.h
@@ -25,6 +25,8 @@
 #define LC_DIVISION_H
 #include <QVector>
 
+#include <memory>
+
 #include "rs_vector.h"
 
 class RS_Line;
@@ -53,7 +55,6 @@ public:
      */
     struct LineSegmentData{
         SegmentDisposition segmentDisposition = SEGMENT_INSIDE;
-        RS_Vector snap;
         RS_Vector snapSegmentStart;
         RS_Vector snapSegmentEnd;
     };
@@ -78,9 +79,9 @@ public:
 
     explicit LC_Division(RS_EntityContainer *entityContainer);
 
-    ArcSegmentData* findArcSegmentBetweenIntersections(const RS_Arc* arc, const RS_Vector& snap, bool allowEntireArcAsSegment);
-    CircleSegmentData* findCircleSegmentBetweenIntersections(const RS_Circle* circle, const RS_Vector& snap, bool allowEntireCircleAsSegment);
-    LineSegmentData* findLineSegmentBetweenIntersections(const RS_Line* line, const RS_Vector& snap, bool allowEntireLine);
+    std::unique_ptr<ArcSegmentData> findArcSegmentBetweenIntersections(const RS_Arc* arc, const RS_Vector& snap, bool allowEntireArcAsSegment);
+    std::unique_ptr<CircleSegmentData> findCircleSegmentBetweenIntersections(const RS_Circle* circle, const RS_Vector& snap, bool allowEntireCircleAsSegment);
+    std::unique_ptr<LineSegmentData> findLineSegmentBetweenIntersections(const RS_Line* line, const RS_Vector& snap, bool allowEntireLine);
 
     LineSegmentData* findLineSegmentEdges(const RS_Line* line, const RS_Vector& snap, QVector<RS_Vector> intersections, bool allowEntireLineAsSegment);
     ArcSegmentData* findArcSegmentEdges(const RS_Arc* arc, const RS_Vector& snap, const QVector<RS_Vector>& intersections, bool allowEntireArcAsSegment);

--- a/librecad/src/lib/modification/lc_division.h
+++ b/librecad/src/lib/modification/lc_division.h
@@ -42,7 +42,8 @@ public:
     enum SegmentDisposition{
         SEGMENT_INSIDE, // segment is between two intersection points
         SEGMENT_TO_START, // snap is between start point of entity and intersection point
-        SEGMENT_TO_END // snap is between end point of entity and intersection point
+        SEGMENT_TO_END, // snap is between end point of entity and intersection point
+        SEGMENT_ENTIRE // the entire entity is the segment, it has no intersections outside its own endpoints
     };
 
     /**
@@ -68,6 +69,8 @@ public:
      * Snap segment for circle     *
      */
     struct CircleSegmentData{
+        // the circle paths that do not set it leave the circle intact
+        SegmentDisposition segmentDisposition = SEGMENT_INSIDE;
         double snapSegmentStartAngle;
         double snapSegmentEndAngle;
     };

--- a/librecad/src/lib/modification/tests/lc_division_tests.cpp
+++ b/librecad/src/lib/modification/tests/lc_division_tests.cpp
@@ -82,6 +82,9 @@ TEST_CASE("LC_Division identifies an unbounded selection as the whole entity",
 
         REQUIRE(data != nullptr);
         CHECK(data->segmentDisposition == LC_Division::SEGMENT_ENTIRE);
+        // ENTIRE data must describe the source arc itself.
+        CHECK(data->snapSegmentStartAngle == arc.getAngle1());
+        CHECK(data->snapSegmentEndAngle == arc.getAngle2());
     }
 
     SECTION("circle") {
@@ -91,6 +94,8 @@ TEST_CASE("LC_Division identifies an unbounded selection as the whole entity",
 
         REQUIRE(data != nullptr);
         CHECK(data->segmentDisposition == LC_Division::SEGMENT_ENTIRE);
+        CHECK(data->snapSegmentStartAngle == 0.0);
+        CHECK(data->snapSegmentEndAngle == 2.0 * HALF_TURN);
     }
 }
 
@@ -427,4 +432,38 @@ TEST_CASE("a single tangency does not divide a circle",
         CHECK(list.isEmpty());
         qDeleteAll(list);
     }
+}
+TEST_CASE("whole-entity preview shows nothing but the hover highlight",
+          "[lc_division][break_divide][whole_entity][action]") {
+    // The guard must hold on the preview path too: a mutant restricting it to
+    // the trigger would paint division markers and a phantom segment for a
+    // click that deletes the whole entity.
+    BreakDivideFixture fixture{/*removeSelected=*/true};
+    RS_Line line{nullptr, RS_Vector{0.0, 0.0}, RS_Vector{10.0, 0.0}};
+    QList<RS_Entity*> list;
+
+    CHECK(fixture.action->createEntitiesForLine(&line, RS_Vector{5.0, 0.0}, list, true)
+          == SegmentCreation::Segments);
+    CHECK(list.isEmpty());
+
+    qDeleteAll(list);
+}
+
+TEST_CASE("divide mode never sees a whole-entity selection",
+          "[lc_division][break_divide][whole_entity][action]") {
+    // allowEntire* is m_alternativeActionMode && m_removeSegments, so plain
+    // divide on an intersection-free entity stays a no-op in both directions.
+    BreakDivideFixture fixture{/*removeSelected=*/false};
+    fixture.action->setRemoveSegment(false);
+    RS_Line line{nullptr, RS_Vector{0.0, 0.0}, RS_Vector{10.0, 0.0}};
+    QList<RS_Entity*> list;
+
+    CHECK(fixture.action->createEntitiesForLine(&line, RS_Vector{5.0, 0.0}, list, false)
+          == SegmentCreation::Segments);
+    CHECK(list.isEmpty());
+    CHECK(fixture.action->createEntitiesForLine(&line, RS_Vector{5.0, 0.0}, list, true)
+          == SegmentCreation::Segments);
+    CHECK(list.isEmpty());
+
+    qDeleteAll(list);
 }

--- a/librecad/src/lib/modification/tests/lc_division_tests.cpp
+++ b/librecad/src/lib/modification/tests/lc_division_tests.cpp
@@ -24,11 +24,19 @@
 
 #include <memory>
 
+#include <QApplication>
+#include <QList>
+
+#include "lc_action_modify_break_divide.h"
+#include "lc_actioncontext.h"
 #include "lc_division.h"
 #include "rs_arc.h"
 #include "rs_circle.h"
 #include "rs_entitycontainer.h"
+#include "rs_graphic.h"
+#include "rs_graphicview.h"
 #include "rs_line.h"
+#include "rs_settings.h"
 #include "rs_vector.h"
 
 namespace {
@@ -136,4 +144,169 @@ TEST_CASE("LC_Division keeps ordinary partial-segment behavior",
         REQUIRE(data != nullptr);
         CHECK(data->segmentDisposition == LC_Division::SEGMENT_TO_START);
     }
+}
+
+// The classification tests above prove LC_Division reports SEGMENT_ENTIRE. The
+// tests below prove the consumer acts on it: without them, deleting the
+// SEGMENT_ENTIRE guards from LC_ActionModifyBreakDivide leaves the suite green
+// while #2700 returns.
+namespace {
+
+/**
+ * Returns a QApplication, reusing the process-wide one if another test built it
+ * first. The pointer is deliberately leaked: only one ~QApplication may run at
+ * exit, and rs_graphicview_close_tests.cpp already owns it via a by-value
+ * static. A second destructor tears down Qt's globals twice and crashes after
+ * Catch2 has printed its summary.
+ */
+QApplication* application() {
+    static int argc = 1;
+    static char name[] = "librecad_tests";
+    static char* argv[] = {name, nullptr};
+    static QApplication* app = [] {
+        auto* existing = qobject_cast<QApplication*>(QCoreApplication::instance());
+        return existing != nullptr ? existing : new QApplication(argc, argv);
+    }();
+    static bool settingsReady = [] {
+        QCoreApplication::setOrganizationName("LibreCAD");
+        QCoreApplication::setApplicationName("LibreCAD-tests");
+        RS_Settings::init("LibreCAD", "LibreCAD-tests");
+        return true;
+    }();
+    (void)settingsReady;
+    return app;
+}
+
+class BreakDivideTestView final : public RS_GraphicView {
+public:
+    BreakDivideTestView() : RS_GraphicView(nullptr) {}
+
+    int getWidth() const override { return 640; }
+    int getHeight() const override { return 480; }
+    void redraw([[maybe_unused]] RS2::RedrawMethod method = RS2::RedrawAll,
+                [[maybe_unused]] bool immediately = false) override {}
+    void adjustOffsetControls() override {}
+    void adjustZoomControls() override {}
+    void setMouseCursor([[maybe_unused]] RS2::CursorType cursor) override {}
+    void updateGridStatusWidget([[maybe_unused]] QString status) override {}
+};
+
+/**
+ * Reaches the protected segment builders, and the protected flag that SHIFT
+ * sets: whole-entity selection needs m_alternativeActionMode && m_removeSegments,
+ * and there is no public setter for the former.
+ */
+class BreakDivideProbe final : public LC_ActionModifyBreakDivide {
+public:
+    explicit BreakDivideProbe(LC_ActionContext* actionContext)
+        : LC_ActionModifyBreakDivide(actionContext) {}
+
+    using LC_ActionModifyBreakDivide::createEntitiesForLine;
+    using LC_ActionModifyBreakDivide::createEntitiesForCircle;
+    using LC_ActionModifyBreakDivide::createEntitiesForArc;
+
+    void setWholeEntityMode(const bool value) { m_alternativeActionMode = value; }
+};
+
+/**
+ * Member order matters: the action is destroyed before the view, because
+ * ~RS_PreviewActionInterface reaches into overlay containers the view owns.
+ */
+struct BreakDivideFixture {
+    // Declared first on purpose: members are initialised before the constructor
+    // body, and RS_Graphic's own constructor already reads RS_Settings.
+    const bool qtReady{application() != nullptr};
+    RS_Graphic graphic;
+    BreakDivideTestView view;
+    LC_ActionContext context;
+    std::unique_ptr<BreakDivideProbe> action;
+
+    explicit BreakDivideFixture(const bool removeSelected) {
+        graphic.initForNewDocument();
+        view.setDocument(&graphic);
+        context.setDocumentAndView(&graphic, &view);
+        action = std::make_unique<BreakDivideProbe>(&context);
+        action->setWholeEntityMode(true);  // the SHIFT modifier
+        action->setRemoveSegment(true);    // break, not divide
+        action->setRemoveSelected(removeSelected);
+    }
+};
+
+} // namespace
+
+TEST_CASE("whole-entity Break removes the source without replacement geometry",
+          "[lc_division][break_divide][whole_entity][action]") {
+    BreakDivideFixture fixture{/*removeSelected=*/true};
+    QList<RS_Entity*> list;
+
+    SECTION("line") {
+        RS_Line line{nullptr, RS_Vector{0.0, 0.0}, RS_Vector{10.0, 0.0}};
+        CHECK(fixture.action->createEntitiesForLine(&line, RS_Vector{5.0, 0.0}, list, false));
+        CHECK(list.isEmpty());
+    }
+
+    SECTION("circle") {
+        RS_Circle circle{nullptr, RS_CircleData{RS_Vector{0.0, 0.0}, 10.0}};
+        RS_Vector snap{10.0, 0.0};
+        CHECK(fixture.action->createEntitiesForCircle(&circle, snap, list, false));
+        CHECK(list.isEmpty());
+    }
+
+    SECTION("arc") {
+        RS_Arc arc{nullptr, RS_ArcData{RS_Vector{0.0, 0.0}, 10.0, 0.0, HALF_TURN, false}};
+        RS_Vector snap{0.0, 10.0};
+        CHECK(fixture.action->createEntitiesForArc(&arc, snap, list, false));
+        CHECK(list.isEmpty());
+    }
+
+    qDeleteAll(list);
+}
+
+TEST_CASE("whole-entity Break that keeps the selection is a no-op, not a delete",
+          "[lc_division][break_divide][whole_entity][action]") {
+    // Without the second conjunct the action would report "remove the source",
+    // deleting the entity the user asked to keep.
+    BreakDivideFixture fixture{/*removeSelected=*/false};
+    RS_Line line{nullptr, RS_Vector{0.0, 0.0}, RS_Vector{10.0, 0.0}};
+    QList<RS_Entity*> list;
+
+    CHECK_FALSE(fixture.action->createEntitiesForLine(&line, RS_Vector{5.0, 0.0}, list, false));
+    CHECK(list.isEmpty());
+
+    qDeleteAll(list);
+}
+
+TEST_CASE("Break bounded by real intersections still creates the remaining segments",
+          "[lc_division][break_divide][action]") {
+    // Catches an over-broad fix: one that keys off the flags, or off coincident
+    // endpoints, instead of off SEGMENT_ENTIRE.
+    BreakDivideFixture fixture{/*removeSelected=*/true};
+    QList<RS_Entity*> list;
+
+    SECTION("line") {
+        fixture.graphic.addEntity(new RS_Line{&fixture.graphic, RS_Vector{3.0, -5.0}, RS_Vector{3.0, 5.0}});
+        fixture.graphic.addEntity(new RS_Line{&fixture.graphic, RS_Vector{7.0, -5.0}, RS_Vector{7.0, 5.0}});
+        RS_Line line{nullptr, RS_Vector{0.0, 0.0}, RS_Vector{10.0, 0.0}};
+        CHECK_FALSE(fixture.action->createEntitiesForLine(&line, RS_Vector{5.0, 0.0}, list, false));
+        CHECK(list.size() == 2);
+    }
+
+    SECTION("circle") {
+        fixture.graphic.addEntity(new RS_Line{&fixture.graphic, RS_Vector{0.0, -12.0}, RS_Vector{0.0, 12.0}});
+        RS_Circle circle{nullptr, RS_CircleData{RS_Vector{0.0, 0.0}, 10.0}};
+        RS_Vector snap{10.0, 0.0};
+        CHECK_FALSE(fixture.action->createEntitiesForCircle(&circle, snap, list, false));
+        CHECK(list.size() == 1);
+    }
+
+    SECTION("arc") {
+        fixture.graphic.addEntity(new RS_Line{&fixture.graphic, RS_Vector{-5.0, -12.0}, RS_Vector{-5.0, 12.0}});
+        fixture.graphic.addEntity(new RS_Line{&fixture.graphic, RS_Vector{5.0, -12.0}, RS_Vector{5.0, 12.0}});
+        RS_Arc arc{nullptr, RS_ArcData{RS_Vector{0.0, 0.0}, 10.0, 0.0, HALF_TURN, false}};
+        RS_Vector snap{0.0, 10.0};
+        CHECK_FALSE(fixture.action->createEntitiesForArc(&arc, snap, list, false));
+        CHECK(list.size() == 2);
+    }
+
+    qDeleteAll(list);
 }

--- a/librecad/src/lib/modification/tests/lc_division_tests.cpp
+++ b/librecad/src/lib/modification/tests/lc_division_tests.cpp
@@ -26,6 +26,9 @@
 
 #include <QApplication>
 #include <QList>
+#include <QtAlgorithms>
+
+#include <type_traits>
 
 #include "lc_action_modify_break_divide.h"
 #include "lc_actioncontext.h"
@@ -154,10 +157,9 @@ namespace {
 
 /**
  * Returns a QApplication, reusing the process-wide one if another test built it
- * first. The pointer is deliberately leaked: only one ~QApplication may run at
- * exit, and rs_graphicview_close_tests.cpp already owns it via a by-value
- * static. A second destructor tears down Qt's globals twice and crashes after
- * Catch2 has printed its summary.
+ * first. The pointer is deliberately leaked: only one QApplication may exist at
+ * a time and only one ~QApplication may run at exit, so every test file uses
+ * this reuse-or-create form and none of them destroys the instance.
  */
 QApplication* application() {
     static int argc = 1;
@@ -204,8 +206,24 @@ public:
     using LC_ActionModifyBreakDivide::createEntitiesForLine;
     using LC_ActionModifyBreakDivide::createEntitiesForCircle;
     using LC_ActionModifyBreakDivide::createEntitiesForArc;
+    using LC_ActionModifyBreakDivide::doCheckMayTrigger;
 
     void setWholeEntityMode(const bool value) { m_alternativeActionMode = value; }
+
+    // The nested TriggerData type is private, but the member is protected; its
+    // type is reachable through decltype, so no production visibility change.
+    void makeTriggerData(RS_Entity* entity, const RS_Vector& snap) {
+        clearTriggerData();
+        using TriggerDataT = std::remove_pointer_t<decltype(m_triggerData)>;
+        m_triggerData = new TriggerDataT{};
+        m_triggerData->entity = entity;
+        m_triggerData->snapPoint = snap;
+    }
+    bool triggerListIsEmpty() const { return m_triggerData->entitiesToCreate.isEmpty(); }
+    void clearTriggerData() {
+        delete m_triggerData;
+        m_triggerData = nullptr;
+    }
 };
 
 /**
@@ -267,19 +285,59 @@ TEST_CASE("whole-entity Break that keeps the selection is a no-op, not a delete"
     // Without the second conjunct the action would report "remove the source",
     // deleting the entity the user asked to keep.
     BreakDivideFixture fixture{/*removeSelected=*/false};
-    RS_Line line{nullptr, RS_Vector{0.0, 0.0}, RS_Vector{10.0, 0.0}};
     QList<RS_Entity*> list;
 
-    CHECK_FALSE(fixture.action->createEntitiesForLine(&line, RS_Vector{5.0, 0.0}, list, false));
-    CHECK(list.isEmpty());
+    SECTION("line") {
+        RS_Line line{nullptr, RS_Vector{0.0, 0.0}, RS_Vector{10.0, 0.0}};
+        CHECK_FALSE(fixture.action->createEntitiesForLine(&line, RS_Vector{5.0, 0.0}, list, false));
+        CHECK(list.isEmpty());
+    }
+
+    SECTION("circle") {
+        RS_Circle circle{nullptr, RS_CircleData{RS_Vector{0.0, 0.0}, 10.0}};
+        RS_Vector snap{10.0, 0.0};
+        CHECK_FALSE(fixture.action->createEntitiesForCircle(&circle, snap, list, false));
+        CHECK(list.isEmpty());
+    }
+
+    SECTION("arc") {
+        RS_Arc arc{nullptr, RS_ArcData{RS_Vector{0.0, 0.0}, 10.0, 0.0, HALF_TURN, false}};
+        RS_Vector snap{0.0, 10.0};
+        CHECK_FALSE(fixture.action->createEntitiesForArc(&arc, snap, list, false));
+        CHECK(list.isEmpty());
+    }
 
     qDeleteAll(list);
 }
 
+TEST_CASE("doCheckMayTrigger accepts whole-entity removal, and only that",
+          "[lc_division][break_divide][whole_entity][action]") {
+    // The acceptance below is the user-visible fix for #2700: an empty
+    // replacement list is normally a refusal, whole-entity removal is the one
+    // exception. Nothing upstream of createEntitiesForX covered it before.
+    RS_Line line{nullptr, RS_Vector{0.0, 0.0}, RS_Vector{10.0, 0.0}};
+
+    SECTION("remove-selected: empty replacement list is accepted") {
+        BreakDivideFixture fixture{/*removeSelected=*/true};
+        fixture.action->makeTriggerData(&line, RS_Vector{5.0, 0.0});
+        CHECK(fixture.action->doCheckMayTrigger());
+        CHECK(fixture.action->triggerListIsEmpty());
+        fixture.action->clearTriggerData();
+    }
+
+    SECTION("keep-selected: same click is refused, not treated as a removal") {
+        BreakDivideFixture fixture{/*removeSelected=*/false};
+        fixture.action->makeTriggerData(&line, RS_Vector{5.0, 0.0});
+        CHECK_FALSE(fixture.action->doCheckMayTrigger());
+        CHECK(fixture.action->triggerListIsEmpty());
+        fixture.action->clearTriggerData();
+    }
+}
+
 TEST_CASE("Break bounded by real intersections still creates the remaining segments",
           "[lc_division][break_divide][action]") {
-    // Catches an over-broad fix: one that keys off the flags, or off coincident
-    // endpoints, instead of off SEGMENT_ENTIRE.
+    // Catches an over-broad fix: one that keys off the flags instead of off
+    // SEGMENT_ENTIRE.
     BreakDivideFixture fixture{/*removeSelected=*/true};
     QList<RS_Entity*> list;
 

--- a/librecad/src/lib/modification/tests/lc_division_tests.cpp
+++ b/librecad/src/lib/modification/tests/lc_division_tests.cpp
@@ -21,6 +21,7 @@
 **********************************************************************/
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include <memory>
 
@@ -108,14 +109,19 @@ TEST_CASE("endpoint-only intersections do not masquerade as split boundaries",
         CHECK(data->segmentDisposition == LC_Division::SEGMENT_ENTIRE);
     }
 
-    SECTION("reversed arc") {
+    SECTION("arc") {
+        // The reversed flag swaps the angle bookkeeping ahead of the endpoint
+        // checks, so both orientations are distinct paths through
+        // findArcSegmentEdges.
+        const bool reversed = GENERATE(false, true);
         RS_EntityContainer container;
         addArcEndpointCutters(container);
         LC_Division division{&container};
-        RS_Arc arc{nullptr, RS_ArcData{RS_Vector{0.0, 0.0}, 10.0, 0.0, HALF_TURN, true}};
+        RS_Arc arc{nullptr, RS_ArcData{RS_Vector{0.0, 0.0}, 10.0, 0.0, HALF_TURN, reversed}};
+        const RS_Vector snap = reversed ? RS_Vector{0.0, -10.0} : RS_Vector{0.0, 10.0};
 
         const std::unique_ptr<LC_Division::ArcSegmentData> data{
-            division.findArcSegmentBetweenIntersections(&arc, RS_Vector{0.0, -10.0}, true)};
+            division.findArcSegmentBetweenIntersections(&arc, snap, true)};
 
         REQUIRE(data != nullptr);
         CHECK(data->segmentDisposition == LC_Division::SEGMENT_ENTIRE);
@@ -226,6 +232,8 @@ public:
     }
 };
 
+using SegmentCreation = LC_ActionModifyBreakDivide::SegmentCreation;
+
 /**
  * Member order matters: the action is destroyed before the view, because
  * ~RS_PreviewActionInterface reaches into overlay containers the view owns.
@@ -259,21 +267,21 @@ TEST_CASE("whole-entity Break removes the source without replacement geometry",
 
     SECTION("line") {
         RS_Line line{nullptr, RS_Vector{0.0, 0.0}, RS_Vector{10.0, 0.0}};
-        CHECK(fixture.action->createEntitiesForLine(&line, RS_Vector{5.0, 0.0}, list, false));
+        CHECK(fixture.action->createEntitiesForLine(&line, RS_Vector{5.0, 0.0}, list, false) == SegmentCreation::RemoveSource);
         CHECK(list.isEmpty());
     }
 
     SECTION("circle") {
         RS_Circle circle{nullptr, RS_CircleData{RS_Vector{0.0, 0.0}, 10.0}};
         RS_Vector snap{10.0, 0.0};
-        CHECK(fixture.action->createEntitiesForCircle(&circle, snap, list, false));
+        CHECK(fixture.action->createEntitiesForCircle(&circle, snap, list, false) == SegmentCreation::RemoveSource);
         CHECK(list.isEmpty());
     }
 
     SECTION("arc") {
         RS_Arc arc{nullptr, RS_ArcData{RS_Vector{0.0, 0.0}, 10.0, 0.0, HALF_TURN, false}};
         RS_Vector snap{0.0, 10.0};
-        CHECK(fixture.action->createEntitiesForArc(&arc, snap, list, false));
+        CHECK(fixture.action->createEntitiesForArc(&arc, snap, list, false) == SegmentCreation::RemoveSource);
         CHECK(list.isEmpty());
     }
 
@@ -289,21 +297,21 @@ TEST_CASE("whole-entity Break that keeps the selection is a no-op, not a delete"
 
     SECTION("line") {
         RS_Line line{nullptr, RS_Vector{0.0, 0.0}, RS_Vector{10.0, 0.0}};
-        CHECK_FALSE(fixture.action->createEntitiesForLine(&line, RS_Vector{5.0, 0.0}, list, false));
+        CHECK(fixture.action->createEntitiesForLine(&line, RS_Vector{5.0, 0.0}, list, false) == SegmentCreation::KeepEntire);
         CHECK(list.isEmpty());
     }
 
     SECTION("circle") {
         RS_Circle circle{nullptr, RS_CircleData{RS_Vector{0.0, 0.0}, 10.0}};
         RS_Vector snap{10.0, 0.0};
-        CHECK_FALSE(fixture.action->createEntitiesForCircle(&circle, snap, list, false));
+        CHECK(fixture.action->createEntitiesForCircle(&circle, snap, list, false) == SegmentCreation::KeepEntire);
         CHECK(list.isEmpty());
     }
 
     SECTION("arc") {
         RS_Arc arc{nullptr, RS_ArcData{RS_Vector{0.0, 0.0}, 10.0, 0.0, HALF_TURN, false}};
         RS_Vector snap{0.0, 10.0};
-        CHECK_FALSE(fixture.action->createEntitiesForArc(&arc, snap, list, false));
+        CHECK(fixture.action->createEntitiesForArc(&arc, snap, list, false) == SegmentCreation::KeepEntire);
         CHECK(list.isEmpty());
     }
 
@@ -345,16 +353,28 @@ TEST_CASE("Break bounded by real intersections still creates the remaining segme
         fixture.graphic.addEntity(new RS_Line{&fixture.graphic, RS_Vector{3.0, -5.0}, RS_Vector{3.0, 5.0}});
         fixture.graphic.addEntity(new RS_Line{&fixture.graphic, RS_Vector{7.0, -5.0}, RS_Vector{7.0, 5.0}});
         RS_Line line{nullptr, RS_Vector{0.0, 0.0}, RS_Vector{10.0, 0.0}};
-        CHECK_FALSE(fixture.action->createEntitiesForLine(&line, RS_Vector{5.0, 0.0}, list, false));
+        CHECK(fixture.action->createEntitiesForLine(&line, RS_Vector{5.0, 0.0}, list, false)
+              == SegmentCreation::Segments);
         CHECK(list.size() == 2);
+        // #2700's signature was the right count of zero-extent remnants.
+        for (const RS_Entity* e: list) {
+            CHECK(e->getLength() > RS_TOLERANCE);
+        }
     }
 
     SECTION("circle") {
         fixture.graphic.addEntity(new RS_Line{&fixture.graphic, RS_Vector{0.0, -12.0}, RS_Vector{0.0, 12.0}});
         RS_Circle circle{nullptr, RS_CircleData{RS_Vector{0.0, 0.0}, 10.0}};
         RS_Vector snap{10.0, 0.0};
-        CHECK_FALSE(fixture.action->createEntitiesForCircle(&circle, snap, list, false));
+        CHECK(fixture.action->createEntitiesForCircle(&circle, snap, list, false)
+              == SegmentCreation::Segments);
         CHECK(list.size() == 1);
+        // A zero-sweep arc reports a full-turn length, so bound it from both
+        // sides: the remainder must be a real partial arc.
+        for (const RS_Entity* e: list) {
+            CHECK(e->getLength() > RS_TOLERANCE);
+            CHECK(e->getLength() < 2.0 * HALF_TURN * 10.0 - RS_TOLERANCE);
+        }
     }
 
     SECTION("arc") {
@@ -362,9 +382,49 @@ TEST_CASE("Break bounded by real intersections still creates the remaining segme
         fixture.graphic.addEntity(new RS_Line{&fixture.graphic, RS_Vector{5.0, -12.0}, RS_Vector{5.0, 12.0}});
         RS_Arc arc{nullptr, RS_ArcData{RS_Vector{0.0, 0.0}, 10.0, 0.0, HALF_TURN, false}};
         RS_Vector snap{0.0, 10.0};
-        CHECK_FALSE(fixture.action->createEntitiesForArc(&arc, snap, list, false));
+        CHECK(fixture.action->createEntitiesForArc(&arc, snap, list, false)
+              == SegmentCreation::Segments);
         CHECK(list.size() == 2);
+        for (const RS_Entity* e: list) {
+            CHECK(e->getLength() > RS_TOLERANCE);
+            CHECK(e->getLength() < 2.0 * HALF_TURN * 10.0 - RS_TOLERANCE);
+        }
     }
 
     qDeleteAll(list);
+}
+
+TEST_CASE("a single tangency does not divide a circle",
+          "[lc_division][break_divide][whole_entity]") {
+    // One tangent line touches the circle at exactly one point. A closed curve
+    // with fewer than two distinct boundary points has no segments, so SHIFT
+    // whole-entity removal must work exactly as it does with no intersections.
+    RS_EntityContainer container;
+    container.addEntity(new RS_Line{&container, RS_Vector{10.0, -5.0}, RS_Vector{10.0, 5.0}});
+    LC_Division division{&container};
+    RS_Circle circle{nullptr, RS_CircleData{RS_Vector{0.0, 0.0}, 10.0}};
+
+    SECTION("whole-entity selection allowed: the circle itself is the segment") {
+        const std::unique_ptr<LC_Division::CircleSegmentData> data{
+            division.findCircleSegmentBetweenIntersections(&circle, RS_Vector{-10.0, 0.0}, true)};
+        REQUIRE(data != nullptr);
+        CHECK(data->segmentDisposition == LC_Division::SEGMENT_ENTIRE);
+    }
+
+    SECTION("divide mode: still nothing to split") {
+        const std::unique_ptr<LC_Division::CircleSegmentData> data{
+            division.findCircleSegmentBetweenIntersections(&circle, RS_Vector{-10.0, 0.0}, false)};
+        CHECK(data == nullptr);
+    }
+
+    SECTION("through the action: SHIFT removes the circle cleanly") {
+        BreakDivideFixture fixture{/*removeSelected=*/true};
+        fixture.graphic.addEntity(new RS_Line{&fixture.graphic, RS_Vector{10.0, -5.0}, RS_Vector{10.0, 5.0}});
+        QList<RS_Entity*> list;
+        RS_Vector snap{-10.0, 0.0};
+        CHECK(fixture.action->createEntitiesForCircle(&circle, snap, list, false)
+              == SegmentCreation::RemoveSource);
+        CHECK(list.isEmpty());
+        qDeleteAll(list);
+    }
 }

--- a/librecad/src/lib/modification/tests/lc_division_tests.cpp
+++ b/librecad/src/lib/modification/tests/lc_division_tests.cpp
@@ -1,0 +1,139 @@
+/****************************************************************************
+**
+** This file is part of the LibreCAD project, unit tests for LC_Division
+**
+** Copyright (C) 2026 LibreCAD.org
+** Copyright (C) 2026 Dongxu Li (github.com/dxli)
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+**********************************************************************/
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+
+#include "lc_division.h"
+#include "rs_arc.h"
+#include "rs_circle.h"
+#include "rs_entitycontainer.h"
+#include "rs_line.h"
+#include "rs_vector.h"
+
+namespace {
+
+constexpr double HALF_TURN = 3.14159265358979323846;
+
+void addEndpointCutters(RS_EntityContainer& container) {
+    container.addEntity(new RS_Line{&container, RS_Vector{0.0, -5.0}, RS_Vector{0.0, 5.0}});
+    container.addEntity(new RS_Line{&container, RS_Vector{10.0, -5.0}, RS_Vector{10.0, 5.0}});
+}
+
+void addArcEndpointCutters(RS_EntityContainer& container) {
+    container.addEntity(new RS_Line{&container, RS_Vector{-10.0, -5.0}, RS_Vector{-10.0, 5.0}});
+    container.addEntity(new RS_Line{&container, RS_Vector{10.0, -5.0}, RS_Vector{10.0, 5.0}});
+}
+
+} // namespace
+
+TEST_CASE("LC_Division identifies an unbounded selection as the whole entity",
+          "[lc_division][break_divide][whole_entity]") {
+    RS_EntityContainer emptyContainer;
+    LC_Division division{&emptyContainer};
+
+    SECTION("line") {
+        RS_Line line{nullptr, RS_Vector{0.0, 0.0}, RS_Vector{10.0, 0.0}};
+        const std::unique_ptr<LC_Division::LineSegmentData> data{
+            division.findLineSegmentBetweenIntersections(&line, RS_Vector{5.0, 0.0}, true)};
+
+        REQUIRE(data != nullptr);
+        CHECK(data->segmentDisposition == LC_Division::SEGMENT_ENTIRE);
+        CHECK(data->snapSegmentStart == line.getStartpoint());
+        CHECK(data->snapSegmentEnd == line.getEndpoint());
+    }
+
+    SECTION("arc") {
+        RS_Arc arc{nullptr, RS_ArcData{RS_Vector{0.0, 0.0}, 10.0, 0.0, HALF_TURN, false}};
+        const std::unique_ptr<LC_Division::ArcSegmentData> data{
+            division.findArcSegmentBetweenIntersections(&arc, RS_Vector{0.0, 10.0}, true)};
+
+        REQUIRE(data != nullptr);
+        CHECK(data->segmentDisposition == LC_Division::SEGMENT_ENTIRE);
+    }
+
+    SECTION("circle") {
+        RS_Circle circle{nullptr, RS_CircleData{RS_Vector{0.0, 0.0}, 10.0}};
+        const std::unique_ptr<LC_Division::CircleSegmentData> data{
+            division.findCircleSegmentBetweenIntersections(&circle, RS_Vector{10.0, 0.0}, true)};
+
+        REQUIRE(data != nullptr);
+        CHECK(data->segmentDisposition == LC_Division::SEGMENT_ENTIRE);
+    }
+}
+
+TEST_CASE("endpoint-only intersections do not masquerade as split boundaries",
+          "[lc_division][break_divide][whole_entity]") {
+    SECTION("line") {
+        RS_EntityContainer container;
+        addEndpointCutters(container);
+        LC_Division division{&container};
+        RS_Line line{nullptr, RS_Vector{0.0, 0.0}, RS_Vector{10.0, 0.0}};
+
+        const std::unique_ptr<LC_Division::LineSegmentData> data{
+            division.findLineSegmentBetweenIntersections(&line, RS_Vector{5.0, 0.0}, true)};
+
+        REQUIRE(data != nullptr);
+        CHECK(data->segmentDisposition == LC_Division::SEGMENT_ENTIRE);
+    }
+
+    SECTION("reversed arc") {
+        RS_EntityContainer container;
+        addArcEndpointCutters(container);
+        LC_Division division{&container};
+        RS_Arc arc{nullptr, RS_ArcData{RS_Vector{0.0, 0.0}, 10.0, 0.0, HALF_TURN, true}};
+
+        const std::unique_ptr<LC_Division::ArcSegmentData> data{
+            division.findArcSegmentBetweenIntersections(&arc, RS_Vector{0.0, -10.0}, true)};
+
+        REQUIRE(data != nullptr);
+        CHECK(data->segmentDisposition == LC_Division::SEGMENT_ENTIRE);
+    }
+}
+
+TEST_CASE("LC_Division keeps ordinary partial-segment behavior",
+          "[lc_division][break_divide]") {
+    SECTION("whole entity selection must be explicitly enabled") {
+        RS_EntityContainer emptyContainer;
+        LC_Division division{&emptyContainer};
+        RS_Line line{nullptr, RS_Vector{0.0, 0.0}, RS_Vector{10.0, 0.0}};
+
+        const std::unique_ptr<LC_Division::LineSegmentData> data{
+            division.findLineSegmentBetweenIntersections(&line, RS_Vector{5.0, 0.0}, false)};
+
+        CHECK(data == nullptr);
+    }
+
+    SECTION("an interior intersection still bounds a partial segment") {
+        RS_EntityContainer container;
+        container.addEntity(new RS_Line{&container, RS_Vector{5.0, -5.0}, RS_Vector{5.0, 5.0}});
+        LC_Division division{&container};
+        RS_Line line{nullptr, RS_Vector{0.0, 0.0}, RS_Vector{10.0, 0.0}};
+
+        const std::unique_ptr<LC_Division::LineSegmentData> data{
+            division.findLineSegmentBetweenIntersections(&line, RS_Vector{2.0, 0.0}, true)};
+
+        REQUIRE(data != nullptr);
+        CHECK(data->segmentDisposition == LC_Division::SEGMENT_TO_START);
+    }
+}


### PR DESCRIPTION
Fixes #2700 — SHIFT-clicking a standalone line in Break/Divide deletes it but leaves two points behind.

## Cause

`LC_Division::SegmentDisposition` can say the selected segment runs to the entity's start, to its end, or lies between two intersections. It cannot say **"the segment is the entire entity"** — which is exactly what SHIFT asks for. So the five branches that SHIFT enables report `SEGMENT_INSIDE` while handing back the entity's own endpoints:

```
lc_division.cpp:57    arc,    no intersections
lc_division.cpp:84    circle, no intersections
lc_division.cpp:112   line,   no intersections
lc_division.cpp:273   line,   intersections only on its own endpoints
lc_division.cpp:395   arc,    intersections only on its own endpoints
```

The action then computes the *remaining* segments as the complement of the selected one. For a whole-entity selection that complement is empty — but the code emits it anyway:

| | emitted | what the user sees |
| --- | --- | --- |
| line | `(start, start)` and `(end, end)` | two zero-length lines: the reported points, selectable by window drag |
| arc | two zero-sweep arcs | invisible leftovers that take a **full-circle** bounding box, since `RS_Math::isAngleBetween` is true when `angle1 == angle2` |
| circle | complement of `0..2π` is another full turn | delete appears to do nothing; the circle becomes a full-sweep arc |
| preview | same guards drive the markers and info cursor | SHIFT-hover paints and announces division points on the entity's own endpoints |

The last two rows are the same bug, not extras: one missing enum value, four symptoms.

## Fix

Add the missing value. The five branches report `SEGMENT_ENTIRE`, and each `createEntitiesForX` reads it once into a local that gates all five consumers — snap segment, remaining segments, preview markers, info cursor, trigger.

```diff
-        SEGMENT_TO_END // snap is between end point of entity and intersection point
+        SEGMENT_TO_END, // snap is between end point of entity and intersection point
+        SEGMENT_ENTIRE // the entire entity is the segment, it has no intersections outside its own endpoints
```

Every other disposition keeps its exact previous behaviour, so break/divide by intersections is unaffected by construction rather than by a tolerance test.

`CircleSegmentData` had no disposition field and gains one; the circle paths that don't set it are the ones bounded by intersections, hence the `SEGMENT_INSIDE` default. `ArcSegmentData::segmentDisposition` was an `int` while its two sibling structs used the enum — with a fourth value in play that inconsistency stops being cosmetic, so it becomes `SegmentDisposition` here.

**Why not detect it from geometry.** My first attempt guarded the emission sites with `isMeaningfulDistance` / `RS_ArcData::isValid()`. That proxy fails both ways: a **reversed** arc touched only at its endpoints yields two remainders that are exact copies of the arc — valid geometry no degeneracy test can reject — and the same test can fire on a segment that is *not* the whole entity, where treating it as a full removal drops real geometry. Only `LC_Division` knows which case it is.

**The trigger has to be told too.** `doCheckMayTrigger()` refuses an empty `entitiesToCreate`, and the entity is removed only inside `doTriggerEntitiesPrepare()`. Suppressing the segments alone turns the bug into *"SHIFT-click refuses and the line stays"*. So the three helpers **return** whether the entity was fully consumed, and the check accepts an empty list in that case only — a locked entity or a click on an endpoint still refuses. Returning it keeps those helpers `const` instead of having them reach back into the action to set a flag.

With **Remove selected** cleared, the answer is false, so SHIFT on a whole entity is a no-op rather than an identity delete-and-recreate.

**Blast radius.** `segmentDisposition` is written only in `lc_division.cpp` and read only in `lc_action_modify_break_divide.cpp`; no `switch` anywhere. The only other `LC_Division` consumer, `LC_ActionInteractivePickDistance` (`:123`, `:223`, which does pass `allowEntireLine=true`), contains zero occurrences of it — it reads only `snapSegmentStart`/`snapSegmentEnd`, unchanged here.

## Verification

Built with `-DBUILD_TESTS=ON` and driven headlessly through a Catch2 harness modelled on `librecad/src/lib/gui/tests/rs_graphicview_close_tests.cpp`, constructing a real `LC_ActionModifyBreakDivide`:

| case | before | after |
| --- | --- | --- |
| SHIFT-delete isolated line | 2 zero-length entities | 0 |
| SHIFT-click end-to-end (`doOnLeftMouseButtonRelease`) | line deleted, 2 points remain | line deleted, nothing remains |
| SHIFT-delete isolated arc | 2 zero-sweep arcs | 0 |
| SHIFT-delete isolated circle | full-turn arc | 0 |
| SHIFT-delete reversed arc touched only at endpoints | 2 duplicate copies | 0 |
| SHIFT-hover preview on whole entity | 2 spurious markers | 0 |
| ordinary divide, crossed line | 2 real remainders | unchanged |
| ordinary divide, crossed circle | 2 real arcs | unchanged |

8/8 pass; the last two exist to catch an over-broad fix.

### Committed coverage

`librecad/src/lib/modification/tests/lc_division_tests.cpp` pins both halves of the fix.

*Classification* — that `LC_Division` reports `SEGMENT_ENTIRE` from all five branches.

*Consumer* — that the action acts on it. Three `createEntitiesForX()` are driven through a
test-local subclass; a subclass is needed either way, because `m_alternativeActionMode` is the flag
SHIFT sets, it is `protected`, and it has no setter, so without it `allowEntire*` stays false and
`LC_Division` never returns a whole-entity segment. **No production code and no CMakeLists change** —
the cases are appended to the file this branch already adds and registers.

Teeth, measured rather than assumed:

| mutation | result |
| --- | --- |
| delete all three `SEGMENT_ENTIRE` guards | 7 assertions fail; bounded-break cases stay green |
| delete the line / circle / arc guard individually | 3 / 2 / 2 fail |
| revert `doCheckMayTrigger`'s acceptance of whole-entity removal | exactly 1 fails — the trigger-acceptance case |
| report removal despite **Remove selected** off, per entity kind | exactly 1 fails each — the line, circle, and arc keep-selected sections |
| accept the keep-selected no-op as a removal in `doCheckMayTrigger` | exactly 1 fails — the trigger keep-selected case |
| revert the tangent-circle gate to `empty()` | 2 fail — the tangency classification and its action-level case |

The removal-despite-keep rows are the data-loss class: they would delete the entity the user asked
to keep. Every row was rebuilt and run, not reasoned.

The trigger-path test reaches the protected `m_triggerData` through the test subclass via
`decltype` — the nested `TriggerData` type stays private and no production visibility changes.
`rs_graphicview_close_tests.cpp` now uses the same reuse-or-create `QApplication` form as the
other two test files: its old by-value static constructed a second instance whenever another file
created the application first (silently tolerated on release Qt, an abort on assert-enabled Qt).

Full suite: **13006 assertions in 743 test cases, exit status 0**, in default order and under
randomised orderings. Note `BUILD_TESTS` is off in CI, so this is developer-local coverage, not a
gate.

## Addressed after review

The later commits close what the deep review found: the trigger acceptance and all three
keep-selection guards are mutation-pinned; the keep-selected no-op reports through its own string
instead of `"Invalid entity selected"` (`createEntitiesForX` returns a three-value
`SegmentCreation`, since the bool could not distinguish the no-op from a genuine refusal); a circle
touched by a single tangency now takes the whole-entity branch — one boundary point divides a
closed curve no more than none does, and the gate counts *distinct* points because the solver may
report a tangency once or as two coincident points; the pre-existing `TriggerData` leak on a
refused click is fixed; bounded-break remainders are asserted to have nonzero extent (bounded above
too for arcs, since a zero-sweep arc reports a full-turn length); and the endpoint-only arc case
runs both orientations.

The final commit closes the hygiene items: `LC_Division::find*` return `std::unique_ptr` (the two
`lc_actioninteractivepickdistance.cpp` call sites drop their manual deletes; that action never reads
`segmentDisposition`, so it is unaffected by `SEGMENT_ENTIRE` by construction), the three
`createEntitiesForX` are `[[nodiscard]]` with explicit discards at the preview sites, the dead
`LineSegmentData::snap` field is gone, and the preview path is mutation-pinned - restricting the
guard to the trigger fails exactly the new whole-entity preview assertion.

## Merge note

Please do not squash: the commit history is what keeps the ~27 semantic lines findable in the
455-line anchor diff — fix, behavior-preserving restyle, and tests are separate commits.

## Deliberately not in this PR

Found while working here, all pre-existing and none needed for the fix — happy to send any as separate PRs:

- The whole-entity SHIFT preview shows only the hover highlight. That is accurate - the old markers
  announced division points that did not exist - but whether deletion deserves a stronger visual
  affordance is a design choice, left open.
- `RS_Settings::init` is not idempotent (a second call leaks and swaps the singleton). Benign today;
  production infrastructure beyond this change's subject.

Note on the `QApplication` obstacle mentioned in earlier discussion: the trigger is not a second
`QApplication`-using file, and not a second `QApplication` being *constructed* — it is a second
`~QApplication` *running* at exit. `rs_graphicview_close_tests.cpp:43` holds a by-value static and
therefore owns the one destructor this process gets. A new file that reuses-or-heap-allocates and
never deletes is safe, which is what the tests here do; three such files now coexist at exit 0.

