### PR TITLE
Stop no-op undo cycles from destroying redo history

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2399,6 +2399,7 @@ if (BUILD_TESTS)
         librecad/src/lib/modification/tests/rs_modification_trim_tests.cpp
         librecad/src/lib/filters/tests/dwg_buffer_round_trip_tests.cpp
         librecad/src/lib/creation/tests/lc_action_draw_line_parallel_tests.cpp
+        librecad/src/lib/engine/undo/tests/rs_undo_tests.cpp
         librecad/src/lib/filters/tests/dwg_entity_encode_round_trip_tests.cpp
         librecad/src/lib/filters/tests/dwg_header_encode_round_trip_tests.cpp
         librecad/src/lib/filters/tests/dwg_header_app_vars_tests.cpp

--- a/librecad/src/lib/engine/document/rs_document.cpp
+++ b/librecad/src/lib/engine/document/rs_document.cpp
@@ -60,8 +60,11 @@ void RS_Document::endUndoCycle(){
     if (hasUndoable()) {
         setModified(true);
     }
-    m_selectedSet->enableListeners();
+    // keep the selection listeners silent while RS_Undo::endUndoCycle()
+    // prunes the obsolete redo cycles (removeEntity() may unselect), then
+    // fire the single deferred selection-changed notification
     RS_Undo::endUndoCycle();
+    m_selectedSet->enableListeners();
     setAutoUpdateBorders(m_savedAutoUpdateBorders);
     calculateBorders();
 }
@@ -110,12 +113,12 @@ bool RS_Document::undoableModify(LC_GraphicViewport* viewport, const FunUndoable
 }
 
 void RS_Document::startBulkUndoablesCleanup() {
-    m_savedAutoUpdateBorders = getAutoUpdateBorders();
+    m_savedAutoUpdateBordersBulk = getAutoUpdateBorders();
     setAutoUpdateBorders(false);
 }
 
 void RS_Document::endBulkUndoablesCleanup() {
-    setAutoUpdateBorders(m_savedAutoUpdateBorders);
+    setAutoUpdateBorders(m_savedAutoUpdateBordersBulk);
     calculateBorders();
 }
 

--- a/librecad/src/lib/engine/document/rs_document.h
+++ b/librecad/src/lib/engine/document/rs_document.h
@@ -292,6 +292,9 @@ protected:
 
     bool m_inBulkUndoableCleanup = false;
     bool m_savedAutoUpdateBorders = false;
+    /** The redo-tail prune nests bulk cleanup inside the start/endUndoCycle()
+     *  bracket, so it must not share m_savedAutoUpdateBorders. */
+    bool m_savedAutoUpdateBordersBulk = false;
 
     QList<LC_DocumentModificationListener*> m_modificationListeners;
 

