### PR TITLE
Show hatch moments at 8 significant digits, and show all of them

### DIFF
--- a/librecad/src/lib/engine/document/entities/tests/rs_hatch_tests.cpp
+++ b/librecad/src/lib/engine/document/entities/tests/rs_hatch_tests.cpp
@@ -37,11 +37,15 @@
 #include <iostream>
 #include <map>
 
+#include <QApplication>
 #include <QCoreApplication>
+#include <QLayout>
+#include <QLineEdit>
 
 #include "drw_entities.h"
 #include "lc_containertraverser.h"
 #include "lc_graphicviewport.h"
+#include "lc_hatchpropertieseditingwidget.h"
 #include "lc_looputils.h"
 #include "lc_secondmoment.h"
 #include "lc_splinepoints.h"
@@ -1350,4 +1354,98 @@ TEST_CASE("RS_Hatch snap - getNearestPointOnEntity inside solid fill terminates"
     // Calling directly on the hatch must likewise terminate.
     RS_Vector pHatch = hatch->getNearestPointOnEntity(insideFill, true, nullptr, nullptr);
     CHECK_FALSE(pHatch.valid);
+}
+
+namespace {
+
+/**
+ * Reuse the process-wide QApplication if some other test already built one,
+ * otherwise create it. Widgets need QApplication, not just QCoreApplication.
+ */
+QApplication& widgetApplication()
+{
+    static int argc = 1;
+    static char name[] = "librecad-tests";
+    static char* argv[] = {name, nullptr};
+    static QApplication* app = [] {
+        auto* existing = qobject_cast<QApplication*>(QCoreApplication::instance());
+        return existing ? existing : new QApplication(argc, argv);
+    }();
+    static bool settingsReady = [] {
+        QCoreApplication::setOrganizationName("LibreCAD");
+        QCoreApplication::setApplicationName("LibreCAD-tests");
+        RS_Settings::init("LibreCAD", "LibreCAD-tests");
+        return true;
+    }();
+    (void)settingsReady;
+    return *app;
+}
+
+//! Significant digits in a 'g'-formatted number, ignoring sign, point and exponent.
+int significantDigits(const QString& text)
+{
+    const QString mantissa = text.section('e', 0, 0);
+    int digits = 0;
+    bool seenNonZero = false;
+    for (const QChar c: mantissa) {
+        if (!c.isDigit())
+            continue;
+        if (c != QLatin1Char('0'))
+            seenNonZero = true;
+        if (seenNonZero)
+            ++digits;
+    }
+    return digits;
+}
+
+} // namespace
+
+TEST_CASE("LC_HatchPropertiesEditingWidget shows 8 significant digits, fully visible",
+          "[hatch][properties][widget]")
+{
+    widgetApplication();
+
+    // Deliberately awkward extents: the area and the moments then need far more
+    // than eight digits to write out in full, and the moments reach ~1e12.
+    std::unique_ptr<RS_Hatch> hatch{makeRectHatch(123.456789012, 234.567890123,
+                                                  2345.678901234, 3456.789012345)};
+    REQUIRE(hatch->getTotalArea() > 0.0);
+
+    LC_GraphicViewport viewport;
+    LC_HatchPropertiesEditingWidget widget;
+    widget.setGraphicViewport(&viewport);
+    widget.setEntity(hatch.get());
+
+    const QStringList valueFieldNames{
+        QStringLiteral("leScale"), QStringLiteral("leAngle"),
+        QStringLiteral("leArea"), QStringLiteral("leCentroidX"), QStringLiteral("leCentroidY"),
+        QStringLiteral("leIxx"), QStringLiteral("leIyy"), QStringLiteral("leIxy"),
+        QStringLiteral("leI1"), QStringLiteral("leI2"), QStringLiteral("lePrincipalAngle")};
+
+    // Squeeze the widget well below its preferred width. Only a minimum width
+    // that accounts for the text keeps the fields from being shrunk to nothing,
+    // which is exactly what left the moments clipped in the dialog.
+    widget.resize(200, widget.sizeHint().height());
+    widget.layout()->activate();
+
+    for (const QString& name: valueFieldNames) {
+        auto* ed = widget.findChild<QLineEdit*>(name);
+        INFO("field " << name.toStdString());
+        REQUIRE(ed != nullptr);
+
+        const QString text = ed->text();
+        REQUIRE_FALSE(text.isEmpty());
+
+        // 1. never more than eight significant digits
+        INFO("text " << text.toStdString());
+        CHECK(significantDigits(text) <= 8);
+
+        // 2. the whole value fits, even with the layout squeezed
+        const int textWidth = ed->fontMetrics().horizontalAdvance(text);
+        CHECK(ed->width() >= textWidth);
+        CHECK(ed->minimumWidth() >= textWidth);
+
+        // and it is scrolled to the front, so the leading digits are the visible ones
+        CHECK(ed->cursorPosition() == 0);
+    }
 }

