### PR TITLE
2.2.1: fix text not rendered in the drawing view (#2737)

### DIFF
--- a/librecad/src/actions/rs_actionzoompan.cpp
+++ b/librecad/src/actions/rs_actionzoompan.cpp
@@ -106,7 +106,15 @@ void RS_ActionZoomPan::mouseReleaseEvent(QMouseEvent* e) {
 		setStatus(SetPanEnd);
 		break;
 	default:
+		// A left button release ends the drag but keeps the action alive for
+		// the next drag. The panning flag must still be cleared here: it is
+		// only reset by finish(), which this path never reaches, and while it
+		// is set RS_Text/RS_MText draw themselves as a bounding box instead of
+		// glyphs. Leaving it set makes every text in the drawing view
+		// invisible until the view is recreated.
 		setStatus(SetPanStart);
+		graphicView->setPanning(false);
+		graphicView->redraw();
 	}
 	trigger();
     //RS_DEBUG->print("RS_ActionZoomPan::mousePressEvent(): %f %f", v1.x, v1.y);

--- a/librecad/src/lib/engine/rs_entity.h
+++ b/librecad/src/lib/engine/rs_entity.h
@@ -167,6 +167,20 @@ public:
     virtual bool isContainer() const = 0;
 
     /**
+     * @retval true if this entity's borders describe a real extent and should
+     * therefore be folded into the extent of its parent container.
+     *
+     * An empty container normally has no meaningful borders, and including it
+     * would drag the parent's extent to 0/0. Entities that derive their borders
+     * from their own data rather than from child entities (RS_Text, RS_MText)
+     * override this so they still count towards the drawing extent when they
+     * hold no children.
+     */
+    virtual bool hasMeaningfulBorders() const {
+        return true;
+    }
+
+    /**
      * Must be overwritten to return true if an entity type
      * is an atomic entity.
      */

--- a/librecad/src/lib/engine/rs_entitycontainer.cpp
+++ b/librecad/src/lib/engine/rs_entitycontainer.cpp
@@ -564,8 +564,9 @@ void RS_EntityContainer::adjustBorders(RS_Entity* entity) {
 
     if (entity) {
         // make sure a container is not empty (otherwise the border
-        //   would get extended to 0/0):
-        if (!entity->isContainer() || entity->count()>0) {
+        //   would get extended to 0/0). Entities that derive their borders from
+        //   their own data still count when empty - see hasMeaningfulBorders().
+        if (entity->hasMeaningfulBorders()) {
             minV = RS_Vector::minimum(entity->getMin(),minV);
             maxV = RS_Vector::maximum(entity->getMax(),maxV);
         }

--- a/librecad/src/lib/engine/rs_entitycontainer.h
+++ b/librecad/src/lib/engine/rs_entitycontainer.h
@@ -136,6 +136,10 @@ public:
         autoUpdateBorders = enable;
     }
     virtual void adjustBorders(RS_Entity* entity);
+	bool hasMeaningfulBorders() const override {
+		return count() > 0;
+	}
+
 	void calculateBorders() override;
 	void forcedCalculateBorders();
 	void updateDimensions( bool autoText=true);

--- a/librecad/src/lib/engine/rs_fontlist.cpp
+++ b/librecad/src/lib/engine/rs_fontlist.cpp
@@ -96,8 +96,6 @@ RS_Font* RS_FontList::requestFont(const QString& name) {
 
     QString name2 = name.toLower();
     RS_Font* foundFont = nullptr;
-    if (name.isEmpty())
-        return foundFont;
 
     // QCAD 1 compatibility:
     if (name2.contains('#') && name2.contains('_')) {
@@ -112,14 +110,20 @@ RS_Font* RS_FontList::requestFont(const QString& name) {
 	for( auto const& f: fonts){
 
         if (f->getFileName().toLower() == name2) {
-            // Make sure this font is loaded into memory:
-            f->loadFont();
-			foundFont = f.get();
+            // Make sure this font is loaded into memory. A font that fails to
+            // load has an empty letter list, including no replacement glyph, so
+            // it is no more usable than no font at all: treat it as not found
+            // and let the "standard" fallback below have a turn.
+            if (f->loadFont()) {
+                foundFont = f.get();
+            }
             break;
         }
     }
 
-	if (!foundFont && name!="standard") {
+    // An empty style name reaches here too: it matches no font, so it also
+    // falls back to "standard" instead of leaving the text without any font.
+	if (!foundFont && name2!="standard") {
         foundFont = requestFont("standard");
     }
 

--- a/librecad/src/lib/engine/rs_mtext.cpp
+++ b/librecad/src/lib/engine/rs_mtext.cpp
@@ -24,6 +24,7 @@
 **
 **********************************************************************/
 
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 
@@ -202,6 +203,10 @@ void RS_MText::update() {
 
   RS_Font *font{RS_FONTLIST->requestFont(data.style)};
   if (nullptr == font) {
+    // No font at all: the text cannot be turned into letters. Keep a
+    // data-derived extent so the entity still has a location and can be drawn
+    // as a placeholder box rather than vanishing silently.
+    applyFallbackBorders();
     return;
   }
 
@@ -377,8 +382,102 @@ void RS_MText::update() {
 
   updateAddLine(oneLine, lineCounter);
 
+  forcedCalculateBorders();
+  if (isEmpty() || getSize().x <= RS_TOLERANCE || !std::isfinite(getSize().x)) {
+    // Either the string produced no letters at all (empty or whitespace-only
+    // text), or the letters carry no geometry - which is what happens when the
+    // font loaded but its letter list is empty, leaving every letter an empty
+    // insert. Normalise both to an empty container with a data-derived extent.
+    clear();
+    applyFallbackBorders();
+    RS_DEBUG->print("RS_MText::update: no letters generated");
+    return;
+  }
+
   alignVertically();
   RS_DEBUG->print("RS_MText::update: OK");
+}
+
+/**
+ * Nominal advance width of one glyph cell, as a fraction of the text height.
+ * The LFF letters are drawn on a 9-unit grid and a typical cell including the
+ * letter spacing is about 7.5 units wide.
+ */
+static constexpr double RS_MTEXT_NOMINAL_ASPECT = 7.5 / 9.0;
+
+void RS_MText::applyFallbackBorders() {
+  // Derive the extent from the text data. Falling back to the container borders
+  // is not an option here: RS_EntityContainer::calculateBorders() collapses an
+  // empty container to 0/0, which would place the placeholder at the drawing
+  // origin instead of where the text actually is.
+  double height = data.height;
+  if (!(height > RS_TOLERANCE) || !std::isfinite(height)) {
+    height = 1.0;
+  }
+
+  // Longest line drives the width; the number of lines drives the height.
+  const QStringList lines = data.text.split('\n');
+  int columns = 1;
+  for (const QString &line : lines) {
+    columns = std::max(columns, static_cast<int>(line.length()));
+  }
+  int rows = std::max(1, static_cast<int>(lines.size()));
+
+  double width = columns * height * RS_MTEXT_NOMINAL_ASPECT;
+  if (data.width > RS_TOLERANCE && std::isfinite(data.width)) {
+    // A reference rectangle width was given, so the text wraps within it.
+    width = std::min(width, data.width);
+  }
+  double totalHeight = rows * height;
+
+  // Local box, top-left at the origin: RS_MText is laid out downwards from the
+  // insertion point (VATop is the no-op case in alignVertically()).
+  double left = 0.0;
+  double top = 0.0;
+  switch (data.halign) {
+  case RS_MTextData::HACenter:
+    left = -width / 2.0;
+    break;
+  case RS_MTextData::HARight:
+    left = -width;
+    break;
+  default:
+    break;
+  }
+  switch (data.valign) {
+  case RS_MTextData::VAMiddle:
+    top = totalHeight / 2.0;
+    break;
+  case RS_MTextData::VABottom:
+    top = totalHeight;
+    break;
+  default:
+    break;
+  }
+
+  RS_Vector corners[4] = {{left, top},
+                          {left + width, top},
+                          {left + width, top - totalHeight},
+                          {left, top - totalHeight}};
+
+  resetBorders();
+  for (RS_Vector corner : corners) {
+    corner.rotate(RS_Vector(0.0, 0.0), data.angle);
+    corner.move(data.insertionPoint);
+    minV = RS_Vector::minimum(corner, minV);
+    maxV = RS_Vector::maximum(corner, maxV);
+  }
+}
+
+void RS_MText::calculateBorders() {
+  RS_EntityContainer::calculateBorders();
+  // No letters, or letters whose geometry collapsed to a point: in both cases
+  // the base class has just left the borders at 0/0, which is neither the right
+  // size nor the right place. Fall back to the data-derived extent.
+  if (isEmpty() ||
+      (maxV.x - minV.x <= RS_TOLERANCE && maxV.y - minV.y <= RS_TOLERANCE)) {
+    applyFallbackBorders();
+  }
 }
 
 void RS_MText::alignVertically()
@@ -641,8 +740,19 @@ void RS_MText::draw(RS_Painter *painter, RS_GraphicView *view,
   if (!(painter && view))
     return;
 
+  // No letters could be generated (missing font, or a string that produces no
+  // glyphs). Draw the placeholder box in every mode, including print preview and
+  // printing: silently omitting the entity would hide from the user that the
+  // drawing contains text which cannot be rendered.
+  if (isEmpty()) {
+    painter->drawPlaceholderRect(view->toGui(getMin()), view->toGui(getMax()));
+    return;
+  }
+
   if (!view->isPrintPreview() && !view->isPrinting()) {
     if (view->isPanning() || view->toGuiDY(getHeight()) < 4) {
+      // Performance substitution for glyphs that do exist, so it keeps the
+      // entity's own pen - including a deliberate NoPen.
       painter->drawRect(view->toGui(getMin()), view->toGui(getMax()));
       return;
     }

--- a/librecad/src/lib/engine/rs_mtext.h
+++ b/librecad/src/lib/engine/rs_mtext.h
@@ -155,6 +155,19 @@ public:
 
   void update() override;
 
+  void calculateBorders() override;
+
+  /** Borders come from the text data when there are no letters. */
+  bool hasMeaningfulBorders() const override { return true; }
+
+  /**
+   * Derives the extent of this text from its data (insertion point, height,
+   * reference width, string length, alignment, angle) instead of from its
+   * letter entities. Used whenever no letters could be generated, so that the
+   * entity still reports a usable location and size.
+   */
+  void applyFallbackBorders();
+
   int getNumberOfLines();
 
   RS_Vector getInsertionPoint() { return data.insertionPoint; }

--- a/librecad/src/lib/engine/rs_text.cpp
+++ b/librecad/src/lib/engine/rs_text.cpp
@@ -24,8 +24,9 @@
 **
 **********************************************************************/
 
-#include<iostream>
-#include<cmath>
+#include <algorithm>
+#include <cmath>
+#include <iostream>
 #include "rs_font.h"
 #include "rs_text.h"
 
@@ -268,6 +269,10 @@ void RS_Text::update() {
     RS_Font* font = RS_FONTLIST->requestFont(data.style);
 
     if (font==NULL) {
+        // No font at all: the text cannot be turned into letters. Keep a
+        // data-derived extent so the entity still has a location and can be
+        // drawn as a placeholder box rather than vanishing silently.
+        applyFallbackBorders();
         return;
     }
 
@@ -328,6 +333,19 @@ void RS_Text::update() {
         forcedCalculateBorders();
     }
     RS_Vector textSize = getSize();
+
+    if (isEmpty() || textSize.x <= RS_TOLERANCE || !std::isfinite(textSize.x)) {
+        // Either the string produced no letters at all (empty or whitespace-only
+        // text), or the letters carry no geometry - which is what happens when
+        // the font loaded but its letter list is empty, leaving every letter an
+        // empty insert. Both cases are the same thing as far as drawing goes, so
+        // normalise to an empty container with a data-derived extent. Stopping
+        // here also protects the HAAligned/HAFit branch below, which divides by
+        // textSize.x and would otherwise corrupt data.height.
+        clear();
+        applyFallbackBorders();
+        return;
+    }
 
     RS_DEBUG->print("RS_Text::updateAddLine: width 2: %f", textSize.x);
 
@@ -421,6 +439,83 @@ void RS_Text::update() {
     RS_DEBUG->print("RS_Text::update: OK");
 }
 
+
+/**
+ * Nominal advance width of one glyph cell, as a fraction of the text height.
+ * The LFF letters are drawn on a 9-unit grid and a typical cell including the
+ * letter spacing is about 7.5 units wide.
+ */
+static constexpr double RS_TEXT_NOMINAL_ASPECT = 7.5 / 9.0;
+
+void RS_Text::applyFallbackBorders() {
+    // Derive the extent from the text data. Falling back to the container
+    // borders is not an option here: RS_EntityContainer::calculateBorders()
+    // collapses an empty container to 0/0, which would place the placeholder at
+    // the drawing origin instead of where the text actually is.
+    double height = data.height;
+    if (!(height > RS_TOLERANCE) || !std::isfinite(height)) {
+        height = 1.0;
+    }
+    double widthRel = data.widthRel;
+    if (!(widthRel > RS_TOLERANCE) || !std::isfinite(widthRel)) {
+        widthRel = 1.0;
+    }
+    // An empty string still gets a one-character box so that the entity stays
+    // visible and selectable.
+    int chars = std::max(1, static_cast<int>(data.text.length()));
+    double width = chars * height * widthRel * RS_TEXT_NOMINAL_ASPECT;
+
+    // Local box, baseline-left at the origin.
+    double left = 0.0;
+    double bottom = 0.0;
+    switch (data.halign) {
+    case RS_TextData::HACenter:
+    case RS_TextData::HAMiddle:
+        left = -width / 2.0;
+        break;
+    case RS_TextData::HARight:
+        left = -width;
+        break;
+    default:
+        break;
+    }
+    switch (data.valign) {
+    case RS_TextData::VAMiddle:
+        bottom = -height / 2.0;
+        break;
+    case RS_TextData::VATop:
+        bottom = -height;
+        break;
+    default:
+        break;
+    }
+
+    RS_Vector corners[4] = {
+        {left,         bottom},
+        {left + width, bottom},
+        {left + width, bottom + height},
+        {left,         bottom + height}
+    };
+
+    resetBorders();
+    for (RS_Vector corner: corners) {
+        corner.rotate(RS_Vector(0.0, 0.0), data.angle);
+        corner.move(data.insertionPoint);
+        minV = RS_Vector::minimum(corner, minV);
+        maxV = RS_Vector::maximum(corner, maxV);
+    }
+}
+
+void RS_Text::calculateBorders() {
+    RS_EntityContainer::calculateBorders();
+    // No letters, or letters whose geometry collapsed to a point: in both cases
+    // the base class has just left the borders at 0/0, which is neither the
+    // right size nor the right place. Fall back to the data-derived extent.
+    if (isEmpty()
+            || (maxV.x - minV.x <= RS_TOLERANCE && maxV.y - minV.y <= RS_TOLERANCE)) {
+        applyFallbackBorders();
+    }
+}
 
 RS_Vector RS_Text::getNearestEndpoint(const RS_Vector& coord, double* dist)const {
 	if (dist) {
@@ -542,10 +637,22 @@ void RS_Text::draw(RS_Painter* painter, RS_GraphicView* view, double& /*patternO
         return;
     }
 
+    // No letters could be generated (missing font, or a string that produces no
+    // glyphs). Draw the placeholder box in every mode, including print preview
+    // and printing: silently omitting the entity would hide from the user that
+    // the drawing contains text which cannot be rendered.
+    if (isEmpty())
+    {
+        painter->drawPlaceholderRect(view->toGui(getMin()), view->toGui(getMax()));
+        return;
+    }
+
     if (!view->isPrintPreview() && !view->isPrinting())
     {
         if (view->isPanning() || view->toGuiDY(getHeight()) < 4)
         {
+            // Performance substitution for glyphs that do exist, so it keeps
+            // the entity's own pen - including a deliberate NoPen.
             painter->drawRect(view->toGui(getMin()), view->toGui(getMax()));
             return;
         }

--- a/librecad/src/lib/engine/rs_text.h
+++ b/librecad/src/lib/engine/rs_text.h
@@ -154,6 +154,21 @@ public:
 
     void update() override;
 
+    void calculateBorders() override;
+
+    /** Borders come from the text data when there are no letters. */
+    bool hasMeaningfulBorders() const override {
+        return true;
+    }
+
+    /**
+     * Derives the extent of this text from its data (insertion point, height,
+     * width relation, string length, alignment, angle) instead of from its
+     * letter entities. Used whenever no letters could be generated, so that the
+     * entity still reports a usable location and size.
+     */
+    void applyFallbackBorders();
+
     int getNumberOfLines();
 
 

--- a/librecad/src/lib/gui/rs_graphicview.cpp
+++ b/librecad/src/lib/gui/rs_graphicview.cpp
@@ -1162,7 +1162,15 @@ void RS_GraphicView::drawEntity(RS_Painter *painter, RS_Entity* e, double& patte
         switch(e->rtti()){
         case RS2::EntityMText:
         case RS2::EntityText:
-            painter->drawRect(toGui(e->getMin()), toGui(e->getMax()));
+            // A text with no letters has no glyphs for the box to stand in for:
+            // its box reports a rendering failure and must stay visible even
+            // under a NoPen line type. A text that does have glyphs keeps its
+            // own pen, exactly as it would outside draft mode.
+            if (static_cast<RS_EntityContainer*>(e)->isEmpty()) {
+                painter->drawPlaceholderRect(toGui(e->getMin()), toGui(e->getMax()));
+            } else {
+                painter->drawRect(toGui(e->getMin()), toGui(e->getMax()));
+            }
             break;
         case RS2::EntityImage:
             // all images as rectangles:

--- a/librecad/src/lib/gui/rs_painter.cpp
+++ b/librecad/src/lib/gui/rs_painter.cpp
@@ -23,7 +23,8 @@
 ** This copyright notice MUST APPEAR in all copies of the script!
 **
 **********************************************************************/
-#include<cmath>
+#include <algorithm>
+#include <cmath>
 
 #include<QPainterPath>
 #include<QPolygon>
@@ -32,6 +33,7 @@
 #include "rs_debug.h"
 #include "rs_math.h"
 #include "rs_painter.h"
+#include "rs_pen.h"
 
 void RS_Painter::createArc(QPolygon& pa,
                              const RS_Vector& cp, double radius,
@@ -141,11 +143,45 @@ void RS_Painter::createEllipse(QPolygon& pa,
 }
 
 void RS_Painter::drawRect(const RS_Vector& p1, const RS_Vector& p2) {
-    drawPolygon(QRect(int(p1.x+0.5), int(p1.y+0.5), int(p2.x - p1.x+0.5), int(p2.y - p1.y+0.5)));
+    // Guard against non-finite input: converting those to int is undefined
+    // behaviour, and an entity with corrupt borders must not take the painter
+    // with it.
+    if (!std::isfinite(p1.x) || !std::isfinite(p1.y)
+            || !std::isfinite(p2.x) || !std::isfinite(p2.y)) {
+        RS_DEBUG->print(RS_Debug::D_WARNING,
+                        "RS_Painter::drawRect: non-finite corner, skipping");
+        return;
+    }
+
+    // The corners arrive unordered - toGui() flips the y axis, so p2.y < p1.y
+    // for a rectangle built from getMin()/getMax(). Normalise, and keep at
+    // least one pixel in each direction: a QRect of zero width or height
+    // becomes four identical points and draws nothing at all, which would make
+    // an entity that is meant to be shown as a box disappear instead.
+    double left = std::min(p1.x, p2.x);
+    double top = std::min(p1.y, p2.y);
+    double right = std::max(p1.x, p2.x);
+    double bottom = std::max(p1.y, p2.y);
+
+    int w = std::max(1, RS_Math::round(right - left));
+    int h = std::max(1, RS_Math::round(bottom - top));
+
+    drawPolygon(QRect(RS_Math::round(left), RS_Math::round(top), w, h));
 //    drawLine(RS_Vector(p1.x, p1.y), RS_Vector(p2.x, p1.y));
 //    drawLine(RS_Vector(p2.x, p1.y), RS_Vector(p2.x, p2.y));
 //    drawLine(RS_Vector(p2.x, p2.y), RS_Vector(p1.x, p2.y));
 //    drawLine(RS_Vector(p1.x, p2.y), RS_Vector(p1.x, p1.y));
+}
+
+void RS_Painter::drawPlaceholderRect(const RS_Vector& p1, const RS_Vector& p2) {
+    RS_Pen pen = getPen();
+    if (pen.getLineType() == RS2::NoPen) {
+        // The placeholder must stay visible even when the entity asks for no
+        // stroke at all, otherwise the entity renders as nothing.
+        pen.setLineType(RS2::SolidLine);
+        setPen(pen);
+    }
+    drawRect(p1, p2);
 }
 
 void RS_Painter::drawHandle(const RS_Vector& p, const RS_Color& c, int size) {

--- a/librecad/src/lib/gui/rs_painter.h
+++ b/librecad/src/lib/gui/rs_painter.h
@@ -99,6 +99,15 @@ public:
     virtual void drawPoint(const RS_Vector& p, int pdmode, int pdsize) = 0;
     virtual void drawLine(const RS_Vector& p1, const RS_Vector& p2) = 0;
     virtual void drawRect(const RS_Vector& p1, const RS_Vector& p2);
+
+    /**
+     * Draws a rectangle that is used as the last-resort representation of an
+     * entity (a text that has no glyphs, or a draft-mode placeholder). Unlike
+     * drawRect() this guarantees the rectangle is actually painted: a NoPen
+     * line type would otherwise erase the placeholder just as thoroughly as it
+     * erases the geometry it stands in for.
+     */
+    void drawPlaceholderRect(const RS_Vector& p1, const RS_Vector& p2);
     virtual void drawArc(const RS_Vector& cp, double radius,
                          double a1, double a2,
                          bool reversed) = 0;


### PR DESCRIPTION
Fixes #2737.

Text entities were not rendered in the drawing view, while print preview and PDF export were correct. There are two independent causes; the first explains the reported symptom, the second is the class of defect behind it.

## 1. The panning flag was never cleared after a left-button pan

`RS_Text::draw` and `RS_MText::draw` skip their glyphs and emit only a bounding rectangle when `view->isPanning()` is set. Both guard that early-out with `!isPrintPreview() && !isPrinting()`, which is exactly why print preview and PDF export were unaffected while the drawing view lost its text — and why dimension arrows kept rendering but the dimension label did not.

`RS_GraphicView::panning` was only ever reset by `RS_ActionZoomPan::finish()`, reached from the `SetPanEnd` status that a middle- or right-button release sets. A **left**-button release takes the default branch, which sets `SetPanStart` and returns without finishing. `RS_EventHandler::setCurrentAction()` only suspends the outgoing action and never finishes it, so switching tools did not clear the flag either: it survived for the lifetime of the view.

So after one left-button drag with the Pan tool, every text in the drawing renders as a bare box until the file is reopened.

master already does this — `m_viewport->setPanning(false)` on the left-button release path, added in 64fa97a12. This backports it.

Verified by driving the real `RS_ActionZoomPan` with synthetic mouse events:

```
                              before   after
initial                       0        0
after LEFT press              1        1
after LEFT release            1        0
after MIDDLE press/release    0        0
```

## 2. A text that cannot be rendered rendered as nothing at all

The invariant should be: **a text is either drawn as glyphs, or drawn as a bounding box — never as nothing.** It was not held.

The bounding-box fallback was computed from the very letter entities it was meant to substitute for, so when those were missing the box was missing too:

1. `RS_Text::update` / `RS_MText::update` early-return with an empty container when no font resolves, or when the string yields no glyphs.
2. `RS_EntityContainer::calculateBorders` leaves the `resetBorders()` sentinels, and its corrupt-data repair then rewrites them to `(0,0)-(0,0)`. The text loses its *location*, not just its size.
3. `RS_Painter::drawRect` builds a 0x0 `QRect`; the implicit `QPolygon(QRect)` conversion yields four coincident points and `drawPolygon` paints zero pixels.
4. `adjustBorders` skipped the empty container, so the text was absent from the drawing extent and out of reach of zoom-to-fit as well.

Measured with the font directory missing: every text rendered 0 ink in normal, panning **and** draft modes, and a text placed at (500,400) reported borders `(0,0)-(0,0)`.

### Changes

- `RS_Text` / `RS_MText` derive their extent from their own data (insertion point, height, width, string length, alignment, angle) whenever they hold no letters, and draw that box in every mode including print preview. A text whose letters carry no geometry is normalised to the empty case, which also stops the `HAAligned`/`HAFit` branch dividing by a zero text size and permanently corrupting `data.height`.
- `RS_Painter::drawRect` normalises its corners, keeps a one-pixel minimum in each direction, and rejects non-finite input instead of converting it to `int`.
- `drawPlaceholderRect` forces a stroke for the failure box only, so a `NoPen` line type cannot conceal that text failed to render. The draft-mode and panning boxes stand in for glyphs that *do* exist and keep honouring the entity's own pen.
- `RS_FontList::requestFont` falls back to `standard` for an empty style name — it previously returned `nullptr` outright, which is a deterministic trigger for the above — and honours `RS_Font::loadFont()`'s failure result instead of handing back a font with an empty letter list and no replacement glyph.
- `hasMeaningfulBorders()` lets an entity that derives its borders from its own data count towards its parent's extent while holding no children. For every other entity type the predicate is identical to the previous `!isContainer() || count() > 0`.

### Testing

A matrix of 9 text cases (normal, empty string, whitespace-only, unknown style name, empty style name, height 0, height 1e-9, insertion point far from the origin, `NoPen` layer) against 3 font configurations (working fonts, a font that loads with zero glyphs, no fonts installed) in 3 modes (normal, panning, draft), counting rendered pixels.

- Before: 21 combinations rendered zero pixels.
- After: none, apart from a deliberate `NoPen` line type on text that has glyphs — which is the user's explicit choice and now behaves consistently in all three modes.
- Normal glyph rendering is unchanged: identical pixel count and bounding box.

### Deliberately not changed

- `RS_GraphicView::setPenForEntity` sets a guaranteed-visible foreground pen in draft mode, then overwrites it with `RS_Pen pen = e->getPen(true)` on the next line, so that pen is dead code. Fixing it changes draft-mode colouring for all entity types, which is out of scope here.
- An `RS_Insert` whose scale falls below `MIN_Scale_Factor` discards its whole block, so text inside it disappears with no box. That is INSERT semantics rather than text rendering.
- Print preview combined with reopening Options > General appears to repoint the background-collision remap at the screen background. Different subsystem; worth its own issue.