--- a/librecad/src/lib/engine/undo/rs_undo.cpp
+++ b/librecad/src/lib/engine/undo/rs_undo.cpp
@@ -61,9 +61,8 @@ bool RS_Undo::hasUndoable() {
 }
 
 /**
- * Adds an Undo Cycle at the current position in the list.
- * All Cycles after the new one are removed and the Undoabels
- * on them deleted.
+ * Appends the committed cycle and moves the redo pointer past it.
+ * Expects the obsolete redo tail to be pruned already (pruneRedoCycles()).
  */
 void RS_Undo::addUndoCycle(std::shared_ptr<RS_UndoCycle> undoCycle) {
     RS_DEBUG->print("RS_Undo::addUndoCycle");
@@ -84,43 +83,56 @@ void RS_Undo::startUndoCycle() {
         return;
     }
 
-    // anything after the current existing undoCycle will be removed
-    // if there are undo cycles behind undoPointer
-    // remove obsolete entities and undoCycles
-    if (m_undoList.cend() != m_redoPointer) {
-        // collect remaining undoables
-        std::unordered_set<RS_Undoable*> keep;
-        for (auto it = m_undoList.begin(); it != m_redoPointer; ++it) {
-            for (RS_Undoable* undoable : (*it)->getUndoables()) {
-                keep.insert(undoable);
-            }
-        }
+    m_currentCycle = std::make_shared<RS_UndoCycle>();
+}
 
-        // collect obsolete undoables
-        std::unordered_set<RS_Undoable*> obsolete;
-        for (auto it = m_redoPointer; it != m_undoList.end(); ++it) {
-            for (RS_Undoable* undoable : (*it)->getUndoables()) {
-                obsolete.insert(undoable);
-            }
-        }
-
-        if (!obsolete.empty()) {
-            // delete obsolete undoables which are not in keep list
-            startBulkUndoablesCleanup(); // avoid document borders recalculation on each remove
-            for (RS_Undoable* undoable : obsolete) {
-                if (keep.end() == keep.find(undoable)) {
-                    removeUndoable(undoable);
-                }
-            }
-            endBulkUndoablesCleanup();
-        }
-        // clean up obsolete undoCycles
-        m_undoList.erase(m_redoPointer, m_undoList.cend());
-        m_redoPointer = m_undoList.cend();
+/**
+ * Removes the undo cycles behind the redo pointer and deletes their
+ * undoables, unless an undoable is still referenced by a remaining cycle
+ * or by the cycle about to be committed.
+ * Called only when a non-empty cycle is committed: an empty (no-op) cycle
+ * must leave the pending redo history untouched.
+ */
+void RS_Undo::pruneRedoCycles() {
+    if (m_undoList.cend() == m_redoPointer) {
+        return;
     }
 
-    // alloc new undoCycle
-    m_currentCycle = std::make_shared<RS_UndoCycle>();
+    // collect remaining undoables
+    std::unordered_set<RS_Undoable*> keep;
+    for (auto it = m_undoList.begin(); it != m_redoPointer; ++it) {
+        for (RS_Undoable* undoable : (*it)->getUndoables()) {
+            keep.insert(undoable);
+        }
+    }
+    // the cycle being committed references its undoables, keep them too
+    if (nullptr != m_currentCycle) {
+        for (RS_Undoable* undoable : m_currentCycle->getUndoables()) {
+            keep.insert(undoable);
+        }
+    }
+
+    // collect obsolete undoables
+    std::unordered_set<RS_Undoable*> obsolete;
+    for (auto it = m_redoPointer; it != m_undoList.end(); ++it) {
+        for (RS_Undoable* undoable : (*it)->getUndoables()) {
+            obsolete.insert(undoable);
+        }
+    }
+
+    if (!obsolete.empty()) {
+        // delete obsolete undoables which are not in keep list
+        startBulkUndoablesCleanup(); // avoid document borders recalculation on each remove
+        for (RS_Undoable* undoable : obsolete) {
+            if (keep.end() == keep.find(undoable)) {
+                removeUndoable(undoable);
+            }
+        }
+        endBulkUndoablesCleanup();
+    }
+    // clean up obsolete undoCycles
+    m_undoList.erase(m_redoPointer, m_undoList.cend());
+    m_redoPointer = m_undoList.cend();
 }
 
 /**
@@ -154,6 +166,7 @@ void RS_Undo::endUndoCycle() {
     }
 
     if (hasUndoable()) {
+        pruneRedoCycles();
         // only keep the undoCycle, when it contains undoables
         addUndoCycle(m_currentCycle);
     }

--- a/librecad/src/lib/engine/undo/rs_undo.h
+++ b/librecad/src/lib/engine/undo/rs_undo.h
@@ -79,6 +79,7 @@ protected:
 
 private:
     void addUndoCycle(std::shared_ptr<RS_UndoCycle> undoCycle);
+    void pruneRedoCycles();
     //! List of undo list items. every item is something that can be undone.
     std::vector<std::shared_ptr<RS_UndoCycle>> m_undoList;
 

--- a/librecad/src/lib/engine/undo/tests/rs_undo_tests.cpp
+++ b/librecad/src/lib/engine/undo/tests/rs_undo_tests.cpp
@@ -1,0 +1,311 @@
+/****************************************************************************
+**
+** This file is part of the LibreCAD project, a 2D CAD program
+**
+** Copyright (C) 2026 LibreCAD.org
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+**********************************************************************/
+
+// Regression tests for the RS_Undo redo-tail prune.
+//
+// Invariants under test: an empty (no-op) cycle leaves pending redo history
+// and its entities untouched; a non-empty commit prunes the redo tail,
+// keeping any undoable still referenced by a remaining cycle or by the
+// cycle being committed.
+//
+// Engine-level on RS_Graphic directly: no actions, no QApplication.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <QCoreApplication>
+
+#include "rs_graphic.h"
+#include "rs_line.h"
+#include "rs_settings.h"
+#include "rs_vector.h"
+
+namespace {
+
+void ensureQtApp() {
+    static int qargc = 1;
+    static char qarg0[] = "librecad_tests";
+    static char *qargv[] = {qarg0, nullptr};
+    static QCoreApplication *qapp = QCoreApplication::instance()
+                                        ? QCoreApplication::instance()
+                                        : new QCoreApplication(qargc, qargv);
+    static bool settingsReady = [] {
+        QCoreApplication::setOrganizationName("LibreCAD");
+        QCoreApplication::setApplicationName("LibreCAD-tests");
+        RS_Settings::init("LibreCAD", "LibreCAD-tests");
+        return true;
+    }();
+    (void)qapp;
+    (void)settingsReady;
+}
+
+// Expose the protected RS_Undo/RS_Document API for direct cycle control.
+class TestGraphic : public RS_Graphic {
+public:
+    using RS_Document::startUndoCycle;
+    using RS_Document::endUndoCycle;
+    using RS_Undo::addUndoable;
+    using RS_Undo::countUndoCycles;
+    using RS_Undo::countRedoCycles;
+};
+
+// A line that reports its destruction, so entity frees are observable.
+class TrackedLine : public RS_Line {
+public:
+    TrackedLine(RS_EntityContainer *parent, int *destroyCount, double y)
+        : RS_Line(parent, RS_Vector(0., y), RS_Vector(10., y))
+        , m_destroyCount(destroyCount) {}
+    ~TrackedLine() override {
+        if (m_destroyCount != nullptr) {
+            ++(*m_destroyCount);
+        }
+    }
+
+private:
+    int *m_destroyCount = nullptr;
+};
+
+// Commit one undo cycle that adds a tracked line (mirrors undoableAdd()).
+TrackedLine *commitTrackedLine(TestGraphic &g, int *destroyCount, double y) {
+    auto *line = new TrackedLine(&g, destroyCount, y);
+    g.startUndoCycle();
+    g.addEntity(line);
+    g.addUndoable(line);
+    g.endUndoCycle();
+    return line;
+}
+
+} // namespace
+
+// A no-op action (open + close an empty cycle) must neither wipe pending
+// redo history nor free the undone entities.
+TEST_CASE("empty undo cycle preserves pending redo history",
+          "[rs_undo]") {
+    ensureQtApp();
+    int destroyed = 0;
+    TestGraphic g;
+
+    TrackedLine *line = commitTrackedLine(g, &destroyed, 0.);
+    REQUIRE(g.countUndoCycles() == 1);
+    REQUIRE(g.countRedoCycles() == 0);
+
+    REQUIRE(g.undo());
+    REQUIRE(g.countUndoCycles() == 0);
+    REQUIRE(g.countRedoCycles() == 1);
+    CHECK(line->isDeleted());
+
+    // the no-op click
+    g.startUndoCycle();
+    g.endUndoCycle();
+
+    CHECK(g.countRedoCycles() == 1);   // redo wiped if the prune runs at cycle start
+    REQUIRE(destroyed == 0);           // entity freed if the prune runs at cycle start
+    REQUIRE(g.redo());
+    CHECK(line->isAlive());
+    CHECK(destroyed == 0);
+}
+
+TEST_CASE("repeated empty cycles keep a multi-step redo tail redoable",
+          "[rs_undo]") {
+    ensureQtApp();
+    int d1 = 0;
+    int d2 = 0;
+    TestGraphic g;
+
+    TrackedLine *l1 = commitTrackedLine(g, &d1, 0.);
+    TrackedLine *l2 = commitTrackedLine(g, &d2, 5.);
+    REQUIRE(g.undo());
+    REQUIRE(g.undo());
+    REQUIRE(g.countRedoCycles() == 2);
+
+    for (int i = 0; i < 3; ++i) {
+        g.startUndoCycle();
+        g.endUndoCycle();
+    }
+
+    CHECK(g.countRedoCycles() == 2);
+    REQUIRE(d1 == 0);
+    REQUIRE(d2 == 0);
+    REQUIRE(g.redo());
+    REQUIRE(g.redo());
+    CHECK(l1->isAlive());
+    CHECK(l2->isAlive());
+    CHECK(g.countUndoCycles() == 2);
+    CHECK(g.countRedoCycles() == 0);
+}
+
+TEST_CASE("non-empty commit discards redo tail and frees obsolete entity once",
+          "[rs_undo]") {
+    ensureQtApp();
+    int destroyedOld = 0;
+    int destroyedNew = 0;
+    TestGraphic g;
+
+    REQUIRE(g.getAutoUpdateBorders());
+    commitTrackedLine(g, &destroyedOld, 0.);
+    REQUIRE(g.undo());
+    REQUIRE(g.countRedoCycles() == 1);
+
+    TrackedLine *fresh = commitTrackedLine(g, &destroyedNew, 5.);
+    CHECK(g.countUndoCycles() == 1);
+    CHECK(g.countRedoCycles() == 0);   // tail correctly discarded
+    CHECK(destroyedOld == 1);          // obsolete entity freed exactly once
+    CHECK(destroyedNew == 0);
+    CHECK(fresh->isAlive());
+
+    // regression probe: prune-at-commit must not leave the document with
+    // border auto-updating permanently disabled
+    CHECK(g.getAutoUpdateBorders());
+
+    CHECK(!g.redo());
+    REQUIRE(g.undo());                 // the new cycle still works both ways
+    REQUIRE(g.redo());
+    CHECK(destroyedOld == 1);
+    CHECK(destroyedNew == 0);
+}
+
+TEST_CASE("partial redo tail prune keeps earlier history intact",
+          "[rs_undo]") {
+    ensureQtApp();
+    int d1 = 0;
+    int d2 = 0;
+    int d3 = 0;
+    int dn = 0;
+    TestGraphic g;
+
+    TrackedLine *l1 = commitTrackedLine(g, &d1, 0.);
+    commitTrackedLine(g, &d2, 5.);
+    commitTrackedLine(g, &d3, 10.);
+    REQUIRE(g.undo());
+    REQUIRE(g.undo());                 // tail = {cycle2, cycle3}
+    REQUIRE(g.countUndoCycles() == 1);
+    REQUIRE(g.countRedoCycles() == 2);
+
+    commitTrackedLine(g, &dn, 20.);
+    CHECK(g.countUndoCycles() == 2);
+    CHECK(g.countRedoCycles() == 0);
+    CHECK(d1 == 0);
+    CHECK(d2 == 1);
+    CHECK(d3 == 1);
+    CHECK(dn == 0);
+    CHECK(l1->isAlive());
+
+    REQUIRE(g.undo());
+    REQUIRE(g.undo());
+    CHECK(g.countRedoCycles() == 2);
+    REQUIRE(g.redo());
+    REQUIRE(g.redo());
+}
+
+TEST_CASE("nested empty inner cycle does not disturb the outer commit",
+          "[rs_undo]") {
+    ensureQtApp();
+    int destroyedOld = 0;
+    int destroyedNew = 0;
+    TestGraphic g;
+
+    commitTrackedLine(g, &destroyedOld, 0.);
+    REQUIRE(g.undo());
+    REQUIRE(g.countRedoCycles() == 1);
+
+    g.startUndoCycle();                // outer
+    g.startUndoCycle();                // nested inner
+    g.endUndoCycle();                  // inner end: no commit, no prune
+    CHECK(g.countRedoCycles() == 1);   // fails if the prune runs at the outer cycle start
+
+    auto *line = new TrackedLine(&g, &destroyedNew, 5.);
+    g.addEntity(line);
+    g.addUndoable(line);
+    g.endUndoCycle();                  // outer end: commit + prune once
+
+    CHECK(g.countUndoCycles() == 1);
+    CHECK(g.countRedoCycles() == 0);
+    CHECK(destroyedOld == 1);          // pruned exactly once
+    CHECK(destroyedNew == 0);
+    REQUIRE(g.undo());
+    REQUIRE(g.redo());
+}
+
+// The committed cycle still references the shared undoable; freeing it in
+// the prune would be a use-after-free on the next undo.
+TEST_CASE("undoable in both redo tail and committed cycle is not freed",
+          "[rs_undo]") {
+    ensureQtApp();
+    int destroyed = 0;
+    TestGraphic g;
+
+    TrackedLine *line = commitTrackedLine(g, &destroyed, 0.);
+    REQUIRE(g.undo());
+    REQUIRE(g.countRedoCycles() == 1);
+
+    g.startUndoCycle();
+    // a prune at cycle start would already have freed the entity here
+    REQUIRE(destroyed == 0);
+    g.addUndoable(line);               // same object recorded in the new cycle
+    g.endUndoCycle();
+
+    // fails if the prune's keep-set omits the cycle being committed
+    REQUIRE(destroyed == 0);
+    CHECK(g.countUndoCycles() == 1);
+    CHECK(g.countRedoCycles() == 0);
+
+    REQUIRE(g.undo());                 // toggles the shared undoable: alive
+    CHECK(line->isAlive());
+    REQUIRE(g.redo());
+    CHECK(line->isDeleted());
+    REQUIRE(destroyed == 0);
+}
+
+TEST_CASE("undoable shared between kept history and redo tail survives",
+          "[rs_undo]") {
+    ensureQtApp();
+    int d = 0;
+    int dn = 0;
+    TestGraphic g;
+
+    TrackedLine *line = commitTrackedLine(g, &d, 0.);   // cycle1: add line
+
+    g.startUndoCycle();                // cycle2: delete the same line
+    line->markDeleted();
+    g.addUndoable(line);
+    g.endUndoCycle();
+
+    REQUIRE(g.undo());                 // undo the delete: line alive again
+    CHECK(line->isAlive());
+    REQUIRE(g.countRedoCycles() == 1);
+
+    commitTrackedLine(g, &dn, 5.);     // prune: line is obsolete AND kept
+    CHECK(d == 0);                     // must not be freed: cycle1 keeps it
+    CHECK(line->isAlive());
+    CHECK(g.countUndoCycles() == 2);   // cycle1 + new cycle; cycle2 pruned
+    CHECK(g.countRedoCycles() == 0);
+}
+
+TEST_CASE("empty cycle with no pending redo is a no-op", "[rs_undo]") {
+    ensureQtApp();
+    TestGraphic g;
+
+    g.startUndoCycle();
+    g.endUndoCycle();
+    CHECK(g.countUndoCycles() == 0);
+    CHECK(g.countRedoCycles() == 0);
+    CHECK(!g.undo());
+    CHECK(!g.redo());
+}


### PR DESCRIPTION
General fix for the redo-history wipe that #2710 guarded in one tool. Follow-up promised in
[the #2710 review](https://github.com/LibreCAD/LibreCAD/pull/2710#issuecomment-5229527469).

## The bug

`RS_Undo::startUndoCycle` pruned the redo tail **eagerly**: everything past the redo pointer was
erased and the undone entities freed, before anyone knew whether the cycle would receive any
undoables. So *any* action that opened a cycle and added nothing — a click that produced no
modification — silently destroyed the user's pending redo history, and freed the entities backing
it without even setting the modified flag. The empty-cycle gate in `endUndoCycle`
(`hasUndoable()`) only prevented the empty *step* from being recorded; by then the redo stack was
already gone.

One carve-out stays real after this fix: a click that moves the relative zero records an
`LC_UndoableRelZero`, so that cycle is *not* empty and still prunes — per-tool guards like #2710's
keep their value for those clicks.

#2710 fixed the one instance reachable from the parallel tool, at the action layer. This moves the
prune itself to where it belongs: **commit time**, in `endUndoCycle`'s non-empty branch,
immediately before `addUndoCycle`. Empty cycles now leave the redo tail untouched; committing real
work discards it exactly as before.

## Two amendments that turned out to be mandatory

Both were found by adversarial review and confirmed empirically — each has a dedicated regression
test that fails without it:

1. **The keep-set must include the cycle being committed.** Delete an entity, undo, delete it
   again: the same undoable sits in the obsolete redo tail *and* in the new cycle. Pruning without
   this frees an object the committed cycle still references — use-after-free on the next undo.
   (The old start-side prune had the mirror image of this bug: it freed the entity before the
   action could re-register it.)
2. **`RS_Document`'s bulk-cleanup bracket needs its own saved-borders slot.** The prune calls
   `startBulkUndoablesCleanup`/`endBulkUndoablesCleanup`, which shared `m_savedAutoUpdateBorders`
   with the `start/endUndoCycle` bracket. With the prune now running inside that bracket, the
   shared slot clobbered the saved value and left border auto-updating **permanently disabled**
   after the first pruning commit.

A third production change is required for the same reason: `RS_Document::endUndoCycle` now
re-enables the selection listeners *after* the base-class commit rather than before. At base the
prune ran inside `startUndoCycle`'s silence window; undo marks entities deleted without clearing
`FlagSelected`, so a prune outside that window fires one `selectionChanged` per pruned entity via
`removeEntity` → `clearSelectionBeforeDeletion`. The reorder keeps them batched into the single
deferred notification. It swaps the notification order — `undoStateChanged` now fires before the
deferred `selectionChanged`; the current listeners of both are indifferent to it.

Because of (2), **the four production files are one atomic change** — cherry-picking the
`rs_undo.cpp` part alone silently disables border auto-update. Please don't split it.

## Blast radius

Every `start/endUndoCycle` caller was enumerated (`LC_UndoSection` + the `undoableModify` lambdas,
polyline actions, rel-zero, the plugin interface's 16 sites, `RS_Graphic::removeLayer`): none depends on
the eager prune, and no code opens a cycle *in order to* clear redo history. The undo/redo buttons
update through `updateUndoState` at commit; the graphic-view context menu also pulls
`collectUndoState` when it opens, which under an open cycle now sees the redo tail still present —
a more accurate answer than the old pre-wiped state. Mid-cycle `undo()` via the plugin event pump
(`getPoint`/`getEnt` run a nested event loop inside an open `LC_UndoSection`) is *improved*: the
old code could commit a cycle onto an unpruned tail through that path, corrupting the history.
Mid-cycle `redo()` through the same pump becomes newly reachable state — reasoned coherent, but
untested.

One deliberate non-change: no `Q_ASSERT(m_refCount == 0)` in `undo()`/`redo()` — the plugin event
pump makes mid-cycle undo user-reachable, so the assert would abort debug builds during legitimate
plugin use.

## Behavior change, stated plainly

No-op actions no longer destroy redo. Users will see Redo stay enabled after clicks that do
nothing — previously those clicks wiped it, which also meant silent data loss in documents whose
modified flag was never set.

## Tests

`librecad/src/lib/engine/undo/tests/rs_undo_tests.cpp` — engine-level on `RS_Graphic` directly,
with a destruction-tracking entity so frees are observable. Eight cases: the no-op cycle bug, 
repeated no-ops over a multi-step tail, non-empty commit still pruning and freeing exactly once
with borders intact, partial-tail prune keeping earlier history, nested refcounted cycles pruning
once at the outer commit, the shared-undoable use-after-free guard, the kept-history keep-set
regression, and the empty-document no-op.

Verified by mutation, each rebuilt and run: reverting the move fails 4 cases; dropping the
keep-current-cycle amendment fails exactly the UAF case; dropping the borders slot fails exactly
the borders check. Full suite at this branch tip: **13222 assertions in 758 test cases, exit 0** (13028/741 on the
older baseline the mutation runs used); default order and randomised orderings; ASan/UBSan clean,
including a 5-seed × 2000-op randomised stress harness from the adversarial review.

## Out of scope (pre-existing, noted during review)

- Nested `startUndoCycle` calls clobber `m_savedAutoUpdateBorders` at every refcount depth
  (reachable via nested plugin sections).
- `LC_UndoableRelZero` leaks when pruned — `removeUndoable` handles only entities.
- `RS_Graphic::removeLayer` drives a raw `start/end` pair.
- `endBulkUndoablesCleanup`'s unconditional O(N) `calculateBorders` per pruning commit.
- `RS_Document::m_inBulkUndoableCleanup` is dead — its only reference is its declaration, and its
  name misleadingly suggests it guards the bracket this PR reworks.
- The compiled-out `#ifdef RS_TEST` block cannot build: `RS_UndoStub` leaves the pure-virtual bulk
  hooks unimplemented, so it is abstract.
