### PR TITLE
Name LFF letter blocks by code point, not by UTF-16 code unit

### DIFF
--- a/librecad/src/lib/filters/rs_filterlff.cpp
+++ b/librecad/src/lib/filters/rs_filterlff.cpp
@@ -103,14 +103,15 @@ bool RS_FilterLFF::fileImport(RS_Graphic& g, const QString& file, RS2::FormatTyp
         RS_Block* ch = font.letterAt(i);
 
         QString uCode;
-        uCode.setNum(ch->getName().at(0).unicode(), 16);
+        // the letter name is a full code point, which is a surrogate pair above U+FFFF
+        uCode.setNum(ch->getName().toUcs4().value(0), 16);
         while (uCode.length() < 4) {
             //            uCode.rightJustified(4, '0');
             uCode = "0" + uCode;
         }
         //ch->setName("[" + uCode + "] " + ch->getName());
         //letterList->rename(ch, QString("[%1]").arg(ch->getName()));
-        letterList->rename(ch, QString("[%1] %2").arg(uCode).arg(ch->getName().at(0)));
+        letterList->rename(ch, QString("[%1] %2").arg(uCode).arg(ch->getName()));
 
         g.addBlock(ch, false);
         ch->reparent(&g);
@@ -243,7 +244,7 @@ bool RS_FilterLFF::fileExport(RS_Graphic& g, const QString& file, RS2::FormatTyp
                             // Reference codes are written compactly too; leading zeros
                             // are optional and the reader parses any width.
                             QString uCode;
-                            uCode.setNum(b->getName().at(0).unicode(), 16);
+                            uCode.setNum(b->getName().toUcs4().value(0), 16);
                             ts << QString("C%1\n").arg(uCode);
                         }
                         else if (e->rtti() == RS2::EntityPolyline) {

--- a/librecad/src/ui/main/fontviewer/lc_fontfileviewer.cpp
+++ b/librecad/src/ui/main/fontviewer/lc_fontfileviewer.cpp
@@ -67,7 +67,11 @@ void LC_FontFileViewer::drawFontChars() const {
         currentLetterX += maxLetterWidth + sep;
         const auto in = new RS_Insert(m_document, data);
         m_document->addEntity(in);
-        QString uCode = ch->getName().mid(1,4);
+        // the code is "[hhhh]", but a code point above U+FFFF needs 5 or 6 digits
+        const QString chName = ch->getName();
+        const int closingBracket = chName.indexOf(']');
+        QString uCode = (chName.startsWith('[') && closingBracket > 1)
+                        ? chName.mid(1, closingBracket - 1) : chName;
         RS_MTextData datatx(RS_Vector(currentColumn*sep,currentLetterY-h), h, 4*h, RS_MTextData::VATop,
                            RS_MTextData::HALeft, RS_MTextData::ByStyle, RS_MTextData::AtLeast,
                            1, uCode, "standard", 0);


### PR DESCRIPTION
Saving an LFF font that contains characters above U+FFFF drops those glyphs and
produces a file the reader can no longer parse.

## Cause

`RS_Font` keys its letters by the character itself, which for a code point above
U+FFFF is a two-code-unit QString (a UTF-16 surrogate pair). Three places still read
only the first code unit — the **high surrogate**:

```
librecad/src/lib/filters/rs_filterlff.cpp:106   uCode.setNum(ch->getName().at(0).unicode(), 16);
librecad/src/lib/filters/rs_filterlff.cpp:113   .arg(uCode).arg(ch->getName().at(0))
librecad/src/lib/filters/rs_filterlff.cpp:246   uCode.setNum(b->getName().at(0).unicode(), 16);
librecad/src/ui/main/fontviewer/lc_fontfileviewer.cpp:70   QString uCode = ch->getName().mid(1,4);
```

`fileImport` renames each letter block to `[<code>] <char>`, and `fileExport` writes
that block name back out verbatim. So every letter sharing a high surrogate — one per
1024 code points — asks for the *same* block name. `RS_BlockList::rename` is a silent
no-op when the name is taken, so the losers keep their raw name and are then written
as a **bracket-less** line, which `readLFF` skips on the way back in.

The winners are not much better: the name holds a lone surrogate, which cannot be
encoded in UTF-8, so `QTextStream` substitutes `?`.

## Reproduction

Import/export round trip of a font with `[#41]`, `[#20000]`, `[#20001]`, `[#3106c]`:

```
before:  [0041] A     [d840] ?     𠀁 (no brackets)     [d884] ?
after:   [0041] A     [20000] 𠀀   [20001] 𠀁            [3106c] 𱁬
```

Four of the five blocks written before, five after — and three of the four carried the
wrong code point.

## Fix

Take the whole code point via `toUcs4().value(0)`, and use the whole name for the
display character. The existing zero-padding loop still applies below U+FFFF, so a font
with no supplementary characters exports **byte for byte** as before — verified on
`standard.lff` (220 glyph headers, `cmp` clean). The reader's
`^\[#?([0-9A-Fa-f]{1,6})\]` already accepts the 5- and 6-digit codes this can now
produce.

The font viewer's fixed `mid(1,4)` slice is widened to read up to the closing bracket
for the same reason.

Builds clean; found while backporting the LFF reader fix to 2.2.1
(LibreCAD/LibreCAD#2729), which carries the identical change so the branches do not
diverge.