--- a/librecad/src/lib/engine/document/entities/tests/rs_hatch_tests.cpp
+++ b/librecad/src/lib/engine/document/entities/tests/rs_hatch_tests.cpp
@@ -40,6 +40,7 @@
 #include <QApplication>
 #include <QCoreApplication>
 #include <QLayout>
+#include <QFont>
 #include <QLineEdit>
 
 #include "drw_entities.h"
@@ -1440,12 +1441,37 @@ TEST_CASE("LC_HatchPropertiesEditingWidget shows 8 significant digits, fully vis
         INFO("text " << text.toStdString());
         CHECK(significantDigits(text) <= 8);
 
-        // 2. the whole value fits, even with the layout squeezed
-        const int textWidth = ed->fontMetrics().horizontalAdvance(text);
-        CHECK(ed->width() >= textWidth);
-        CHECK(ed->minimumWidth() >= textWidth);
+        // 2. the whole value fits, even with the layout squeezed. The frame and
+        // the text margins are not usable width, so discount them: Qt's own
+        // sizeHint is 17 'x' advances of text plus exactly that overhead.
+        const QFontMetrics fm = ed->fontMetrics();
+        const int overhead = ed->sizeHint().width() - 17 * fm.horizontalAdvance(QLatin1Char('x'));
+        const int textWidth = fm.horizontalAdvance(text);
+        CHECK(ed->width() - overhead >= textWidth);
+        CHECK(ed->minimumWidth() - overhead >= textWidth);
 
         // and it is scrolled to the front, so the leading digits are the visible ones
         CHECK(ed->cursorPosition() == 0);
     }
+
+    // The fields must also hold the widest string 8 'g' digits can produce, not
+    // merely the values this particular hatch happened to yield.
+    auto* widest = widget.findChild<QLineEdit*>(QStringLiteral("leIxx"));
+    REQUIRE(widest != nullptr);
+    widest->setText(QStringLiteral("-1.2345678e-308"));
+    widget.layout()->activate();
+    const QFontMetrics fm = widest->fontMetrics();
+    const int overhead = widest->sizeHint().width() - 17 * fm.horizontalAdvance(QLatin1Char('x'));
+    CHECK(widest->width() - overhead >= fm.horizontalAdvance(widest->text()));
+
+    // The widths are in font units, so they must follow the font. Nothing changes
+    // the font under the dialog today, but the widget should not quietly depend
+    // on that: it is built before it is ever shown.
+    QFont bigger = widget.font();
+    bigger.setPointSize(bigger.pointSize() * 2);
+    widget.setFont(bigger);
+    widget.layout()->activate();
+    const QFontMetrics bigFm = widest->fontMetrics();
+    const int bigOverhead = widest->sizeHint().width() - 17 * bigFm.horizontalAdvance(QLatin1Char('x'));
+    CHECK(widest->minimumWidth() - bigOverhead >= bigFm.horizontalAdvance(widest->text()));
 }

--- a/librecad/src/ui/dialogs/entity/lc_hatchpropertieseditingwidget.cpp
+++ b/librecad/src/ui/dialogs/entity/lc_hatchpropertieseditingwidget.cpp
@@ -26,6 +26,7 @@
 #include <array>
 #include <cmath>
 
+#include <QEvent>
 #include <QFontMetrics>
 #include <QLineEdit>
 
