### PR TITLE
2.2.1: load and save LFF glyph codes over the full Unicode range

### DIFF
--- a/.github/ci-trigger-pr-2729.txt
+++ b/.github/ci-trigger-pr-2729.txt
@@ -1,0 +1,6 @@
+CI trigger for PR #2729
+
+This file was created by GitHub Copilot to trigger CI build jobs for testing the PR:
+https://github.com/LibreCAD/LibreCAD/pull/2729
+
+Timestamp: 2026-08-05T00:00:00Z

--- a/librecad/src/lib/engine/rs_font.cpp
+++ b/librecad/src/lib/engine/rs_font.cpp
@@ -26,7 +26,11 @@
 
 
 
+#include <cstdint>
 #include <iostream>
+#include <utility>
+
+#include <QRegularExpression>
 #include <QTextStream>
 #include <QTextCodec>
 
@@ -38,6 +42,41 @@
 #include "rs_system.h"
 #include "rs_math.h"
 #include "rs_debug.h"
+
+namespace {
+    // Encode a unicode character from its hexdecimal string
+    // "0x20" is encoded to the character '0'
+    QString charFromHex(const QString& hexCode) {
+        bool okay = false;
+        const char32_t ucsCode = hexCode.toUInt(&okay, 16);
+        //  REPLACEMENT CHARACTER for unicode
+        constexpr char32_t invalidCode = 0xFFFD;
+        return (okay) ? QString::fromUcs4(&ucsCode, 1) : QString::fromUcs4(&invalidCode, 1);
+    }
+
+    // Extract the unicode char from LFF font line, e.g. "[0041]" or "[#0041]"
+    // (the '#' is optional, so files written by either convention load the same way).
+    // Up to 6 hex digits so the full Unicode range (to U+10FFFF) is accepted.
+    std::pair<QString, bool> extractFontChar(const QString& line) {
+        // read unicode:
+        static QRegularExpression regexp("^\\[#?([0-9A-Fa-f]{1,6})\\]");
+        const QRegularExpressionMatch match = regexp.match(line);
+        if (!match.hasMatch()) {
+            return {};
+        }
+
+        const QString cap = match.captured(1);
+        bool okay = false;
+        const std::uint32_t code = cap.toUInt(&okay, 16);
+
+        if (!okay) {
+            LC_ERR << __func__ << "() line " << __LINE__ << ": invalid font code in " << line;
+            return {};
+        }
+        const char32_t ucsCode{static_cast<char32_t>(code)};
+        return {QString::fromUcs4(&ucsCode, 1), true};
+    }
+}
 
 /**
  * Constructor.
@@ -328,18 +367,9 @@ void RS_Font::readLFF(QString path) {
         else if (line.at(0)=='[') {
 
             // uniode character:
-            QChar ch;
-
-            // read unicode:
-            QRegExp regexp("[0-9A-Fa-f]{1,5}");
-            regexp.indexIn(line);
-            QString cap = regexp.cap();
-            if (!cap.isNull()) {
-				int uCode = cap.toInt(nullptr, 16);
-                ch = QChar(uCode);
-            }
+            const auto [ch, okay] = extractFontChar(line);
             // only unicode allowed
-            else {
+            if (!okay) {
                 LC_LOG(RS_Debug::D_WARNING)<<"Ignoring code from LFF font file: "<<line;
                 continue;
             }
@@ -350,9 +380,9 @@ void RS_Font::readLFF(QString path) {
                 if(line.isEmpty()) break;
                 fontData.push_back(line);
             } while(true);
-            if (0 < fontData.size()                             // valid data
-                && !rawLffFontList.contains( QString(ch))) {    // ignore duplicates
-                rawLffFontList[QString(ch)] = fontData;
+            if (0 < fontData.size()                  // valid data
+                && !rawLffFontList.contains(ch)) {   // ignore duplicates
+                rawLffFontList[ch] = fontData;
             }
         }
     }
@@ -372,7 +402,7 @@ RS_Block* RS_Font::generateLffFont(const QString& key){
         return nullptr;
 
     if (!rawLffFontList.contains( key)) {
-        LC_ERR<<QString{"RS_Font::generateLffFont([%1]): can not find the letter in LFF file "}.arg(QChar(key.front())) << fileName;
+        LC_ERR<<QString{"RS_Font::generateLffFont([%1]): can not find the letter in LFF file "}.arg(key) << fileName;
         return nullptr;
     }
 
@@ -395,9 +425,9 @@ RS_Block* RS_Font::generateLffFont(const QString& key){
         // Defined char:
         if (line.at(0)=='C') {
             line.remove(0,1);
-			int uCode = line.toInt(nullptr, 16);
-            QChar ch = QChar(uCode);
-            if (QString(ch) == key) {   // recursion, a character can't include itself
+            const uint uCode = line.toUInt(nullptr, 16);
+            const QString ch = charFromHex(line);
+            if (ch == key) {   // recursion, a character can't include itself
                 LC_ERR<<QString{"RS_Font::generateLffFont([%1]) : recursion, ignore this character from "}.arg(uCode, 4, 16)<<fileName;
                 delete letter;
                 return nullptr;
@@ -406,7 +436,7 @@ RS_Block* RS_Font::generateLffFont(const QString& key){
             RS_Block* bk = letterList.find(ch);
             if (nullptr == bk) {
                 if (!rawLffFontList.contains(ch)) {
-                LC_ERR<<QString{"RS_Font::generateLffFont([%1]) : can not find the letter %2 in LFF file "}.arg(uCode, 4, 16).arg(QChar(key.front()))<<fileName;
+                LC_ERR<<QString{"RS_Font::generateLffFont([%1]) : can not find the letter %2 in LFF file "}.arg(uCode, 4, 16).arg(key)<<fileName;
                     delete letter;
                     return nullptr;
                 }

--- a/librecad/src/lib/filters/rs_filterlff.cpp
+++ b/librecad/src/lib/filters/rs_filterlff.cpp
@@ -92,7 +92,8 @@ bool RS_FilterLFF::fileImport(RS_Graphic& g, const QString& file, RS2::FormatTyp
         RS_Block* ch = font.letterAt(i);
 
         QString uCode;
-        uCode.setNum(ch->getName().at(0).unicode(), 16);
+        // the letter name is a full code point, which is a surrogate pair above U+FFFF
+        uCode.setNum(ch->getName().toUcs4().value(0), 16);
         while (uCode.length()<4) {
 //            uCode.rightJustified(4, '0');
             uCode="0"+uCode;
@@ -100,7 +101,7 @@ bool RS_FilterLFF::fileImport(RS_Graphic& g, const QString& file, RS2::FormatTyp
         //ch->setName("[" + uCode + "] " + ch->getName());
         //letterList->rename(ch, QString("[%1]").arg(ch->getName()));
         letterList->rename(ch,
-                           QString("[%1] %2").arg(uCode).arg(ch->getName().at(0)));
+                           QString("[%1] %2").arg(uCode).arg(ch->getName()));
 
         g.addBlock(ch, false);
         ch->reparent(&g);
@@ -228,7 +229,7 @@ bool RS_FilterLFF::fileExport(RS_Graphic& g, const QString& file, RS2::FormatTyp
                         else if (e->rtti()==RS2::EntityBlock) {
                             RS_Block* b = (RS_Block*)e;
                             QString uCode;
-                            uCode.setNum(b->getName().at(0).unicode(), 16);
+                            uCode.setNum(b->getName().toUcs4().value(0), 16);
                             if (uCode.length()<4) {
                                 uCode = uCode.rightJustified(4, '0');
                             }

--- a/librecad/src/main/qc_mdiwindow.cpp
+++ b/librecad/src/main/qc_mdiwindow.cpp
@@ -384,7 +384,11 @@ void QC_MDIWindow::drawChars() {
         RS_Insert* in = new RS_Insert(document, data);
         document->addEntity(in);
         QFileInfo info(document->getFilename() );
-        QString uCode = (ch->getName()).mid(1,4);
+        // the code is "[hhhh]", but a code point above U+FFFF needs 5 or 6 digits
+        const QString chName = ch->getName();
+        const int closingBracket = chName.indexOf(']');
+        QString uCode = (chName.startsWith('[') && closingBracket > 1)
+                        ? chName.mid(1, closingBracket - 1) : chName;
         RS_MTextData datatx(RS_Vector(i*sep,-h), h, 4*h, RS_MTextData::VATop,
                            RS_MTextData::HALeft, RS_MTextData::ByStyle, RS_MTextData::AtLeast,
                            1, uCode, "standard", 0);


### PR DESCRIPTION
Targets **2.2.1**. Makes the LFF reader load glyph codes over the full Unicode range, so
the CJK fonts in #2713 work on the stable branch, and fixes the export path that the
widened keys expose.

Not a cherry-pick of #2711 — `rs_font.cpp` has moved on master and `rs_filterlff.cpp`
conflicts textually, so the change is hand-ported to 2.2.1's Qt5 code.

## What was actually broken

Worth stating plainly, because it is not what #2711's title suggests: **the four spellings
`[20]` / `[#20]` / `[0020]` / `[#0020]` already load identically on 2.2.1.**
`rs_font.cpp:335` uses `QRegExp("[0-9A-Fa-f]{1,5}")` with `indexIn()`, an *unanchored*
search, so the `#` and any leading zeros are simply skipped. That works by accident rather
than by design.

The real defect is one line further down — `QChar(uCode)` at `rs_font.cpp:339`. `QChar` is
16 bits, so any code point above U+FFFF is **truncated**, and the truncated value becomes
the font's key. The three fonts in #2713 hold 2,399 supplementary-plane glyphs (up to
U+3106C), and this does not merely drop them — it installs them at unrelated BMP code
points.

`noto-sans-sc.lff` defines `[#3106c]` and does not define `[#106c]`. `0x3106C & 0xFFFF ==
0x106C`, so on 2.2.1 today that CJK ideograph is registered as U+106C, and any drawing
using U+106C renders it.

| font | supplementary glyphs | landing on BMP slots the font does not define |
|---|---|---|
| noto-sans-sc | 445 | 401 |
| noto-sans-tc | 1,948 | 1,300 |
| wqy-microhei | 6 | 0 |

**1,701 BMP code points across the three fonts would render a wrong glyph.**

## 1. Reader — full Unicode range

`librecad/src/lib/engine/rs_font.cpp`, +49 −19: master's `charFromHex()` and
`extractFontChar()` helpers, hand-ported. The parse becomes an anchored
`^\[#?([0-9A-Fa-f]{1,6})\]` and characters are built with `QString::fromUcs4` instead of
`QChar`. The `C<hex>` reference branch in `generateLffFont()` gets the same treatment.

Both APIs exist in Qt 5.15, so nothing inside the changed region needed adapting; 2.2.1's
`QRegExp` in `readCXF` and its `QTextCodec` usage are untouched.

Side benefit of anchoring: 6-digit zero-padded codes such as `[#03106C]` now parse, where
the old `{1,5}` capture greedily took `03106` and silently produced U+3106.

## 2. Export — name letter blocks by code point

The widened keys expose a latent defect in the LFF filter. `RS_Font` now keys letters by a
two-code-unit QString above U+FFFF, but `rs_filterlff.cpp:95/103/231` and
`qc_mdiwindow.cpp:387` read only the first code unit — the **high surrogate**. Since
`fileExport` writes the block name back verbatim, every letter sharing a high surrogate
asks for the same name, `RS_BlockList::rename` is a silent no-op on collision, and the
losers get written **without brackets**, which `readLFF` then skips.

Import/export round trip of a font with `[#41] [#20000] [#20001] [#3106c]`:

```
reader fix only:  [0041] A   [d840] ?   𠀁 (no brackets)   [d884] ?
with this fix:    [0041] A   [20000] 𠀀  [20001] 𠀁          [3106c] 𱁬
```

Stock 2.2.1 is corrupt here too — it relocates the glyph to a truncated BMP code and can
write a literal NUL — so supplementary characters have never survived an LFF save. But the
failure mode without this hunk is a **structurally malformed file**, which is worse on a
stable branch, so it is fixed here rather than left.

Below U+FFFF the existing zero-padding makes the output **byte for byte identical** —
verified with `cmp` on a full `standard.lff` round trip (220 glyph headers).

The same defect exists on master; **#2730** carries the identical fix there so the branches
do not diverge.

## Verification

Built against Qt 5.15.19 with 2.2.1's own CMake config, then linked a harness against the
437 real librecad objects so it drives the actual `RS_Font` and `RS_FilterLFF`. Built
twice, differing only in the changed objects:

| font | letters before → after | supplementary-named blocks before → after |
|---|---|---|
| noto-sans-sc | 30,842 → **30,886** | 0 → **445** |
| noto-sans-tc | 20,093 → **20,741** | 0 → **1,948** |
| wqy-microhei | 34,552 → **34,558** | 0 → **6** |

`findLetter(U+3106C)`: not present → **FOUND** (sc and tc). `findLetter(U+1D30C)`: not
present → **FOUND** (wqy).

**No regression on the 46 shipped fonts:** every one of their 33,231 glyph headers is plain
`[hhhh]` and every `C` reference is 4 digits; a 33,276-line dump of every generated letter
(name, recursive entity count, coordinate digest) is byte-identical before and after.

## Scope notes

* **This does not make supplementary-plane characters render.** `RS_Text::update()` and
  `RS_MText::addLetter()` iterate per UTF-16 code unit and look the font up one `QChar` at
  a time, so a surrogate pair still falls back to U+FFFD. Master has the identical
  limitation. What changes here is that the glyphs load and save under their true code
  point and stop corrupting unrelated BMP characters.
* **`tools/ttf2lff` is deliberately not updated.** An earlier revision of this PR copied
  master's version; it turns out not to be needed — 2.2.1's own tool already emits
  full-range codes, because `main.cpp:234` uses `"[#%04X]"` and `%04X` is a *minimum* field
  width, so U+10100 has always printed as `10100`. Converting the same TTF with either tool
  yields identical `[#1xxxx]` headers, and the patched reader loads both with an identical
  key set. Updating the tool would also have pulled in ~1,600 lines from two unrelated PRs
  and a calibration pass that is gated on opening `/dev/null`, which silently mirrors every
  glyph where that path is unavailable.
* `rs_filtercxf.cpp` and `readCXF` are a different format and are untouched.
* The font files themselves are #2713's job.
