### PR TITLE
Stop shipping unused Qt plugins in the AppImage and macOS bundles (#2734)

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get -y update
-          sudo apt-get -qq install qmake6 qt6-base-dev qt6-declarative-dev qt6-image-formats-plugin-pdf qt6-pdf-dev linguist-qt6
-          sudo apt-get -qq install qt6-svg-dev libqt6svgwidgets6 qt6-l10n-tools qtchooser qt6-wayland-dev qt6-tools-dev
+          sudo apt-get -qq install qmake6 qt6-base-dev qt6-declarative-dev qt6-image-formats-plugin-pdf qt6-image-formats-plugins qt6-pdf-dev linguist-qt6
+          sudo apt-get -qq install qt6-svg-dev libqt6svgwidgets6 qt6-l10n-tools qtchooser qt6-wayland qt6-wayland-dev qt6-tools-dev
           sudo apt-get -qq install libgl-dev libxcb-cursor0 libmuparser-dev libboost-dev libssl-dev libssl3
           sudo apt-get -qq install imagemagick librsvg2-bin libfreetype6-dev libicu-dev pkg-config libfuse2 rsync
           sudo apt-get -qq install cmake
@@ -82,8 +82,8 @@ jobs:
       - name: Install Qt and dependencies
         run: |
           sudo apt-get -y update
-          sudo apt-get -qq install qmake6 qt6-base-dev qt6-declarative-dev qt6-image-formats-plugin-pdf qt6-pdf-dev linguist-qt6
-          sudo apt-get -qq install qt6-svg-dev libqt6svgwidgets6 qt6-l10n-tools qtchooser qt6-wayland-dev qt6-tools-dev
+          sudo apt-get -qq install qmake6 qt6-base-dev qt6-declarative-dev qt6-image-formats-plugin-pdf qt6-image-formats-plugins qt6-pdf-dev linguist-qt6
+          sudo apt-get -qq install qt6-svg-dev libqt6svgwidgets6 qt6-l10n-tools qtchooser qt6-wayland qt6-wayland-dev qt6-tools-dev
           sudo apt-get -qq install libgl-dev libxcb-cursor0 libmuparser-dev libboost-dev libssl-dev libssl3
           sudo apt-get -qq install imagemagick librsvg2-bin libfreetype6-dev libicu-dev pkg-config libfuse2 rsync
           sudo apt-get -qq install cmake

--- a/CI/build-appimg-aarch64.sh
+++ b/CI/build-appimg-aarch64.sh
@@ -39,8 +39,43 @@ mkdir -p appdir/usr/share/librecad
 mkdir -p appdir/usr/lib/aarch64-linux-gnu/qt6
 echo "copying Qt6 plugins"
 export QPA_PLUGIN_FOLDER="$(find /usr/lib/aarch64-linux-gnu/qt6/ -type d -name plugins -print)"
-rsync -Par ${QPA_PLUGIN_FOLDER} appdir/usr/lib/aarch64-linux-gnu/qt6/
-rsync -Par ${QPA_PLUGIN_FOLDER}/platforms appdir/usr/bin/
+# See CI/build-appimg.sh for the full rationale, including which categories
+# appimagetool re-deploys wholesale regardless of what is staged here. In
+# short: the blanket copy pulled in libraries nothing in LibreCAD ever opens
+# (GTK3+Cairo+Pango+ATK, QML/Quick, the Wayland compositor side), and its
+# GTK3 platform theme plugin supplies its own font settings on GTK desktops.
+LC_QT_PLUGINS=(
+    platforms/libqxcb.so
+    platforms/libqwayland-egl.so
+    platforms/libqwayland-generic.so
+    platforms/libqminimal.so
+    platforms/libqoffscreen.so
+    xcbglintegrations/libqxcb-glx-integration.so
+    xcbglintegrations/libqxcb-egl-integration.so
+    platforminputcontexts/libcomposeplatforminputcontextplugin.so
+    platforminputcontexts/libibusplatforminputcontextplugin.so
+    iconengines/libqsvgicon.so
+    imageformats/libqgif.so
+    imageformats/libqico.so
+    imageformats/libqjpeg.so
+    imageformats/libqsvg.so
+    imageformats/libqtiff.so
+    tls/libqopensslbackend.so
+    tls/libqcertonlybackend.so
+    printsupport/libcupsprintersupport.so
+    wayland-decoration-client/libbradient.so
+    wayland-graphics-integration-client/libqt-plugin-wayland-egl.so
+    wayland-shell-integration/libxdg-shell.so
+)
+for plugin in "${LC_QT_PLUGINS[@]}"; do
+    src="${QPA_PLUGIN_FOLDER}/${plugin}"
+    if [ -f "${src}" ]; then
+        install -D "${src}" "appdir/usr/lib/aarch64-linux-gnu/qt6/plugins/${plugin}"
+    else
+        echo "warning: expected Qt6 plugin not found: ${src}" >&2
+    fi
+done
+cp -r appdir/usr/lib/aarch64-linux-gnu/qt6/plugins/platforms appdir/usr/bin/
 echo "copying xcb-cursor library"
 find /usr/lib -name "libxcb-cursor.so*" -exec cp -L {} appdir/usr/lib/ \;
 

--- a/CI/build-appimg.sh
+++ b/CI/build-appimg.sh
@@ -39,8 +39,65 @@ mkdir -p appdir/usr/share/librecad/qm
 mkdir -p appdir/usr/lib/x86_64-linux-gnu/qt6
 echo "copying Qt6 plugins"
 export QPA_PLUGIN_FOLDER="$(find /usr/lib/x86_64-linux-gnu/qt6/ -type d -name plugins -print)"
-rsync -Par ${QPA_PLUGIN_FOLDER} appdir/usr/lib/x86_64-linux-gnu/qt6/
-rsync -Par ${QPA_PLUGIN_FOLDER}/platforms appdir/usr/bin/
+# Only the plugin families LibreCAD actually loads at runtime: X11 and Wayland
+# QPA backends (desktop + native Wayland support, #2100), IME/compose input,
+# SVG icons, the raster formats surfaced in the image-import dialog, the TLS
+# backend the release-checker's HTTPS request needs, and CUPS printing.
+#
+# The previous `rsync -Par ${QPA_PLUGIN_FOLDER}` copied the *entire* system
+# Qt6 plugins tree, most of which is unrelated to anything LibreCAD links
+# (verified against CMakeLists.txt: only Core/Gui/Widgets/PrintSupport/Svg/
+# Network). appimagetool's deploy step then bundled every *transitive*
+# shared library those extra plugins pull in - GTK3 with its full Cairo/
+# Pango/ATK/AT-SPI stack (platformthemes/libqgtk3.so), the QML/Quick engine
+# (qmltooling/*), and the Wayland *compositor* side (LibreCAD is a client,
+# never a compositor). Bundling libqgtk3.so also lets Qt auto-select the
+# GTK3 platform theme on GTK desktops, which supplies its own font settings
+# instead of Qt's - the font half of #2734.
+#
+# Note that appimagetool re-deploys much of this from the system Qt no
+# matter what is staged here: given QtGui it copies all of iconengines/,
+# imageformats/ and platforminputcontexts/, given QtGui or libxcb-glx all
+# of xcbglintegrations/, and given QtNetwork all of tls/. It also picks up
+# printsupport/libcupsprintersupport.so and platforms/libqxcb.so - but
+# nothing else out of platforms/. So the entries that genuinely have to be
+# staged here are the non-xcb platform plugins (wayland, minimal,
+# offscreen) and the wayland-* integration plugins, without which native
+# Wayland support is lost; the rest are belt-and-braces. platformthemes/
+# is never re-deployed, which is precisely why dropping the blanket copy
+# is what removes libqgtk3.so.
+LC_QT_PLUGINS=(
+    platforms/libqxcb.so
+    platforms/libqwayland-egl.so
+    platforms/libqwayland-generic.so
+    platforms/libqminimal.so
+    platforms/libqoffscreen.so
+    xcbglintegrations/libqxcb-glx-integration.so
+    xcbglintegrations/libqxcb-egl-integration.so
+    platforminputcontexts/libcomposeplatforminputcontextplugin.so
+    platforminputcontexts/libibusplatforminputcontextplugin.so
+    iconengines/libqsvgicon.so
+    imageformats/libqgif.so
+    imageformats/libqico.so
+    imageformats/libqjpeg.so
+    imageformats/libqsvg.so
+    imageformats/libqtiff.so
+    tls/libqopensslbackend.so
+    tls/libqcertonlybackend.so
+    printsupport/libcupsprintersupport.so
+    wayland-decoration-client/libbradient.so
+    wayland-graphics-integration-client/libqt-plugin-wayland-egl.so
+    wayland-shell-integration/libxdg-shell.so
+)
+for plugin in "${LC_QT_PLUGINS[@]}"; do
+    src="${QPA_PLUGIN_FOLDER}/${plugin}"
+    if [ -f "${src}" ]; then
+        install -D "${src}" "appdir/usr/lib/x86_64-linux-gnu/qt6/plugins/${plugin}"
+    else
+        echo "warning: expected Qt6 plugin not found: ${src}" >&2
+    fi
+done
+cp -r appdir/usr/lib/x86_64-linux-gnu/qt6/plugins/platforms appdir/usr/bin/
 echo "copying xcb-cursor library"
 find /usr/lib -name "libxcb-cursor.so*" -exec cp -L {} appdir/usr/lib/ \;
 

--- a/scripts/build-osx.sh
+++ b/scripts/build-osx.sh
@@ -131,10 +131,43 @@ OUTPUT_DMG=${APP_FILE}.dmg
 
 if [[ $CODESIGN_IDENTITY ]]
 then
-	${QT_PATH}macdeployqt ${APP_FILE}.app -verbose=2 -dmg -always-overwrite -codesign=$CODESIGN_IDENTITY
+	${QT_PATH}macdeployqt ${APP_FILE}.app -verbose=2 -always-overwrite -codesign=$CODESIGN_IDENTITY
 else
-	${QT_PATH}macdeployqt ${APP_FILE}.app -verbose=2 -dmg -always-overwrite
+	${QT_PATH}macdeployqt ${APP_FILE}.app -verbose=2 -always-overwrite
 fi
+
+# macdeployqt bundles platforminputcontexts/libqtvirtualkeyboardplugin
+# unconditionally once QtGui is linked, even though LibreCAD never uses
+# virtual-keyboard input. That plugin drags in QtQuick/QtQml/QtQmlModels/
+# QtQmlWorkerScript/QtQmlMeta/QtOpenGL (~12 MB) as dead weight - and it
+# doesn't even work: macdeployqt can't resolve its own QtVirtualKeyboard[Qml]
+# framework dependencies, so the plugin would fail to load if Qt ever tried
+# it. Strip it and the frameworks it orphans before packaging the DMG.
+VKBD_PLUGIN="${APP_FILE}.app/Contents/PlugIns/platforminputcontexts/libqtvirtualkeyboardplugin.dylib"
+if [ -f "$VKBD_PLUGIN" ]
+then
+	rm -f "$VKBD_PLUGIN"
+	for fw in QtQuick QtQml QtQmlModels QtQmlWorkerScript QtQmlMeta QtOpenGL
+	do
+		rm -rf "${APP_FILE}.app/Contents/Frameworks/${fw}.framework"
+	done
+	# removing bundle contents after the fact invalidates macdeployqt's
+	# code-signature resource manifest; re-sign to match the trimmed bundle
+	if [[ $CODESIGN_IDENTITY ]]
+	then
+		codesign --force -s $CODESIGN_IDENTITY "${APP_FILE}.app"
+	else
+		codesign --force -s - "${APP_FILE}.app"
+	fi
+fi
+
+# build the DMG ourselves (macdeployqt's -dmg would redeploy from scratch,
+# undoing the plugin removal above) with the same drag-to-install layout
+DMG_STAGING_DIR=$(mktemp -d)
+cp -R "${APP_FILE}.app" "$DMG_STAGING_DIR/"
+ln -s /Applications "$DMG_STAGING_DIR/Applications"
+hdiutil create -volname "${APP_FILE}" -srcfolder "$DMG_STAGING_DIR" -ov -format UDRW -fs HFS+ "$OUTPUT_DMG"
+rm -rf "$DMG_STAGING_DIR"
 
 #bz2 compression
 hdiutil convert -shadow -format UDZO -ov -o "$OUTPUT_DMG" "$OUTPUT_DMG"


### PR DESCRIPTION
Fixes #2734 — the AppImage that grew and started rendering with a different font.

Both symptoms trace to one line, and the same class of bug turned out to exist on macOS via a different
tool. Windows was audited and needs no change.

## Root cause

`CI/build-appimg.sh` copied the **entire** system Qt6 plugins tree:

```bash
rsync -Par ${QPA_PLUGIN_FOLDER} appdir/usr/lib/x86_64-linux-gnu/qt6/
```

`appimagetool -s deploy` then does what it is supposed to do: it walks the shared-library dependencies of
everything already in `appdir` and bundles what they need. So every unrelated plugin that got rsync'd in
pulled its own transitive closure into the image — GTK3 with Cairo/Pango/ATK/AT-SPI behind
`platformthemes/libqgtk3.so`, the QML/Quick engine behind `qmltooling/*`, and the Wayland **compositor**
side (LibreCAD is a Wayland client, never a compositor).

The font change is the same line. Bundling `libqgtk3.so` lets Qt's platform-theme auto-detection select
the GTK3 theme on GTK-based desktops, and that theme supplies its own font settings — family *and* size —
instead of Qt's. Confirmed by diffing `QT_DEBUG_PLUGINS=1` output with and without the plugin present.

This is also the mechanism behind #2113, so this class of bug has bitten the project before.

## What the curated list actually changes

Worth being precise, because `appimagetool` has its own opinions and they partly overlap with the script.
From [`appdirtool.go`](https://github.com/probonopd/go-appimage/blob/master/src/appimagetool/appdirtool.go),
its deploy step re-copies these **wholesale from the system Qt**, no matter what the script stages:

| condition | re-deployed wholesale |
| --- | --- |
| QtGui present | all of `iconengines/`, `imageformats/`, `platforminputcontexts/` |
| QtGui / libxcb-glx | all of `xcbglintegrations/` |
| QtNetwork present | all of `bearer/`, `tls/` |
| QtPrintSupport | `printsupport/libcupsprintersupport.so` only |
| always | `platforms/libqxcb.so` **only** |

So the reduction comes from the categories it *never* re-adds — `platformthemes/` (the font fix),
`qmltooling/`, `qmllint/`, `designer/`, `sqldrivers/`, `generic/`, `egldeviceintegrations/` and the
compositor-side Wayland plugins — and the Wayland **client** plugins have to be staged explicitly, or
native Wayland support (#2100) is silently lost. Entries for the five wholesale
categories are belt-and-braces: harmless, and they keep the AppDir self-describing if appimagetool's
behaviour changes. The script comments now record all of this so the list does not get "simplified" back
into a blanket copy.

Being honest about the number: the ~51 MB I measured is the dependency closure of *all* the plugins the
curated list drops. Because appimagetool re-adds those five categories, the realised saving is smaller
than that, and I have not re-measured the exact post-fix delta — producing a real AppImage requires the
`build-all.yml` workflow, which (see below) does not run on PRs.

## macOS

`macdeployqt` has the same problem from the other direction: it bundles
`platforminputcontexts/libqtvirtualkeyboardplugin.dylib` unconditionally once QtGui is linked, and that
plugin pulls in `QtQuick`, `QtQml`, `QtQmlModels`, `QtQmlWorkerScript`, `QtQmlMeta` and `QtOpenGL` —
**~12 MB** for a virtual keyboard LibreCAD never uses. It cannot even load:

```
Log: Skipping outside dependency:  ".../QtVirtualKeyboard.framework/Versions/A/QtVirtualKeyboard"
Log: Skipping outside dependency:  ".../QtVirtualKeyboardQml.framework/Versions/A/QtVirtualKeyboardQml"
```

`macdeployqt` has no per-plugin exclusion flag, and `-no-plugins` also drops the mandatory
`platforms/libqcocoa.dylib` (tested — the app will not start). So `scripts/build-osx.sh` drops `-dmg`,
removes the plugin and the frameworks it orphans, re-signs, and builds the image itself.

Two details that are load-bearing:

- **Re-signing is required, not cosmetic.** `macdeployqt` ad-hoc-signs by default even without
  `-codesign=`, and deleting bundle contents afterwards invalidates the sealed resource manifest. Verified
  on a synthetic bundle: sign → delete a resource → `codesign -v` fails with *"a sealed resource is missing
  or invalid"* → re-sign → passes.
- **`-fs HFS+` is pinned deliberately.** `macdeployqt -dmg` uses HFS+; a bare `hdiutil create` defaults to
  whatever the host prefers (APFS on current macOS). Pinning keeps the shipped image format stable rather
  than varying with the runner's OS version.

### What this actually does to the shipped DMG: nothing, today

I checked rather than assumed, by unpacking the real published artifacts.

**`LibreCAD-2.2.2_alpha1-612-g768b7d4ce-arm64.dmg`** — built from `768b7d4ce`, which is precisely this PR's
base commit — carries exactly seven frameworks (`QtCore`, `QtDBus`, `QtGui`, `QtNetwork`, `QtPrintSupport`,
`QtSvg`, `QtWidgets`) and six plugin categories, with **no `platforminputcontexts`, no virtual keyboard and
no QML/Quick/OpenGL at all**. CI installs official Qt with `modules: 'qt5compat'`, which does not include
qtvirtualkeyboard, so `macdeployqt` has nothing to bundle. **The guard skips and the shipped DMG is
unchanged.**

So the ~12 MB is not a saving against today's release. It is real for Qt installs that *do* carry
qtvirtualkeyboard — Homebrew, which is what `build-osx.sh` targets for local builds. And it is not
hypothetical: **`LibreCAD-v2.2.1.5-arm64.dmg` shipped ~13 MB of it** — `virtualkeyboard/` (3.3 MB),
`QtVirtualKeyboard.framework` (852 KB), `QtQuick` (4.5 MB), `QtQml` (3.8 MB), `QtQmlModels` (516 KB) — in a
126 MB bundle, with `otool -L` confirming nothing but the keyboard plugins referenced any of it. One Qt
packaging change is all it takes for that to come back, which is the case for keeping the guard.

That release also exposes a gap: it bundles a whole `PlugIns/virtualkeyboard/` IME directory and
`QtVirtualKeyboard.framework`, neither of which the six-framework list here removes. Worth widening if this
is kept — noted below rather than fixed blind, since I have no current Qt build that reproduces it.

### One unconditional change reviewers should notice

The DMG restructuring runs whether or not the plugin was found. The published DMG today contains only
`LibreCAD.app`; building it with `hdiutil` adds an `/Applications` symlink beside it, so users get the
usual drag-to-install layout instead of dragging out to Finder. I read that as an improvement, but it is a
visible change and not one the issue asked for. Filesystem is unaffected — the shipped image is
`Apple_HFS` and `-fs HFS+` keeps it that way (verified with `hdiutil pmap` on both).

## Windows

Audited, no change needed. `windeployqt` bundles from the executable's actual imports rather than copying
a directory, and the NSIS `File /nonfatal` list is already a deliberate curated fallback. It did surface a
gap in the other direction: Windows ships `qtiff.dll` but Linux was not shipping the TIFF plugin, so that
is now added.

## Two packages made explicit

`qt6-image-formats-plugins` (sole provider of `libqtiff.so`) and `qt6-wayland` (which owns *every* Wayland
plugin file the new list references — `qt6-wayland-dev` does not depend on it). Both were previously
arriving only through apt's `Recommends` chain via `libqt6gui6t64`. That is the same implicit mechanism
that pulled in `qt6-gtk-platformtheme` and caused this bug, and it would break silently under a routine
`--no-install-recommends` hardening pass.

## Verification

Not desk-checked — built and run:

- Ubuntu 24.04 container with the workflow's exact package list; built LibreCAD from source, ran the real
  curated-copy logic (all 21 entries resolved, zero warnings), then launched the binary with the **system
  Qt6 plugin directory renamed away** so only bundled plugins were reachable. Clean startup, no fatal
  errors in a 218-line `QT_DEBUG_PLUGINS=1` trace, `libqtiff.so` loading from the bundled path.
- macOS (Apple Silicon, Homebrew Qt): ran the full new pipeline — `macdeployqt6` → cleanup → re-sign →
  `hdiutil create` → `hdiutil convert` → mount and inspect. 248 MB → 236 MB, DMG mounts with the trimmed
  app and a working `/Applications` symlink, `hdiutil pmap` confirms `Apple_HFS`. Launched the cleaned
  binary under `DYLD_PRINT_LIBRARIES`: every dependency resolves, nothing missing, no crash.
- `otool -L` sweep of every other bundled macOS plugin: the virtual-keyboard plugin is the only one
  pulling anything from the Qml/Quick/OpenGL family.
- A second pass on **aarch64** (different arch from the checks above) diffed the old rsync tree against
  the new one directly: the only difference is deletions — no file moves, no renames — so Qt's plugin
  lookup path is untouched. Both arrays are byte-identical across the two scripts (md5 and hexdump), all
  21 entries resolve on both architectures, and there is not a single symlink in the Debian Qt6 plugin
  layout, so `install -D`'s dereference cannot drop or duplicate anything. It does change mode 644 → 755,
  which nothing cares about: neither `dlopen` nor appimagetool's ELF scanner consults the execute bit.
- The dropped `networkinformation/` plugin is not re-added by appimagetool, so it was checked directly
  rather than reasoned about: a probe issuing the release checker's exact request against both trees
  returned `NoError` and a byte-identical response, with `QSslSocket::supportsSsl() == true`.

One caveat reviewers should weigh: `build-all.yml` triggers on `push` to `master`/`2.2.1` only, not on
`pull_request`, so **the workflow that builds the AppImage and DMG does not run on this PR** — the checks
here are CodeQL and the pixi builds, which compile the app but never execute these packaging scripts. The
out-of-band verification above stands in for that missing coverage; the change is unexercised by CI until
it reaches `master`.

## One tradeoff worth stating explicitly

Dropping `platformthemes/libqgtk3.so` removes more than the font override. `QGtk3Theme` also supplies
native GTK **file, colour and font dialogs**, so on GTK-based desktops those revert to Qt's own dialogs
(22 files under `librecad/src` use `QFileDialog`/`QColorDialog`/`QFontDialog`). appimagetool was bundling a
working GTK stack alongside it — `deployGtkDirectory()` pulls in GDK/GTK modules whenever a `libgtk-*` is
present in the AppDir — so this was live behaviour, not dead weight.

I think losing it is the right call anyway: bundling a full GTK3 stack inside an AppImage and letting it
meet the host's GTK at runtime is exactly the sort of arrangement that produces theme and GIO-module
mismatches, and it is what dragged in the ~50 MB and changed the font in the first place. But it is a
visible change for GNOME users and reviewers should decide it deliberately rather than discover it.

## Deliberate follow-ups, not in this PR

- **`qt6-image-formats-plugin-pdf` / `qt6-pdf-dev` look droppable and are worth ~4.5 MB.** Nothing in the
  tree references `Qt6::Pdf`; the packages have been in the apt list since Jan 2025 (33a91b02c) and appear
  to have been carried along rather than chosen. Because appimagetool re-deploys `imageformats/` wholesale,
  `libqpdf.so` — and `libqt6pdf6` behind it (4434 KB installed, plus 241 KB for the plugin) — ships in
  every AppImage regardless of this PR. Removing the packages is the only thing that actually drops it.
  Left out because it removes a real if accidental capability (opening a PDF through the image-import
  dialog), which is a maintainer call rather than packaging hygiene.
- **A regression guard.** Nothing prevents the blanket copy from being reinstated, and the copy loop is
  warn-only by design. A cheap assertion after deploy — fail if `platformthemes/libqgtk3.so` is present in
  the AppDir — would pin the fix permanently.
- **Widen the macOS removal to `PlugIns/virtualkeyboard/` and `QtVirtualKeyboard.framework`**, per the
  v2.2.1.5 evidence above. Left out because no Qt build I have access to currently produces them, so I
  cannot verify the change end-to-end, and I would rather not ship an unexercised `rm -rf`.
- **Happy to split the macOS half into its own PR** if you would rather keep this one strictly to the
  Linux fix that closes #2734 — the two halves share a diagnosis but not a line of code, and the macOS
  half currently changes the shipped DMG's layout without reducing its size.
- **Pre-existing, found while auditing this and unrelated to the change:** LibreCAD's own icon-engine
  plugin never reaches the AppImage. `libraries/lciconengine` builds `lc_svgiconengine` via
  `qt_add_plugin`, and `main.cpp:360` adds `applicationDirPath()/iconengines` to the library paths, but
  both AppImage scripts copy only `unix/resources/plugins/*/*.so` into `usr/lib/librecad/` — nothing ever
  lands in `usr/bin/iconengines/`. The blanket rsync never covered it either, since it only ever copied
  *system* plugins, so this is not a regression from this PR. Qt's own `libqsvgicon.so` is bundled and
  still renders SVG icons, which is presumably why it has gone unnoticed.

The changes are packaging-only; no application code is touched.