@@ -43,7 +44,7 @@ namespace {
      * Widest text QString::number(v, 'g', g_precision) can produce: sign, leading
      * digit, decimal point, g_precision-1 further digits and a three digit exponent.
      */
-    const QString g_widestValue = QStringLiteral("-1.2345678e-308");
+    constexpr auto g_widestValue = QLatin1StringView("-1.2345678e-308");
 
     //! Every field of the widget that shows a value.
     std::array<QLineEdit*, 13> valueFields(Ui::LC_HatchPropertiesEditingWidget* ui) {
@@ -73,11 +74,18 @@ LC_HatchPropertiesEditingWidget::LC_HatchPropertiesEditingWidget(QWidget *parent
  * extra character widths stand in for the frame and the text margins.
  */
 void LC_HatchPropertiesEditingWidget::setupValueFields() {
-    const QFontMetrics fm = ui->leArea->fontMetrics();
-    const int valueWidth = fm.horizontalAdvance(g_widestValue) + 2 * fm.horizontalAdvance(QLatin1Char('0'));
-
     for (QLineEdit* ed: valueFields(ui)) {
-        ed->setMinimumWidth(valueWidth);
+        const QFontMetrics fm = ed->fontMetrics();
+        ed->setMinimumWidth(fm.horizontalAdvance(g_widestValue)
+                            + 2 * fm.horizontalAdvance(QLatin1Char('0')));
+    }
+}
+
+//! The widths above are in font units, so they have to be redone when the font changes.
+void LC_HatchPropertiesEditingWidget::changeEvent(QEvent* event) {
+    LC_EntityPropertiesEditorWidget::changeEvent(event);
+    if (event->type() == QEvent::FontChange) {
+        setupValueFields();
     }
 }
 

--- a/librecad/src/ui/dialogs/entity/lc_hatchpropertieseditingwidget.cpp
+++ b/librecad/src/ui/dialogs/entity/lc_hatchpropertieseditingwidget.cpp
@@ -23,21 +23,83 @@
 
 #include "lc_hatchpropertieseditingwidget.h"
 
+#include <array>
 #include <cmath>
 
+#include <QFontMetrics>
+#include <QLineEdit>
+
+#include "lc_convert.h"
 #include "lc_secondmoment.h"
 #include "rs_hatch.h"
 #include "rs_settings.h"
 #include "ui_lc_hatchpropertieseditingwidget.h"
+
+namespace {
+    //! Significant digits shown for every numeric field of this widget.
+    constexpr int g_precision = 8;
+
+    /**
+     * Widest text QString::number(v, 'g', g_precision) can produce: sign, leading
+     * digit, decimal point, g_precision-1 further digits and a three digit exponent.
+     */
+    const QString g_widestValue = QStringLiteral("-1.2345678e-308");
+
+    //! Every field of the widget that shows a value.
+    std::array<QLineEdit*, 13> valueFields(Ui::LC_HatchPropertiesEditingWidget* ui) {
+        return {ui->lePattern, ui->leScale, ui->leAngle,
+                ui->leArea, ui->leCentroidX, ui->leCentroidY,
+                ui->leIxx, ui->leIyy, ui->leIxy,
+                ui->leI1, ui->leI2, ui->lePrincipalAngle, ui->leDegenerate};
+    }
+}
 
 LC_HatchPropertiesEditingWidget::LC_HatchPropertiesEditingWidget(QWidget *parent)
     : LC_EntityPropertiesEditorWidget(parent)
     , ui(new Ui::LC_HatchPropertiesEditingWidget) {
     ui->setupUi(this);
 
+    setupValueFields();
+
     connect(ui->leScale, &QLineEdit::editingFinished, this, &LC_HatchPropertiesEditingWidget::onScaleEditingFinished);
     connect(ui->leAngle, &QLineEdit::editingFinished, this, &LC_HatchPropertiesEditingWidget::onAngleEditingFinished);
     connect(ui->cbSolid, &QCheckBox::toggled, this, &LC_HatchPropertiesEditingWidget::onSolidToggled);
+}
+
+/**
+ * The moments span many orders of magnitude, so the value fields have to be wide
+ * enough for the longest string g_precision digits can produce. Sizing from the
+ * font rather than from a pixel constant keeps this correct at any DPI. The two
+ * extra character widths stand in for the frame and the text margins.
+ */
+void LC_HatchPropertiesEditingWidget::setupValueFields() {
+    const QFontMetrics fm = ui->leArea->fontMetrics();
+    const int valueWidth = fm.horizontalAdvance(g_widestValue) + 2 * fm.horizontalAdvance(QLatin1Char('0'));
+
+    for (QLineEdit* ed: valueFields(ui)) {
+        ed->setMinimumWidth(valueWidth);
+    }
+}
+
+/**
+ * A QLineEdit keeps whatever scroll position it had, so a field that was once too
+ * narrow shows the tail of the number. Rewind every field so the most significant
+ * digits are the ones on screen.
+ */
+void LC_HatchPropertiesEditingWidget::showValueStarts() {
+    for (QLineEdit* ed: valueFields(ui)) {
+        ed->setCursorPosition(0);
+    }
+}
+
+//! Like toUIValue(), but at this widget's precision instead of the shared default.
+void LC_HatchPropertiesEditingWidget::setValue(double value, QLineEdit* ed) const {
+    ed->setText(LC_Convert::asString(value, g_precision));
+}
+
+//! Like toUIAngleDeg(), but at this widget's precision instead of the shared default.
+void LC_HatchPropertiesEditingWidget::setAngle(double wcsAngle, QLineEdit* ed) const {
+    ed->setText(LC_Convert::asStringAngleDeg(toUCSAngle(wcsAngle), g_precision));
 }
 
 LC_HatchPropertiesEditingWidget::~LC_HatchPropertiesEditingWidget() {
@@ -50,10 +112,11 @@ void LC_HatchPropertiesEditingWidget::setEntity(RS_Entity* entity) {
     LC_GROUP_GUARD("Draw");
     toUIBool(m_entity->isSolid(), ui->cbSolid);
     ui->lePattern->setText(m_entity->getPattern());
-    toUIValue(m_entity->getScale(), ui->leScale);
-    toUIAngleDeg(m_entity->getAngle(), ui->leAngle);
+    setValue(m_entity->getScale(), ui->leScale);
+    setAngle(m_entity->getAngle(), ui->leAngle);
 
     updateMomentFields();
+    showValueStarts();
 }
 
 void LC_HatchPropertiesEditingWidget::saveSettings() {
@@ -66,11 +129,13 @@ void LC_HatchPropertiesEditingWidget::saveSettings() {
 
 void LC_HatchPropertiesEditingWidget::updateMomentFields() {
     double area = m_entity->getTotalArea();
-    toUIValue(area, ui->leArea);
+    setValue(area, ui->leArea);
 
     RS_Vector centroid = m_entity->getCentroid();
     if (centroid.valid) {
-        toUI(centroid, ui->leCentroidX, ui->leCentroidY);
+        const RS_Vector ucsCentroid = toUCSVector(centroid);
+        setValue(ucsCentroid.x, ui->leCentroidX);
+        setValue(ucsCentroid.y, ui->leCentroidY);
     } else {
         ui->leCentroidX->setText(tr("N/A"));
         ui->leCentroidY->setText(tr("N/A"));
@@ -79,9 +144,9 @@ void LC_HatchPropertiesEditingWidget::updateMomentFields() {
     LC_SecondMoment m = m_entity->getMomentOfInertia();
 
     // Raw central moments
-    toUIValue(m.ixx, ui->leIxx);
-    toUIValue(m.iyy, ui->leIyy);
-    toUIValue(m.ixy, ui->leIxy);
+    setValue(m.ixx, ui->leIxx);
+    setValue(m.iyy, ui->leIyy);
+    setValue(m.ixy, ui->leIxy);
 
     // Principal axes: eigenvalues of the inertia tensor
     //   I = | iyy  -ixy |
@@ -108,10 +173,10 @@ void LC_HatchPropertiesEditingWidget::updateMomentFields() {
     }
     // else: degenerate case (I1 ≈ I2), keep theta = 0
 
-    toUIValue(I1, ui->leI1);
-    toUIValue(I2, ui->leI2);
-    toUIAngleDeg(theta, ui->lePrincipalAngle);
-    
+    setValue(I1, ui->leI1);
+    setValue(I2, ui->leI2);
+    setAngle(theta, ui->lePrincipalAngle);
+
     // Display degeneracy status
     ui->leDegenerate->setText(isDegenerate ? tr("Yes") : tr("No"));
     if (isDegenerate) {

--- a/librecad/src/ui/dialogs/entity/lc_hatchpropertieseditingwidget.h
+++ b/librecad/src/ui/dialogs/entity/lc_hatchpropertieseditingwidget.h
@@ -26,6 +26,7 @@
 
 #include "lc_entitypropertieseditorwidget.h"
 
+class QLineEdit;
 class RS_Hatch;
 
 namespace Ui {
@@ -45,6 +46,10 @@ protected slots:
 private:
     void updateMomentFields();
     void saveSettings();
+    void setupValueFields();
+    void showValueStarts();
+    void setValue(double value, QLineEdit* ed) const;
+    void setAngle(double wcsAngle, QLineEdit* ed) const;
     Ui::LC_HatchPropertiesEditingWidget *ui;
     RS_Hatch* m_entity{nullptr};
 };

--- a/librecad/src/ui/dialogs/entity/lc_hatchpropertieseditingwidget.h
+++ b/librecad/src/ui/dialogs/entity/lc_hatchpropertieseditingwidget.h
@@ -26,6 +26,7 @@
 
 #include "lc_entitypropertieseditorwidget.h"
 
+class QEvent;
 class QLineEdit;
 class RS_Hatch;
 
@@ -39,6 +40,8 @@ public:
     explicit LC_HatchPropertiesEditingWidget(QWidget *parent = nullptr);
     ~LC_HatchPropertiesEditingWidget() override;
     void setEntity(RS_Entity* entity) override;
+protected:
+    void changeEvent(QEvent* event) override;
 protected slots:
     void onScaleEditingFinished();
     void onAngleEditingFinished();


### PR DESCRIPTION
The Hatch Properties dialog clipped its computed values:

```
Ixx:            1.0871534 2…      <- cut off on the right
Iyy:            516423e+11        <- scrolled, leading digits gone
Ixy:            626747e+10
I1 (max):       667662e+12
```

## Two causes

**Precision.** Every field went through the `LC_EntityPropertiesEditorSupport`
helpers, whose `LC_Convert` default is **10** significant digits, so a moment of
inertia came out as `1.0871534275e+12` — sixteen characters.

**Width.** The value fields had no minimum width, so they fell back to Qt's
default `QLineEdit` `sizeHint` of 17 × the advance of `x`. Digits and an
`e+12` exponent are wider than `x` in a proportional font, so the text did not
fit — and because a `QLineEdit` keeps its scroll position, the field ended up
showing the *tail* of the number rather than its leading digits.

## Fix

- Format at 8 significant digits.
- Give each value field a minimum width measured from the font against the
  widest string 8 digits can produce (`-1.2345678e-308`), rather than a
  hardcoded pixel count, so it holds at any DPI or font size.
- Rewind each field to position 0, so the most significant digits are the
  visible ones if the text ever does overflow anyway.

Kept to this one widget on purpose: the shared helpers still format at their
previous default for every other property editor, so nothing else changes.

## Result

Rendering the real dialog for a hatch with deliberately awkward extents:

```
Area:           7160491            Ixx:  2.9467038e+12
Centroid (x):   1234.5678          Iyy:  6.1954412e+12
Centroid (y):   1845.6785          Ixy:  0.0049218886
                                   I1:   6.1954412e+12
                                   I2:   2.9467038e+12
```

## Testing

New test case in `rs_hatch_tests.cpp` builds the widget over such a hatch and
asserts, for every value field, that it carries at most 8 significant digits and
that the field is wide enough for its text with the layout squeezed to 200px.

I checked the test has teeth: with the precision put back to 10 and the minimum
width removed, 21 of its 67 assertions fail.

Full suite green — 13011 assertions in 734 test cases.
