### PR TITLE
Add a projective pencil solver for general conic intersections

### DIFF
--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -73,6 +73,8 @@ namespace {
     using CubicPolynomial = std::array<double, 4>;
 
     constexpr double projectiveMachineTolerance = 128.0 * std::numeric_limits<double>::epsilon();
+    constexpr double projectiveRankTolerance = 1.0e-8;
+    constexpr double projectiveRootTolerance = 1.0e-10;
     constexpr double projectiveResidualTolerance = 1.0e-8;
 
     double maxAbs(const ProjectiveVector& vector) {
@@ -85,6 +87,14 @@ namespace {
             for (const double value : row) {
                 result = std::max(result, std::abs(value));
             }
+        }
+        return result;
+    }
+
+    double maxAbs(const std::vector<double>& values) {
+        double result = 0.0;
+        for (const double value : values) {
+            result = std::max(result, std::abs(value));
         }
         return result;
     }
@@ -144,24 +154,109 @@ namespace {
         }};
     }
 
+    bool normalizeConicCoefficients(const std::vector<double>& coefficients,
+                                    std::vector<double>& normalized) {
+        const double scale = maxAbs(coefficients);
+        if (!std::isfinite(scale) || scale == 0.0) {
+            return false;
+        }
+        int exponent = 0;
+        std::frexp(scale, &exponent);
+        normalized = coefficients;
+        for (double& coefficient : normalized) {
+            coefficient = std::ldexp(coefficient, -exponent);
+        }
+        return true;
+    }
+
     std::vector<double> translateConic(const std::vector<double>& coefficients,
                                        const double xOffset,
                                        const double yOffset) {
-        const double a = coefficients[0];
-        const double b = coefficients[1];
-        const double c = coefficients[2];
-        const double d = coefficients[3];
-        const double e = coefficients[4];
-        const double f = coefficients[5];
+        const long double a = coefficients[0];
+        const long double b = coefficients[1];
+        const long double c = coefficients[2];
+        const long double d = coefficients[3];
+        const long double e = coefficients[4];
+        const long double f = coefficients[5];
+        const long double x = xOffset;
+        const long double y = yOffset;
         return {
-            a,
-            b,
-            c,
-            2.0 * a * xOffset + b * yOffset + d,
-            b * xOffset + 2.0 * c * yOffset + e,
-            a * xOffset * xOffset + b * xOffset * yOffset + c * yOffset * yOffset
-                + d * xOffset + e * yOffset + f
+            static_cast<double>(a),
+            static_cast<double>(b),
+            static_cast<double>(c),
+            static_cast<double>(2.0L * a * x + b * y + d),
+            static_cast<double>(b * x + 2.0L * c * y + e),
+            static_cast<double>(a * x * x + b * x * y + c * y * y
+                                + d * x + e * y + f)
         };
+    }
+
+    std::vector<double> scaleConicCoordinates(const std::vector<double>& coefficients,
+                                              const double coordinateScale) {
+        return {
+            coefficients[0] * coordinateScale * coordinateScale,
+            coefficients[1] * coordinateScale * coordinateScale,
+            coefficients[2] * coordinateScale * coordinateScale,
+            coefficients[3] * coordinateScale,
+            coefficients[4] * coordinateScale,
+            coefficients[5]
+        };
+    }
+
+    void appendCharacteristicScales(const std::vector<double>& coefficients,
+                                    std::vector<double>& scales) {
+        double quadraticScale = std::max({std::abs(coefficients[0]),
+                                          std::abs(coefficients[1]),
+                                          std::abs(coefficients[2])});
+        double linearScale = std::max(std::abs(coefficients[3]),
+                                      std::abs(coefficients[4]));
+        double constantScale = std::abs(coefficients[5]);
+        if (constantScale <= projectiveMachineTolerance
+                             * std::max(quadraticScale, linearScale)) {
+            constantScale = 0.0;
+        }
+        if (linearScale <= projectiveMachineTolerance
+                           * std::max(quadraticScale, constantScale)) {
+            linearScale = 0.0;
+        }
+        const auto append = [&scales](const double scale) {
+            if (std::isfinite(scale) && scale > 0.0) {
+                scales.push_back(scale);
+            }
+        };
+        if (quadraticScale > 0.0) {
+            if (constantScale > 0.0) {
+                append(std::sqrt(constantScale / quadraticScale));
+            }
+            if (linearScale > 0.0) {
+                append(linearScale / quadraticScale);
+            }
+        }
+        if (linearScale > 0.0 && constantScale > 0.0) {
+            append(constantScale / linearScale);
+        }
+    }
+
+    double characteristicCoordinateScale(const std::vector<double>& first,
+                                         const std::vector<double>& second) {
+        std::vector<double> scales;
+        appendCharacteristicScales(first, scales);
+        appendCharacteristicScales(second, scales);
+        if (scales.empty()) {
+            return 1.0;
+        }
+        long double logarithmSum = 0.0L;
+        for (const double scale : scales) {
+            logarithmSum += std::log(static_cast<long double>(scale));
+        }
+        const long double logarithmicMean = logarithmSum / static_cast<long double>(scales.size());
+        const long double scale = std::exp(logarithmicMean);
+        if (!std::isfinite(scale)
+            || scale < static_cast<long double>(std::numeric_limits<double>::min())
+            || scale > static_cast<long double>(std::numeric_limits<double>::max())) {
+            return 1.0;
+        }
+        return static_cast<double>(scale);
     }
 
     bool conicCenter(const std::vector<double>& coefficients,
@@ -171,14 +266,17 @@ namespace {
         const double c = coefficients[2];
         const double d = coefficients[3];
         const double e = coefficients[4];
-        const double determinant = 4.0 * a * c - b * b;
-        const double quadraticScale = std::max({std::abs(a), std::abs(b), std::abs(c), 1.0});
-        if (std::abs(determinant) <= 1.0e-12 * quadraticScale * quadraticScale) {
+        const long double determinant = 4.0L * a * c - static_cast<long double>(b) * b;
+        const double quadraticScale = std::max({std::abs(a), std::abs(b), std::abs(c)});
+        if (quadraticScale == 0.0) {
+            return false;
+        }
+        if (std::abs(determinant) <= 1.0e-12L * quadraticScale * quadraticScale) {
             return false;
         }
         center = {{
-            (b * e - 2.0 * c * d) / determinant,
-            (b * d - 2.0 * a * e) / determinant,
+            static_cast<double>((static_cast<long double>(b) * e - 2.0L * c * d) / determinant),
+            static_cast<double>((static_cast<long double>(b) * d - 2.0L * a * e) / determinant),
             1.0
         }};
         return std::isfinite(center[0]) && std::isfinite(center[1])
@@ -195,7 +293,10 @@ namespace {
         const double c = coefficients[2];
         const double d = coefficients[3];
         const double e = coefficients[4];
-        const double quadraticScale = std::max({std::abs(a), std::abs(b), std::abs(c), 1.0});
+        const double quadraticScale = std::max({std::abs(a), std::abs(b), std::abs(c)});
+        if (quadraticScale == 0.0) {
+            return false;
+        }
         const double average = 0.5 * (a + c);
         const double halfDifference = 0.5 * (a - c);
         const double halfCross = 0.5 * b;
@@ -223,8 +324,9 @@ namespace {
         const ProjectiveVector nullDirection{{-direction[1], direction[0], 0.0}};
         const double nullLinear = conditioned[3] * nullDirection[0]
                                   + conditioned[4] * nullDirection[1];
-        if (std::abs(nullLinear) > projectiveMachineTolerance
-            * std::max({std::abs(conditioned[3]), std::abs(conditioned[4]), 1.0})) {
+        const double linearScale = std::max(std::abs(conditioned[3]), std::abs(conditioned[4]));
+        if (linearScale > 0.0
+            && std::abs(nullLinear) > projectiveMachineTolerance * linearScale) {
             const double nullOffset = -conditioned[5] / nullLinear;
             point[0] += nullOffset * nullDirection[0];
             point[1] += nullOffset * nullDirection[1];
@@ -252,7 +354,7 @@ namespace {
         const bool duplicate = std::any_of(roots.cbegin(), roots.cend(),
                                             [root, scale](const double existing) {
                                                 return std::abs(existing - root)
-                                                       <= projectiveResidualTolerance * scale;
+                                                <= projectiveRootTolerance * scale;
                                             });
         if (!duplicate) {
             roots.push_back(root);
@@ -261,7 +363,10 @@ namespace {
 
     void solveRealQuadratic(const long double a, const long double b, const long double c,
                             std::vector<double>& roots) {
-        const long double scale = std::max({std::abs(a), std::abs(b), std::abs(c), 1.0L});
+        const long double scale = std::max({std::abs(a), std::abs(b), std::abs(c)});
+        if (scale == 0.0L) {
+            return;
+        }
         if (std::abs(a) <= projectiveMachineTolerance * scale) {
             if (std::abs(b) > projectiveMachineTolerance * scale) {
                 appendUniqueRoot(roots, static_cast<double>(-c / b));
@@ -269,7 +374,7 @@ namespace {
             return;
         }
         long double discriminant = b * b - 4.0L * a * c;
-        const long double discriminantScale = std::max({b * b, std::abs(4.0L * a * c), 1.0L});
+        const long double discriminantScale = std::max(b * b, std::abs(4.0L * a * c));
         if (discriminant < -projectiveMachineTolerance * discriminantScale) {
             return;
         }
@@ -294,9 +399,13 @@ namespace {
     std::vector<double> solveRealPolynomial(const CubicPolynomial& polynomial) {
         std::vector<double> roots;
         const double scale = std::max({std::abs(polynomial[0]), std::abs(polynomial[1]),
-                                       std::abs(polynomial[2]), std::abs(polynomial[3]), 1.0});
+                                       std::abs(polynomial[2]), std::abs(polynomial[3])});
         if (!std::all_of(polynomial.cbegin(), polynomial.cend(),
                          [](const double value) { return std::isfinite(value); })) {
+            return roots;
+        }
+
+        if (scale == 0.0) {
             return roots;
         }
 
@@ -323,8 +432,8 @@ namespace {
         const long double p = b - a * a / 3.0L;
         const long double q = 2.0L * a * a * a / 27.0L - a * b / 3.0L + c;
         const long double discriminant = q * q / 4.0L + p * p * p / 27.0L;
-        const long double discriminantScale = std::max({q * q / 4.0L,
-                                                        std::abs(p * p * p / 27.0L), 1.0L});
+        const long double discriminantScale = std::max(q * q / 4.0L,
+                                                       std::abs(p * p * p / 27.0L));
         if (discriminant > projectiveMachineTolerance * discriminantScale) {
             const long double radical = std::sqrt(discriminant);
             const long double u = std::cbrt(-q / 2.0L + radical);
@@ -332,7 +441,7 @@ namespace {
             appendUniqueRoot(roots, static_cast<double>(u + v - a / 3.0L));
             return roots;
         }
-        if (std::abs(p) <= projectiveMachineTolerance * std::max(1.0L, std::abs(q))) {
+        if (std::abs(p) <= projectiveMachineTolerance * std::max(std::abs(p), std::abs(q))) {
             appendUniqueRoot(roots, static_cast<double>(-a / 3.0L));
             return roots;
         }
@@ -351,6 +460,44 @@ namespace {
                                                          - a / 3.0L));
         }
         return roots;
+    }
+
+    double polishPolynomialRoot(const CubicPolynomial& polynomial, const double initialRoot) {
+        long double root = initialRoot;
+        for (size_t iteration = 0; iteration < 5; ++iteration) {
+            const long double value = ((static_cast<long double>(polynomial[3]) * root
+                                        + polynomial[2]) * root
+                                       + polynomial[1]) * root
+                                      + polynomial[0];
+            const long double derivative = (3.0L * polynomial[3] * root
+                                             + 2.0L * polynomial[2]) * root
+                                            + polynomial[1];
+            const long double derivativeScale = std::max({
+                std::abs(3.0L * polynomial[3] * root * root),
+                std::abs(2.0L * polynomial[2] * root),
+                std::abs(static_cast<long double>(polynomial[1]))
+            });
+            if (!std::isfinite(value) || !std::isfinite(derivative)
+                || derivativeScale == 0.0L
+                || std::abs(derivative) <= projectiveMachineTolerance * derivativeScale) {
+                break;
+            }
+            const long double step = value / derivative;
+            if (!std::isfinite(step)) {
+                break;
+            }
+            root -= step;
+            if (std::abs(step) <= projectiveMachineTolerance * std::max(1.0L, std::abs(root))) {
+                break;
+            }
+        }
+        return std::isfinite(root) ? static_cast<double>(root) : initialRoot;
+    }
+
+    double projectiveDeterminant(const ProjectiveMatrix& matrix) {
+        return matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+               - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+               + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0]);
     }
 
     ProjectiveMatrix pencilMatrix(const ProjectiveMatrix& first,
@@ -392,7 +539,8 @@ namespace {
                 }
             }
         }
-        if (nullScale <= projectiveMachineTolerance * std::max(1.0, maxAbs(matrix))) {
+        const double matrixScale = maxAbs(matrix);
+        if (nullScale <= projectiveRankTolerance * matrixScale) {
             // A tangent pencil can contain a rank-1 member, which is a double
             // line rather than two independent lines. Extract that line from
             // any non-zero diagonal pivot and return it twice.
@@ -403,7 +551,7 @@ namespace {
                 }
             }
             const double diagonalScale = std::abs(matrix[diagonal][diagonal]);
-            if (diagonalScale <= projectiveMachineTolerance * std::max(1.0, maxAbs(matrix))) {
+            if (diagonalScale <= projectiveRankTolerance * matrixScale) {
                 return false;
             }
             const double normalizer = std::sqrt(diagonalScale);
@@ -452,7 +600,11 @@ namespace {
         const double qa = dot(firstDirection, matrixTimesFirst);
         const double qb = dot(firstDirection, matrixTimesSecond);
         const double qc = dot(secondDirection, matrixTimesSecond);
-        const double discriminantScale = std::max({std::abs(qb * qb), std::abs(qa * qc), 1.0});
+        const double restrictedScale = std::max({std::abs(qa), std::abs(qb), std::abs(qc)});
+        if (restrictedScale == 0.0) {
+            return false;
+        }
+        const double discriminantScale = std::max(std::abs(qb * qb), std::abs(qa * qc));
         double discriminant = qb * qb - qa * qc;
         if (discriminant < -projectiveResidualTolerance * discriminantScale) {
             return false;
@@ -462,7 +614,8 @@ namespace {
         }
 
         std::array<ProjectiveVector, 2> directions{};
-        if (std::abs(qa) > projectiveMachineTolerance && std::abs(qa) >= std::abs(qc)) {
+        if (std::abs(qa) > projectiveMachineTolerance * restrictedScale
+            && std::abs(qa) >= std::abs(qc)) {
             const double radical = std::sqrt(discriminant);
             const double firstRoot = (-qb + radical) / qa;
             const double secondRoot = (-qb - radical) / qa;
@@ -473,7 +626,7 @@ namespace {
                               secondRoot * firstDirection[1] + secondDirection[1],
                               secondRoot * firstDirection[2] + secondDirection[2]}};
         }
-        else if (std::abs(qc) > projectiveMachineTolerance) {
+        else if (std::abs(qc) > projectiveMachineTolerance * restrictedScale) {
             const double radical = std::sqrt(discriminant);
             const double firstRoot = (-qb + radical) / qc;
             const double secondRoot = (-qb - radical) / qc;
@@ -484,7 +637,7 @@ namespace {
                               firstDirection[1] + secondRoot * secondDirection[1],
                               firstDirection[2] + secondRoot * secondDirection[2]}};
         }
-        else if (std::abs(qb) > projectiveMachineTolerance) {
+        else if (std::abs(qb) > projectiveMachineTolerance * restrictedScale) {
             directions[0] = firstDirection;
             directions[1] = secondDirection;
         }
@@ -525,6 +678,31 @@ namespace {
             }
         }
         return std::max(1.0, scale);
+    }
+
+    bool verifyAffineCandidate(const std::vector<double>& coefficients,
+                               const double x,
+                               const double y) {
+        const long double lx = x;
+        const long double ly = y;
+        const std::array<long double, 6> terms = {{
+            static_cast<long double>(coefficients[0]) * lx * lx,
+            static_cast<long double>(coefficients[1]) * lx * ly,
+            static_cast<long double>(coefficients[2]) * ly * ly,
+            static_cast<long double>(coefficients[3]) * lx,
+            static_cast<long double>(coefficients[4]) * ly,
+            static_cast<long double>(coefficients[5])
+        }};
+        long double value = 0.0L;
+        long double scale = 0.0L;
+        for (const long double term : terms) {
+            value += term;
+            scale += std::abs(term);
+        }
+        if (!std::isfinite(value) || !std::isfinite(scale)) {
+            return false;
+        }
+        return std::abs(value) <= projectiveResidualTolerance * std::max(1.0L, scale);
     }
 
     bool refineProjectivePoint(const ProjectiveMatrix& first,
@@ -627,6 +805,54 @@ namespace {
             }
             appendProjectiveCandidate(conic, otherConic, candidate, result);
         }
+    }
+
+    void appendSingularMemberCandidates(const ProjectiveMatrix& singular,
+                                        const ProjectiveMatrix& first,
+                                        const ProjectiveMatrix& second,
+                                        RS_VectorSolutions& result) {
+        const double scale = maxAbs(singular);
+        if (!std::isfinite(scale) || scale == 0.0) {
+            return;
+        }
+        ProjectiveMatrix normalized = singular;
+        for (auto& row : normalized) {
+            for (double& value : row) {
+                value /= scale;
+            }
+        }
+        if (std::abs(projectiveDeterminant(normalized)) > projectiveRankTolerance) {
+            return;
+        }
+        std::array<ProjectiveVector, 2> lines{};
+        if (!factorSingularConic(normalized, lines)) {
+            return;
+        }
+        const size_t initialSize = result.size();
+        for (const auto& line : lines) {
+            appendLineConicCandidates(line, first, second, result);
+        }
+        if (result.size() == initialSize) {
+            for (const auto& line : lines) {
+                appendLineConicCandidates(line, second, first, result);
+            }
+        }
+    }
+
+    void appendPencilCandidates(const ProjectiveMatrix& first,
+                                const ProjectiveMatrix& second,
+                                RS_VectorSolutions& result) {
+        const CubicPolynomial determinant = pencilDeterminant(first, second);
+        for (const double root : solveRealPolynomial(determinant)) {
+            const double parameter = polishPolynomialRoot(determinant, root);
+            appendSingularMemberCandidates(pencilMatrix(first, second, parameter),
+                                           first, second, result);
+        }
+
+        // The affine parameterization C1 + lambda*C2 omits lambda=infinity.
+        // Trying both endpoints also covers singular input conics directly.
+        appendSingularMemberCandidates(first, first, second, result);
+        appendSingularMemberCandidates(second, first, second, result);
     }
 
     const QRegularExpression REGEXP_UNIT(R"((?P<sign>^-?))" R"((?:(?:(?:(?P<degrees>\d+\.?\d*)(?:degree[s]?|deg|[Dd]|°)))" // DMS
@@ -1670,10 +1896,18 @@ RS_VectorSolutions RS_Math::simultaneousQuadraticSolverProjective(
         return result;
     }
 
+    std::vector<double> normalizedFirst;
+    std::vector<double> normalizedSecond;
+    if (!normalizeConicCoefficients(m[0], normalizedFirst)
+        || !normalizeConicCoefficients(m[1], normalizedSecond)) {
+        return result;
+    }
+    const std::array<std::vector<double>, 2> normalized = {{normalizedFirst, normalizedSecond}};
+
     double xOffset = 0.0;
     double yOffset = 0.0;
     size_t centerCount = 0;
-    for (const auto& coefficients : m) {
+    for (const auto& coefficients : normalized) {
         ProjectiveVector center{};
         if (conicConditioningPoint(coefficients, center)) {
             xOffset += center[0];
@@ -1685,8 +1919,11 @@ RS_VectorSolutions RS_Math::simultaneousQuadraticSolverProjective(
         xOffset /= static_cast<double>(centerCount);
         yOffset /= static_cast<double>(centerCount);
     }
-    const std::vector<double> conditionedFirst = translateConic(m[0], xOffset, yOffset);
-    const std::vector<double> conditionedSecond = translateConic(m[1], xOffset, yOffset);
+    const std::vector<double> translatedFirst = translateConic(normalizedFirst, xOffset, yOffset);
+    const std::vector<double> translatedSecond = translateConic(normalizedSecond, xOffset, yOffset);
+    const double coordinateScale = characteristicCoordinateScale(translatedFirst, translatedSecond);
+    const std::vector<double> conditionedFirst = scaleConicCoordinates(translatedFirst, coordinateScale);
+    const std::vector<double> conditionedSecond = scaleConicCoordinates(translatedSecond, coordinateScale);
     if (!isFiniteCoefficients(conditionedFirst) || !isFiniteCoefficients(conditionedSecond)) {
         return result;
     }
@@ -1708,20 +1945,19 @@ RS_VectorSolutions RS_Math::simultaneousQuadraticSolverProjective(
         return result;
     }
 
-    const auto determinant = pencilDeterminant(first, second);
     RS_VectorSolutions conditionedResult;
-    for (const double parameter : solveRealPolynomial(determinant)) {
-        const ProjectiveMatrix singular = pencilMatrix(first, second, parameter);
-        std::array<ProjectiveVector, 2> lines{};
-        if (!factorSingularConic(singular, lines)) {
-            continue;
-        }
-        for (const auto& line : lines) {
-            appendLineConicCandidates(line, first, second, conditionedResult);
-        }
+    appendPencilCandidates(first, second, conditionedResult);
+    if (conditionedResult.empty()) {
+        appendPencilCandidates(second, first, conditionedResult);
     }
     for (const RS_Vector& point : conditionedResult) {
-        result.push_back(RS_Vector(point.x + xOffset, point.y + yOffset));
+        const double x = std::fma(coordinateScale, point.x, xOffset);
+        const double y = std::fma(coordinateScale, point.y, yOffset);
+        if (std::isfinite(x) && std::isfinite(y)
+            && verifyAffineCandidate(normalizedFirst, x, y)
+            && verifyAffineCandidate(normalizedSecond, x, y)) {
+            result.push_back(RS_Vector(x, y));
+        }
     }
     return result;
 }
@@ -1751,7 +1987,7 @@ RS_VectorSolutions RS_Math::simultaneousQuadraticSolverFull(const std::vector<st
         return ret;
     }
     const RS_VectorSolutions projective = simultaneousQuadraticSolverProjective(m);
-    if (!projective.empty()) {
+    if (projective.size() >= 4) {
         return projective;
     }
     /** eliminate x, quartic equation of y **/
@@ -1830,8 +2066,8 @@ RS_VectorSolutions RS_Math::simultaneousQuadraticSolverFull(const std::vector<st
     //     std::cout<<"roots.size()= "<<roots.size()<<std::endl;
     // }
 
-    if (roots.empty() ) { // no intersection found
-        return ret;
+    if (roots.empty() ) { // no intersection found by the fallback
+        return projective;
     }
     std::vector<double> ce(0, 0.);
 
@@ -1898,7 +2134,16 @@ RS_VectorSolutions RS_Math::simultaneousQuadraticSolverFull(const std::vector<st
                                                             || filtered.getClosestDistance(vp) >= RS_TOLERANCE  );
 
     });
-    return filtered;
+    RS_VectorSolutions merged = projective;
+    for (const RS_Vector& point : filtered) {
+        if (merged.empty() || merged.getClosestDistance(point) >= RS_TOLERANCE) {
+            merged.push_back(point);
+            if (merged.size() == 4) {
+                break;
+            }
+        }
+    }
+    return merged;
 }
 
 RS_VectorSolutions RS_Math::simultaneousQuadraticSolverMixed(const std::vector<std::vector<double> >& m)

--- a/librecad/src/lib/math/rs_math.cpp
+++ b/librecad/src/lib/math/rs_math.cpp
@@ -29,7 +29,10 @@
 #include <QDebug>
 #include <QRegularExpressionMatch>
 #include <QString>
+#include <algorithm>
+#include <array>
 #include <cmath>
+#include <limits>
 #include <muParser.h>
 #include <boost/math/special_functions/ellint_2.hpp>
 #include <boost/numeric/ublas/lu.hpp>
@@ -63,6 +66,567 @@ namespace {
             }
         }
         return true;
+    }
+
+    using ProjectiveVector = std::array<double, 3>;
+    using ProjectiveMatrix = std::array<std::array<double, 3>, 3>;
+    using CubicPolynomial = std::array<double, 4>;
+
+    constexpr double projectiveMachineTolerance = 128.0 * std::numeric_limits<double>::epsilon();
+    constexpr double projectiveResidualTolerance = 1.0e-8;
+
+    double maxAbs(const ProjectiveVector& vector) {
+        return std::max({std::abs(vector[0]), std::abs(vector[1]), std::abs(vector[2])});
+    }
+
+    double maxAbs(const ProjectiveMatrix& matrix) {
+        double result = 0.0;
+        for (const auto& row : matrix) {
+            for (const double value : row) {
+                result = std::max(result, std::abs(value));
+            }
+        }
+        return result;
+    }
+
+    ProjectiveVector cross(const ProjectiveVector& lhs, const ProjectiveVector& rhs) {
+        return {{
+            lhs[1] * rhs[2] - lhs[2] * rhs[1],
+            lhs[2] * rhs[0] - lhs[0] * rhs[2],
+            lhs[0] * rhs[1] - lhs[1] * rhs[0]
+        }};
+    }
+
+    double dot(const ProjectiveVector& lhs, const ProjectiveVector& rhs) {
+        return lhs[0] * rhs[0] + lhs[1] * rhs[1] + lhs[2] * rhs[2];
+    }
+
+    CubicPolynomial polynomialSubtract(const CubicPolynomial& lhs, const CubicPolynomial& rhs) {
+        CubicPolynomial result{};
+        for (size_t i = 0; i < result.size(); ++i) {
+            result[i] = lhs[i] - rhs[i];
+        }
+        return result;
+    }
+
+    CubicPolynomial polynomialMultiply(const CubicPolynomial& lhs, const CubicPolynomial& rhs) {
+        CubicPolynomial result{};
+        for (size_t i = 0; i < lhs.size(); ++i) {
+            for (size_t j = 0; j < rhs.size() && i + j < result.size(); ++j) {
+                result[i + j] += lhs[i] * rhs[j];
+            }
+        }
+        return result;
+    }
+
+    CubicPolynomial polynomialDeterminant(const std::array<std::array<CubicPolynomial, 3>, 3>& matrix) {
+        const auto term0 = polynomialMultiply(matrix[0][0],
+                                               polynomialSubtract(polynomialMultiply(matrix[1][1], matrix[2][2]),
+                                                                  polynomialMultiply(matrix[1][2], matrix[2][1])));
+        const auto term1 = polynomialMultiply(matrix[0][1],
+                                               polynomialSubtract(polynomialMultiply(matrix[1][0], matrix[2][2]),
+                                                                  polynomialMultiply(matrix[1][2], matrix[2][0])));
+        const auto term2 = polynomialMultiply(matrix[0][2],
+                                               polynomialSubtract(polynomialMultiply(matrix[1][0], matrix[2][1]),
+                                                                  polynomialMultiply(matrix[1][1], matrix[2][0])));
+        CubicPolynomial result{};
+        for (size_t i = 0; i < result.size(); ++i) {
+            result[i] = term0[i] - term1[i] + term2[i];
+        }
+        return result;
+    }
+
+    ProjectiveMatrix conicMatrix(const std::vector<double>& coefficients) {
+        return {{
+            {{coefficients[0], 0.5 * coefficients[1], 0.5 * coefficients[3]}},
+            {{0.5 * coefficients[1], coefficients[2], 0.5 * coefficients[4]}},
+            {{0.5 * coefficients[3], 0.5 * coefficients[4], coefficients[5]}}
+        }};
+    }
+
+    std::vector<double> translateConic(const std::vector<double>& coefficients,
+                                       const double xOffset,
+                                       const double yOffset) {
+        const double a = coefficients[0];
+        const double b = coefficients[1];
+        const double c = coefficients[2];
+        const double d = coefficients[3];
+        const double e = coefficients[4];
+        const double f = coefficients[5];
+        return {
+            a,
+            b,
+            c,
+            2.0 * a * xOffset + b * yOffset + d,
+            b * xOffset + 2.0 * c * yOffset + e,
+            a * xOffset * xOffset + b * xOffset * yOffset + c * yOffset * yOffset
+                + d * xOffset + e * yOffset + f
+        };
+    }
+
+    bool conicCenter(const std::vector<double>& coefficients,
+                     ProjectiveVector& center) {
+        const double a = coefficients[0];
+        const double b = coefficients[1];
+        const double c = coefficients[2];
+        const double d = coefficients[3];
+        const double e = coefficients[4];
+        const double determinant = 4.0 * a * c - b * b;
+        const double quadraticScale = std::max({std::abs(a), std::abs(b), std::abs(c), 1.0});
+        if (std::abs(determinant) <= 1.0e-12 * quadraticScale * quadraticScale) {
+            return false;
+        }
+        center = {{
+            (b * e - 2.0 * c * d) / determinant,
+            (b * d - 2.0 * a * e) / determinant,
+            1.0
+        }};
+        return std::isfinite(center[0]) && std::isfinite(center[1])
+               && std::hypot(center[0], center[1]) <= RS_MAXDOUBLE;
+    }
+
+    bool conicConditioningPoint(const std::vector<double>& coefficients,
+                                ProjectiveVector& point) {
+        if (conicCenter(coefficients, point)) {
+            return true;
+        }
+        const double a = coefficients[0];
+        const double b = coefficients[1];
+        const double c = coefficients[2];
+        const double d = coefficients[3];
+        const double e = coefficients[4];
+        const double quadraticScale = std::max({std::abs(a), std::abs(b), std::abs(c), 1.0});
+        const double average = 0.5 * (a + c);
+        const double halfDifference = 0.5 * (a - c);
+        const double halfCross = 0.5 * b;
+        const double radius = std::hypot(halfDifference, halfCross);
+        if (radius <= projectiveMachineTolerance * quadraticScale) {
+            return false;
+        }
+
+        const double firstEigenvalue = average + radius;
+        const double secondEigenvalue = average - radius;
+        const double angle = 0.5 * std::atan2(halfCross, halfDifference);
+        ProjectiveVector direction{{std::cos(angle), std::sin(angle), 0.0}};
+        double eigenvalue = firstEigenvalue;
+        if (std::abs(secondEigenvalue) > std::abs(firstEigenvalue)) {
+            direction = {{-std::sin(angle), std::cos(angle), 0.0}};
+            eigenvalue = secondEigenvalue;
+        }
+        if (std::abs(eigenvalue) <= projectiveMachineTolerance * quadraticScale) {
+            return false;
+        }
+
+        const double rangeOffset = -(d * direction[0] + e * direction[1]) / (2.0 * eigenvalue);
+        point = {{rangeOffset * direction[0], rangeOffset * direction[1], 1.0}};
+        const auto conditioned = translateConic(coefficients, point[0], point[1]);
+        const ProjectiveVector nullDirection{{-direction[1], direction[0], 0.0}};
+        const double nullLinear = conditioned[3] * nullDirection[0]
+                                  + conditioned[4] * nullDirection[1];
+        if (std::abs(nullLinear) > projectiveMachineTolerance
+            * std::max({std::abs(conditioned[3]), std::abs(conditioned[4]), 1.0})) {
+            const double nullOffset = -conditioned[5] / nullLinear;
+            point[0] += nullOffset * nullDirection[0];
+            point[1] += nullOffset * nullDirection[1];
+        }
+        return std::isfinite(point[0]) && std::isfinite(point[1])
+               && std::hypot(point[0], point[1]) <= RS_MAXDOUBLE;
+    }
+
+    CubicPolynomial pencilDeterminant(const ProjectiveMatrix& first,
+                                      const ProjectiveMatrix& second) {
+        std::array<std::array<CubicPolynomial, 3>, 3> pencil{};
+        for (size_t row = 0; row < 3; ++row) {
+            for (size_t column = 0; column < 3; ++column) {
+                pencil[row][column] = {{first[row][column], second[row][column], 0.0, 0.0}};
+            }
+        }
+        return polynomialDeterminant(pencil);
+    }
+
+    void appendUniqueRoot(std::vector<double>& roots, const double root) {
+        if (!std::isfinite(root)) {
+            return;
+        }
+        const double scale = std::max(1.0, std::abs(root));
+        const bool duplicate = std::any_of(roots.cbegin(), roots.cend(),
+                                            [root, scale](const double existing) {
+                                                return std::abs(existing - root)
+                                                       <= projectiveResidualTolerance * scale;
+                                            });
+        if (!duplicate) {
+            roots.push_back(root);
+        }
+    }
+
+    void solveRealQuadratic(const long double a, const long double b, const long double c,
+                            std::vector<double>& roots) {
+        const long double scale = std::max({std::abs(a), std::abs(b), std::abs(c), 1.0L});
+        if (std::abs(a) <= projectiveMachineTolerance * scale) {
+            if (std::abs(b) > projectiveMachineTolerance * scale) {
+                appendUniqueRoot(roots, static_cast<double>(-c / b));
+            }
+            return;
+        }
+        long double discriminant = b * b - 4.0L * a * c;
+        const long double discriminantScale = std::max({b * b, std::abs(4.0L * a * c), 1.0L});
+        if (discriminant < -projectiveMachineTolerance * discriminantScale) {
+            return;
+        }
+        if (discriminant < 0.0L) {
+            discriminant = 0.0L;
+        }
+        if (discriminant == 0.0L) {
+            appendUniqueRoot(roots, static_cast<double>(-b / (2.0L * a)));
+            return;
+        }
+        const long double radical = std::sqrt(discriminant);
+        const long double q = -0.5L * (b + std::copysign(radical, b));
+        if (q == 0.0L) {
+            appendUniqueRoot(roots, static_cast<double>((-b + radical) / (2.0L * a)));
+            appendUniqueRoot(roots, static_cast<double>((-b - radical) / (2.0L * a)));
+            return;
+        }
+        appendUniqueRoot(roots, static_cast<double>(q / a));
+        appendUniqueRoot(roots, static_cast<double>(c / q));
+    }
+
+    std::vector<double> solveRealPolynomial(const CubicPolynomial& polynomial) {
+        std::vector<double> roots;
+        const double scale = std::max({std::abs(polynomial[0]), std::abs(polynomial[1]),
+                                       std::abs(polynomial[2]), std::abs(polynomial[3]), 1.0});
+        if (!std::all_of(polynomial.cbegin(), polynomial.cend(),
+                         [](const double value) { return std::isfinite(value); })) {
+            return roots;
+        }
+
+        int degree = 3;
+        while (degree > 0 && std::abs(polynomial[static_cast<size_t>(degree)])
+               <= projectiveMachineTolerance * scale) {
+            --degree;
+        }
+        if (degree == 0) {
+            return roots;
+        }
+        if (degree == 1) {
+            appendUniqueRoot(roots, -polynomial[0] / polynomial[1]);
+            return roots;
+        }
+        if (degree == 2) {
+            solveRealQuadratic(polynomial[2], polynomial[1], polynomial[0], roots);
+            return roots;
+        }
+
+        const long double a = static_cast<long double>(polynomial[2]) / polynomial[3];
+        const long double b = static_cast<long double>(polynomial[1]) / polynomial[3];
+        const long double c = static_cast<long double>(polynomial[0]) / polynomial[3];
+        const long double p = b - a * a / 3.0L;
+        const long double q = 2.0L * a * a * a / 27.0L - a * b / 3.0L + c;
+        const long double discriminant = q * q / 4.0L + p * p * p / 27.0L;
+        const long double discriminantScale = std::max({q * q / 4.0L,
+                                                        std::abs(p * p * p / 27.0L), 1.0L});
+        if (discriminant > projectiveMachineTolerance * discriminantScale) {
+            const long double radical = std::sqrt(discriminant);
+            const long double u = std::cbrt(-q / 2.0L + radical);
+            const long double v = std::cbrt(-q / 2.0L - radical);
+            appendUniqueRoot(roots, static_cast<double>(u + v - a / 3.0L));
+            return roots;
+        }
+        if (std::abs(p) <= projectiveMachineTolerance * std::max(1.0L, std::abs(q))) {
+            appendUniqueRoot(roots, static_cast<double>(-a / 3.0L));
+            return roots;
+        }
+
+        const long double radius = 2.0L * std::sqrt(std::max(0.0L, -p / 3.0L));
+        if (radius == 0.0L) {
+            appendUniqueRoot(roots, static_cast<double>(-a / 3.0L));
+            return roots;
+        }
+        long double argument = (3.0L * q / (2.0L * p)) * std::sqrt(-3.0L / p);
+        argument = std::max(-1.0L, std::min(1.0L, argument));
+        const long double angle = std::acos(argument) / 3.0L;
+        for (int index = 0; index < 3; ++index) {
+            appendUniqueRoot(roots, static_cast<double>(radius * std::cos(angle
+                                                                         - 2.0L * M_PI * index / 3.0L)
+                                                         - a / 3.0L));
+        }
+        return roots;
+    }
+
+    ProjectiveMatrix pencilMatrix(const ProjectiveMatrix& first,
+                                  const ProjectiveMatrix& second,
+                                  const double parameter) {
+        ProjectiveMatrix result{};
+        for (size_t row = 0; row < 3; ++row) {
+            for (size_t column = 0; column < 3; ++column) {
+                result[row][column] = first[row][column] + parameter * second[row][column];
+            }
+        }
+        const double scale = maxAbs(result);
+        if (std::isfinite(scale) && scale > 0.0) {
+            for (auto& row : result) {
+                for (double& value : row) {
+                    value /= scale;
+                }
+            }
+        }
+        return result;
+    }
+
+    bool factorSingularConic(const ProjectiveMatrix& matrix,
+                             std::array<ProjectiveVector, 2>& lines) {
+        const std::array<ProjectiveVector, 3> rows = {{
+            {{matrix[0][0], matrix[0][1], matrix[0][2]}},
+            {{matrix[1][0], matrix[1][1], matrix[1][2]}},
+            {{matrix[2][0], matrix[2][1], matrix[2][2]}}
+        }};
+        ProjectiveVector nullVector{};
+        double nullScale = 0.0;
+        for (size_t first = 0; first < rows.size(); ++first) {
+            for (size_t second = first + 1; second < rows.size(); ++second) {
+                const ProjectiveVector candidate = cross(rows[first], rows[second]);
+                const double candidateScale = maxAbs(candidate);
+                if (candidateScale > nullScale) {
+                    nullScale = candidateScale;
+                    nullVector = candidate;
+                }
+            }
+        }
+        if (nullScale <= projectiveMachineTolerance * std::max(1.0, maxAbs(matrix))) {
+            // A tangent pencil can contain a rank-1 member, which is a double
+            // line rather than two independent lines. Extract that line from
+            // any non-zero diagonal pivot and return it twice.
+            size_t diagonal = 0;
+            for (size_t index = 1; index < 3; ++index) {
+                if (std::abs(matrix[index][index]) > std::abs(matrix[diagonal][diagonal])) {
+                    diagonal = index;
+                }
+            }
+            const double diagonalScale = std::abs(matrix[diagonal][diagonal]);
+            if (diagonalScale <= projectiveMachineTolerance * std::max(1.0, maxAbs(matrix))) {
+                return false;
+            }
+            const double normalizer = std::sqrt(diagonalScale);
+            ProjectiveVector line{};
+            for (size_t index = 0; index < 3; ++index) {
+                line[index] = matrix[diagonal][index] / normalizer;
+            }
+            const double lineScale = maxAbs(line);
+            if (!std::isfinite(lineScale) || lineScale <= projectiveMachineTolerance) {
+                return false;
+            }
+            for (double& value : line) {
+                value /= lineScale;
+            }
+            lines = {{line, line}};
+            return true;
+        }
+        for (double& value : nullVector) {
+            value /= nullScale;
+        }
+
+        size_t pivot = 0;
+        if (std::abs(nullVector[1]) > std::abs(nullVector[pivot])) {
+            pivot = 1;
+        }
+        if (std::abs(nullVector[2]) > std::abs(nullVector[pivot])) {
+            pivot = 2;
+        }
+        const size_t firstAxis = (pivot + 1) % 3;
+        const size_t secondAxis = (pivot + 2) % 3;
+        ProjectiveVector firstDirection{};
+        ProjectiveVector secondDirection{};
+        firstDirection[firstAxis] = 1.0;
+        secondDirection[secondAxis] = 1.0;
+
+        const auto matrixTimesFirst = ProjectiveVector{{
+            matrix[0][0] * firstDirection[0] + matrix[0][1] * firstDirection[1] + matrix[0][2] * firstDirection[2],
+            matrix[1][0] * firstDirection[0] + matrix[1][1] * firstDirection[1] + matrix[1][2] * firstDirection[2],
+            matrix[2][0] * firstDirection[0] + matrix[2][1] * firstDirection[1] + matrix[2][2] * firstDirection[2]
+        }};
+        const auto matrixTimesSecond = ProjectiveVector{{
+            matrix[0][0] * secondDirection[0] + matrix[0][1] * secondDirection[1] + matrix[0][2] * secondDirection[2],
+            matrix[1][0] * secondDirection[0] + matrix[1][1] * secondDirection[1] + matrix[1][2] * secondDirection[2],
+            matrix[2][0] * secondDirection[0] + matrix[2][1] * secondDirection[1] + matrix[2][2] * secondDirection[2]
+        }};
+        const double qa = dot(firstDirection, matrixTimesFirst);
+        const double qb = dot(firstDirection, matrixTimesSecond);
+        const double qc = dot(secondDirection, matrixTimesSecond);
+        const double discriminantScale = std::max({std::abs(qb * qb), std::abs(qa * qc), 1.0});
+        double discriminant = qb * qb - qa * qc;
+        if (discriminant < -projectiveResidualTolerance * discriminantScale) {
+            return false;
+        }
+        if (discriminant < 0.0) {
+            discriminant = 0.0;
+        }
+
+        std::array<ProjectiveVector, 2> directions{};
+        if (std::abs(qa) > projectiveMachineTolerance && std::abs(qa) >= std::abs(qc)) {
+            const double radical = std::sqrt(discriminant);
+            const double firstRoot = (-qb + radical) / qa;
+            const double secondRoot = (-qb - radical) / qa;
+            directions[0] = {{firstRoot * firstDirection[0] + secondDirection[0],
+                              firstRoot * firstDirection[1] + secondDirection[1],
+                              firstRoot * firstDirection[2] + secondDirection[2]}};
+            directions[1] = {{secondRoot * firstDirection[0] + secondDirection[0],
+                              secondRoot * firstDirection[1] + secondDirection[1],
+                              secondRoot * firstDirection[2] + secondDirection[2]}};
+        }
+        else if (std::abs(qc) > projectiveMachineTolerance) {
+            const double radical = std::sqrt(discriminant);
+            const double firstRoot = (-qb + radical) / qc;
+            const double secondRoot = (-qb - radical) / qc;
+            directions[0] = {{firstDirection[0] + firstRoot * secondDirection[0],
+                              firstDirection[1] + firstRoot * secondDirection[1],
+                              firstDirection[2] + firstRoot * secondDirection[2]}};
+            directions[1] = {{firstDirection[0] + secondRoot * secondDirection[0],
+                              firstDirection[1] + secondRoot * secondDirection[1],
+                              firstDirection[2] + secondRoot * secondDirection[2]}};
+        }
+        else if (std::abs(qb) > projectiveMachineTolerance) {
+            directions[0] = firstDirection;
+            directions[1] = secondDirection;
+        }
+        else {
+            return false;
+        }
+
+        for (size_t index = 0; index < lines.size(); ++index) {
+            lines[index] = cross(nullVector, directions[index]);
+            const double scale = maxAbs(lines[index]);
+            if (scale <= projectiveMachineTolerance || !std::isfinite(scale)) {
+                return false;
+            }
+            for (double& value : lines[index]) {
+                value /= scale;
+            }
+        }
+        return true;
+    }
+
+    double evaluateProjectiveConic(const ProjectiveMatrix& matrix,
+                                   const ProjectiveVector& point) {
+        ProjectiveVector transformed{};
+        for (size_t row = 0; row < 3; ++row) {
+            transformed[row] = matrix[row][0] * point[0]
+                               + matrix[row][1] * point[1]
+                               + matrix[row][2] * point[2];
+        }
+        return dot(point, transformed);
+    }
+
+    double projectiveResidualScale(const ProjectiveMatrix& matrix,
+                                   const ProjectiveVector& point) {
+        double scale = 0.0;
+        for (size_t row = 0; row < 3; ++row) {
+            for (size_t column = 0; column < 3; ++column) {
+                scale += std::abs(matrix[row][column] * point[row] * point[column]);
+            }
+        }
+        return std::max(1.0, scale);
+    }
+
+    bool refineProjectivePoint(const ProjectiveMatrix& first,
+                               const ProjectiveMatrix& second,
+                               ProjectiveVector& point) {
+        if (point[2] == 0.0 || !std::isfinite(point[2])) {
+            return false;
+        }
+        point[0] /= point[2];
+        point[1] /= point[2];
+        point[2] = 1.0;
+        for (size_t iteration = 0; iteration < 5; ++iteration) {
+            const double f0 = evaluateProjectiveConic(first, point);
+            const double f1 = evaluateProjectiveConic(second, point);
+            const double j00 = 2.0 * (first[0][0] * point[0] + first[0][1] * point[1] + first[0][2]);
+            const double j01 = 2.0 * (first[1][0] * point[0] + first[1][1] * point[1] + first[1][2]);
+            const double j10 = 2.0 * (second[0][0] * point[0] + second[0][1] * point[1] + second[0][2]);
+            const double j11 = 2.0 * (second[1][0] * point[0] + second[1][1] * point[1] + second[1][2]);
+            const double determinant = j00 * j11 - j01 * j10;
+            const double jacobianScale = std::max({std::abs(j00 * j11), std::abs(j01 * j10), 1.0});
+            if (!std::isfinite(f0) || !std::isfinite(f1)
+                || std::abs(determinant) <= projectiveMachineTolerance * jacobianScale) {
+                break;
+            }
+            const double dx = (-f0 * j11 + j01 * f1) / determinant;
+            const double dy = (j10 * f0 - j00 * f1) / determinant;
+            if (!std::isfinite(dx) || !std::isfinite(dy)) {
+                break;
+            }
+            point[0] += dx;
+            point[1] += dy;
+            if (std::max(std::abs(dx), std::abs(dy)) <= RS_TOLERANCE) {
+                break;
+            }
+        }
+        const double firstResidual = std::abs(evaluateProjectiveConic(first, point));
+        const double secondResidual = std::abs(evaluateProjectiveConic(second, point));
+        return std::isfinite(point[0]) && std::isfinite(point[1])
+               && std::hypot(point[0], point[1]) <= RS_MAXDOUBLE
+               && firstResidual <= projectiveResidualTolerance * projectiveResidualScale(first, point)
+               && secondResidual <= projectiveResidualTolerance * projectiveResidualScale(second, point);
+    }
+
+    void appendProjectiveCandidate(const ProjectiveMatrix& first,
+                                   const ProjectiveMatrix& second,
+                                   const ProjectiveVector& point,
+                                   RS_VectorSolutions& result) {
+        ProjectiveVector refined = point;
+        if (!refineProjectivePoint(first, second, refined)) {
+            return;
+        }
+        const RS_Vector candidate(refined[0], refined[1]);
+        const double distanceScale = std::max({1.0, std::abs(candidate.x), std::abs(candidate.y)});
+        const bool duplicate = std::any_of(result.cbegin(), result.cend(),
+                                            [&candidate, distanceScale](const RS_Vector& existing) {
+                                                return existing.distanceTo(candidate)
+                                                       <= projectiveResidualTolerance * distanceScale;
+                                            });
+        if (!duplicate) {
+            result.push_back(candidate);
+        }
+    }
+
+    void appendLineConicCandidates(const ProjectiveVector& line,
+                                   const ProjectiveMatrix& conic,
+                                   const ProjectiveMatrix& otherConic,
+                                   RS_VectorSolutions& result) {
+        const double affineNormal = std::max(std::abs(line[0]), std::abs(line[1]));
+        const double lineScale = maxAbs(line);
+        if (affineNormal <= projectiveMachineTolerance * std::max(1.0, lineScale)) {
+            return;
+        }
+
+        ProjectiveVector pointAtZero{};
+        ProjectiveVector pointPerParameter{};
+        if (std::abs(line[1]) >= std::abs(line[0])) {
+            // x=t, y=(-a*t-c)/b
+            pointAtZero = {{0.0, -line[2] / line[1], 1.0}};
+            pointPerParameter = {{1.0, -line[0] / line[1], 0.0}};
+        }
+        else {
+            // y=t, x=(-b*t-c)/a
+            pointAtZero = {{-line[2] / line[0], 0.0, 1.0}};
+            pointPerParameter = {{-line[1] / line[0], 1.0, 0.0}};
+        }
+
+        const double q2 = evaluateProjectiveConic(conic, pointPerParameter);
+        const double q1 = 2.0 * dot(pointPerParameter, ProjectiveVector{{
+            conic[0][0] * pointAtZero[0] + conic[0][1] * pointAtZero[1] + conic[0][2] * pointAtZero[2],
+            conic[1][0] * pointAtZero[0] + conic[1][1] * pointAtZero[1] + conic[1][2] * pointAtZero[2],
+            conic[2][0] * pointAtZero[0] + conic[2][1] * pointAtZero[1] + conic[2][2] * pointAtZero[2]
+        }});
+        const double q0 = evaluateProjectiveConic(conic, pointAtZero);
+        std::vector<double> parameters;
+        solveRealQuadratic(q2, q1, q0, parameters);
+        for (const double parameter : parameters) {
+            ProjectiveVector candidate = pointAtZero;
+            for (size_t index = 0; index < 3; ++index) {
+                candidate[index] += parameter * pointPerParameter[index];
+            }
+            appendProjectiveCandidate(conic, otherConic, candidate, result);
+        }
     }
 
     const QRegularExpression REGEXP_UNIT(R"((?P<sign>^-?))" R"((?:(?:(?:(?P<degrees>\d+\.?\d*)(?:degree[s]?|deg|[Dd]|°)))" // DMS
@@ -1088,6 +1652,80 @@ RS_VectorSolutions RS_Math::simultaneousQuadraticSolver(const std::vector<double
     return simultaneousQuadraticSolverFull(m1);
 }
 
+/**
+ * Solve two full quadratic equations through the projective pencil of conics.
+ *
+ * Each affine equation is lifted to a homogeneous symmetric matrix C. The
+ * singular members of C1 + lambda*C2 are found from the cubic determinant of
+ * the pencil. A real singular member factors into two projective lines; the
+ * intersections of those lines with C1 are then verified against both input
+ * equations. This is an algebraic-geometric candidate path, not a replacement
+ * for the specialised line and mixed quadratic solvers.
+ */
+RS_VectorSolutions RS_Math::simultaneousQuadraticSolverProjective(
+    const std::vector<std::vector<double>>& m) {
+    RS_VectorSolutions result;
+    if (m.size() != 2 || m[0].size() != 6 || m[1].size() != 6
+        || !isFiniteCoefficients(m[0]) || !isFiniteCoefficients(m[1])) {
+        return result;
+    }
+
+    double xOffset = 0.0;
+    double yOffset = 0.0;
+    size_t centerCount = 0;
+    for (const auto& coefficients : m) {
+        ProjectiveVector center{};
+        if (conicConditioningPoint(coefficients, center)) {
+            xOffset += center[0];
+            yOffset += center[1];
+            ++centerCount;
+        }
+    }
+    if (centerCount > 0) {
+        xOffset /= static_cast<double>(centerCount);
+        yOffset /= static_cast<double>(centerCount);
+    }
+    const std::vector<double> conditionedFirst = translateConic(m[0], xOffset, yOffset);
+    const std::vector<double> conditionedSecond = translateConic(m[1], xOffset, yOffset);
+    if (!isFiniteCoefficients(conditionedFirst) || !isFiniteCoefficients(conditionedSecond)) {
+        return result;
+    }
+    ProjectiveMatrix first = conicMatrix(conditionedFirst);
+    ProjectiveMatrix second = conicMatrix(conditionedSecond);
+    const auto normalize = [](ProjectiveMatrix& matrix) {
+        const double scale = maxAbs(matrix);
+        if (!std::isfinite(scale) || scale == 0.0) {
+            return false;
+        }
+        for (auto& row : matrix) {
+            for (double& value : row) {
+                value /= scale;
+            }
+        }
+        return true;
+    };
+    if (!normalize(first) || !normalize(second)) {
+        return result;
+    }
+
+    const auto determinant = pencilDeterminant(first, second);
+    RS_VectorSolutions conditionedResult;
+    for (const double parameter : solveRealPolynomial(determinant)) {
+        const ProjectiveMatrix singular = pencilMatrix(first, second, parameter);
+        std::array<ProjectiveVector, 2> lines{};
+        if (!factorSingularConic(singular, lines)) {
+            continue;
+        }
+        for (const auto& line : lines) {
+            appendLineConicCandidates(line, first, second, conditionedResult);
+        }
+    }
+    for (const RS_Vector& point : conditionedResult) {
+        result.push_back(RS_Vector(point.x + xOffset, point.y + yOffset));
+    }
+    return result;
+}
+
 /** solver quadratic simultaneous equations of a set of two **/
 /* solve the following quadratic simultaneous equations,
   * ma000 x^2 + ma001 xy + ma011 y^2 + mb00 x + mb01 y + mc0 =0
@@ -1103,11 +1741,18 @@ RS_VectorSolutions RS_Math::simultaneousQuadraticSolverFull(const std::vector<st
     if (m.size() != 2) {
         return ret;
     }
+    if (!isFiniteCoefficients(m[0]) || !isFiniteCoefficients(m[1])) {
+        return ret;
+    }
     if (m[0].size() == 3 || m[1].size() == 3) {
         return simultaneousQuadraticSolverMixed(m);
     }
     if (m[0].size() != 6 || m[1].size() != 6) {
         return ret;
+    }
+    const RS_VectorSolutions projective = simultaneousQuadraticSolverProjective(m);
+    if (!projective.empty()) {
+        return projective;
     }
     /** eliminate x, quartic equation of y **/
     auto& a = m[0][0];

--- a/librecad/src/lib/math/rs_math.h
+++ b/librecad/src/lib/math/rs_math.h
@@ -161,6 +161,12 @@ namespace RS_Math {
           *@return a RS_VectorSolutions contains real roots (x,y)
           */
     RS_VectorSolutions simultaneousQuadraticSolverFull(const std::vector<std::vector<double>>& m);
+    /**
+     * Solve two full quadratic equations using the projective pencil of conics.
+     * Real singular pencil members are factored into line pairs, and all
+     * candidate affine points are verified against both original equations.
+     */
+    RS_VectorSolutions simultaneousQuadraticSolverProjective(const std::vector<std::vector<double>>& m);
     RS_VectorSolutions simultaneousQuadraticSolverMixed(const std::vector<std::vector<double>>& m);
 
     /** \brief verify simultaneousQuadraticVerify a solution for simultaneousQuadratic

--- a/librecad/src/lib/math/tests/lc_quadratic_tests.cpp
+++ b/librecad/src/lib/math/tests/lc_quadratic_tests.cpp
@@ -26,6 +26,7 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/catch_approx.hpp>
 
+#include <array>
 #include <cmath>
 #include <limits>
 #include <vector>
@@ -234,6 +235,93 @@ TEST_CASE("Projective pencil solver handles translated conics", "[intersection][
                        -2.0e6 - 2.0 * inverseSqrtFive, 1e-5));
     CHECK(containsPoint(solutions, 1.0e6 - inverseSqrtFive,
                        -2.0e6 + 2.0 * inverseSqrtFive, 1e-5));
+}
+
+TEST_CASE("Projective pencil solver combines equation scaling and translation",
+          "[intersection][projective][conditioning][scale]") {
+    LC_Quadratic first({1.0, 0.0, 1.0, 0.0, 0.0, -1.0});
+    LC_Quadratic second({1.0, 2.0, 2.0, 0.0, 0.0, -1.0});
+    const RS_Vector offset(1.0e6, -2.0e6);
+    first.move(offset);
+    second.move(offset);
+    std::vector<std::vector<double>> equations = {first.getCoefficients(), second.getCoefficients()};
+    for (double& coefficient : equations[0]) {
+        coefficient *= 1.0e-20;
+    }
+    for (double& coefficient : equations[1]) {
+        coefficient *= -1.0e15;
+    }
+
+    const auto solutions = RS_Math::simultaneousQuadraticSolverProjective(equations);
+    const double inverseSqrtFive = 1.0 / std::sqrt(5.0);
+    REQUIRE(solutions.size() == 4);
+    CHECK(containsPoint(solutions, 1.0e6 + 1.0, -2.0e6, 2e-3));
+    CHECK(containsPoint(solutions, 1.0e6 - 1.0, -2.0e6, 2e-3));
+    CHECK(containsPoint(solutions, 1.0e6 + inverseSqrtFive,
+                       -2.0e6 - 2.0 * inverseSqrtFive, 2e-3));
+    CHECK(containsPoint(solutions, 1.0e6 - inverseSqrtFive,
+                       -2.0e6 + 2.0 * inverseSqrtFive, 2e-3));
+}
+
+TEST_CASE("Projective pencil solver normalizes large geometry",
+          "[intersection][projective][conditioning][large]") {
+    constexpr double radius = 1.0e8;
+    const std::vector<std::vector<double>> equations = {
+        {1.0, 0.0, 1.0, 0.0, 0.0, -radius * radius},
+        {1.0, 2.0, 2.0, 0.0, 0.0, -radius * radius}
+    };
+
+    const auto solutions = RS_Math::simultaneousQuadraticSolverProjective(equations);
+    const double inverseSqrtFive = 1.0 / std::sqrt(5.0);
+    REQUIRE(solutions.size() == 4);
+    CHECK(containsPoint(solutions, radius, 0.0, 1e-4));
+    CHECK(containsPoint(solutions, -radius, 0.0, 1e-4));
+    CHECK(containsPoint(solutions, radius * inverseSqrtFive,
+                       -2.0 * radius * inverseSqrtFive, 1e-4));
+    CHECK(containsPoint(solutions, -radius * inverseSqrtFive,
+                       2.0 * radius * inverseSqrtFive, 1e-4));
+}
+
+TEST_CASE("Projective pencil solver includes a singular member at infinity",
+          "[intersection][projective][degenerate]") {
+    // C1: -x^2 + y^2 - 1 = 0; C2: xy = 0. The only useful real
+    // singular member is C2, represented by lambda=infinity in C1+lambda*C2.
+    const std::vector<std::vector<double>> equations = {
+        {-1.0, 0.0, 1.0, 0.0, 0.0, -1.0},
+        {0.0, 1.0, 0.0, 0.0, 0.0, 0.0}
+    };
+
+    const auto solutions = RS_Math::simultaneousQuadraticSolverProjective(equations);
+    REQUIRE(solutions.size() == 2);
+    CHECK(containsPoint(solutions, 0.0, 1.0));
+    CHECK(containsPoint(solutions, 0.0, -1.0));
+}
+
+TEST_CASE("Projective pencil solver returns all prescribed real intersections",
+          "[intersection][projective][completeness]") {
+    // Two independently scaled conics constructed through the four points
+    // below. This previously returned only the last two points.
+    const std::vector<std::vector<double>> equations = {
+        {-1.8845831613810567e-7, 3.237749422672911e-8, 1.228525876264746e-7,
+         -8.152389418661034e-7, 3.2316697475342135e-8, 5.1626730493897085e-6},
+        {-8.448476484508421e-5, -3.078119828265649e-5, 1.167175132144415e-4,
+         3.932145026045648e-4, -7.604078437375504e-4, -4.8202294623243846e-4}
+    };
+
+    const auto projective = RS_Math::simultaneousQuadraticSolverProjective(equations);
+    const auto complete = RS_Math::simultaneousQuadraticSolverFull(equations);
+    const std::array<RS_Vector, 4> expected = {{
+        {11.80413838882098, 14.215848788453172},
+        {-19.0230788944347, -17.436653942853283},
+        {3.491069161017421, -0.156795776381923},
+        {-14.817796823039174, 15.955556536168544}
+    }};
+    REQUIRE(projective.size() == expected.size());
+    REQUIRE(complete.size() == expected.size());
+    for (const RS_Vector& point : expected) {
+        CHECK(containsPoint(projective, point.x, point.y, 1e-8));
+        CHECK(containsPoint(complete, point.x, point.y, 1e-8));
+    }
 }
 
 TEST_CASE("Projective pencil solver conditions translated parabolas", "[intersection][projective][conditioning][parabola]") {

--- a/librecad/src/lib/math/tests/lc_quadratic_tests.cpp
+++ b/librecad/src/lib/math/tests/lc_quadratic_tests.cpp
@@ -27,12 +27,14 @@
 #include <catch2/catch_approx.hpp>
 
 #include <cmath>
+#include <limits>
 #include <vector>
 
 #include "lc_quadratic.h"
 #include "rs_vector.h"
 #include "rs_line.h"
 #include "rs_circle.h"
+#include "rs_math.h"
 
 // Helper: build a circle quadratic (coefficient form) centered at (cx,cy) with radius r
 static LC_Quadratic makeCircleCoeffs(double cx, double cy, double r) {
@@ -45,6 +47,16 @@ static LC_Quadratic makeCircleCoeffs(double cx, double cy, double r) {
     double E = -2.0 * cy;
     double F = cx * cx + cy * cy - r * r;
     return LC_Quadratic({A, B, C, D, E, F});
+}
+
+static bool containsPoint(const RS_VectorSolutions& solutions, double x, double y, double margin = 1e-8) {
+    for (const RS_Vector& point : solutions) {
+        if (point.x == Catch::Approx(x).margin(margin)
+            && point.y == Catch::Approx(y).margin(margin)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 TEST_CASE("License/header sanity test present", "[meta]") {
@@ -153,6 +165,116 @@ TEST_CASE("Two circles intersection (coeff-based) gives two points (standard exa
     }
     CHECK(found_pos);
     CHECK(found_neg);
+}
+
+TEST_CASE("Projective pencil solver finds four generic real conic intersections", "[intersection][projective]") {
+    // C1: x^2 + y^2 - 1 = 0
+    // C2: x^2 + 2xy + 2y^2 - 1 = 0
+    // Their difference is y(2x + y), which exposes four real intersections.
+    const std::vector<std::vector<double>> equations = {
+        {1.0, 0.0, 1.0, 0.0, 0.0, -1.0},
+        {1.0, 2.0, 2.0, 0.0, 0.0, -1.0}
+    };
+    const auto solutions = RS_Math::simultaneousQuadraticSolverProjective(equations);
+    const double inverseSqrtFive = 1.0 / std::sqrt(5.0);
+    REQUIRE(solutions.size() == 4);
+    CHECK(containsPoint(solutions, 1.0, 0.0));
+    CHECK(containsPoint(solutions, -1.0, 0.0));
+    CHECK(containsPoint(solutions, inverseSqrtFive, -2.0 * inverseSqrtFive));
+    CHECK(containsPoint(solutions, -inverseSqrtFive, 2.0 * inverseSqrtFive));
+
+    const LC_Quadratic first(equations[0]);
+    const LC_Quadratic second(equations[1]);
+    const auto integratedSolutions = LC_Quadratic::getIntersection(first, second);
+    REQUIRE(integratedSolutions.size() == 4);
+    CHECK(containsPoint(integratedSolutions, 1.0, 0.0));
+    CHECK(containsPoint(integratedSolutions, -1.0, 0.0));
+    CHECK(containsPoint(integratedSolutions, inverseSqrtFive, -2.0 * inverseSqrtFive));
+    CHECK(containsPoint(integratedSolutions, -inverseSqrtFive, 2.0 * inverseSqrtFive));
+}
+
+TEST_CASE("Projective pencil solver preserves a tangent intersection", "[intersection][projective][tangent]") {
+    // C2 - C1 = (x - 1)^2, so the two conics touch at (1, 0).
+    const std::vector<std::vector<double>> equations = {
+        {1.0, 0.0, 1.0, 0.0, 0.0, -1.0},
+        {2.0, 0.0, 1.0, -2.0, 0.0, 0.0}
+    };
+    const auto solutions = RS_Math::simultaneousQuadraticSolverProjective(equations);
+    REQUIRE(solutions.size() == 1);
+    CHECK(containsPoint(solutions, 1.0, 0.0));
+}
+
+TEST_CASE("Projective pencil solver is invariant to independent equation scaling", "[intersection][projective][scale]") {
+    const std::vector<std::vector<double>> equations = {
+        {1.0e150, 0.0, 1.0e150, 0.0, 0.0, -1.0e150},
+        {-1.0e-120, -2.0e-120, -2.0e-120, 0.0, 0.0, 1.0e-120}
+    };
+    const auto solutions = RS_Math::simultaneousQuadraticSolverProjective(equations);
+    const double inverseSqrtFive = 1.0 / std::sqrt(5.0);
+    REQUIRE(solutions.size() == 4);
+    CHECK(containsPoint(solutions, 1.0, 0.0));
+    CHECK(containsPoint(solutions, -1.0, 0.0));
+    CHECK(containsPoint(solutions, inverseSqrtFive, -2.0 * inverseSqrtFive));
+    CHECK(containsPoint(solutions, -inverseSqrtFive, 2.0 * inverseSqrtFive));
+}
+
+TEST_CASE("Projective pencil solver handles translated conics", "[intersection][projective][conditioning]") {
+    LC_Quadratic first({1.0, 0.0, 1.0, 0.0, 0.0, -1.0});
+    LC_Quadratic second({1.0, 2.0, 2.0, 0.0, 0.0, -1.0});
+    const RS_Vector offset(1.0e6, -2.0e6);
+    first.move(offset);
+    second.move(offset);
+
+    const auto solutions = LC_Quadratic::getIntersection(first, second);
+    const double inverseSqrtFive = 1.0 / std::sqrt(5.0);
+    REQUIRE(solutions.size() == 4);
+    CHECK(containsPoint(solutions, 1.0e6 + 1.0, -2.0e6, 1e-5));
+    CHECK(containsPoint(solutions, 1.0e6 - 1.0, -2.0e6, 1e-5));
+    CHECK(containsPoint(solutions, 1.0e6 + inverseSqrtFive,
+                       -2.0e6 - 2.0 * inverseSqrtFive, 1e-5));
+    CHECK(containsPoint(solutions, 1.0e6 - inverseSqrtFive,
+                       -2.0e6 + 2.0 * inverseSqrtFive, 1e-5));
+}
+
+TEST_CASE("Projective pencil solver conditions translated parabolas", "[intersection][projective][conditioning][parabola]") {
+    LC_Quadratic first({-1.0, 0.0, 0.0, 0.0, 1.0, 0.0});
+    LC_Quadratic second({0.0, 0.0, -1.0, 1.0, 0.0, 0.0});
+    const RS_Vector offset(1.0e6, -2.0e6);
+    first.move(offset);
+    second.move(offset);
+
+    const auto solutions = LC_Quadratic::getIntersection(first, second);
+    REQUIRE(solutions.size() == 2);
+    CHECK(containsPoint(solutions, 1.0e6, -2.0e6, 1e-5));
+    CHECK(containsPoint(solutions, 1.0e6 + 1.0, -2.0e6 + 1.0, 1e-5));
+}
+
+TEST_CASE("Projective pencil solver rejects non-finite coefficients", "[intersection][projective][invalid]") {
+    const std::vector<std::vector<double>> equations = {
+        {1.0, 0.0, 1.0, 0.0, 0.0, -1.0},
+        {1.0, 2.0, 2.0, 0.0, 0.0, std::numeric_limits<double>::quiet_NaN()}
+    };
+    const auto solutions = RS_Math::simultaneousQuadraticSolverProjective(equations);
+    CHECK(solutions.empty());
+    CHECK(RS_Math::simultaneousQuadraticSolverFull(equations).empty());
+}
+
+TEST_CASE("Projective pencil solver does not invent non-real intersections", "[intersection][projective][none]") {
+    const auto solutions = RS_Math::simultaneousQuadraticSolverProjective({
+        {1.0, 0.0, 1.0, 0.0, 0.0, -1.0},
+        {1.0, 2.0, 2.0, 0.0, 0.0, 1.0}
+    });
+    CHECK(solutions.empty());
+}
+
+TEST_CASE("Projective pencil solver handles two parabolas", "[intersection][projective][parabola]") {
+    const auto solutions = RS_Math::simultaneousQuadraticSolverProjective({
+        {-1.0, 0.0, 0.0, 0.0, 1.0, 0.0}, // y - x^2 = 0
+        {0.0, 0.0, -1.0, 1.0, 0.0, 0.0}  // x - y^2 = 0
+    });
+    REQUIRE(solutions.size() == 2);
+    CHECK(containsPoint(solutions, 0.0, 0.0));
+    CHECK(containsPoint(solutions, 1.0, 1.0));
 }
 
 TEST_CASE("Line-line intersection: intersecting and parallel cases", "[intersection][line-line]") {


### PR DESCRIPTION
## Summary

- Add a projective-pencil solver for intersections of two full quadratic equations.
- Lift affine conics to homogeneous symmetric 3x3 matrices.
- Solve the cubic determinant of C1 + lambda*C2 for singular pencil members.
- Factor rank-2 members into projective line pairs and rank-1 members into double lines.
- Intersect affine line factors with one conic, refine candidates, and verify both original equations.
- Keep line/line, line/conic, radical-axis, and the existing resultant solver paths available.

## Numerical design

The implementation is based on the classical pencil-of-conics construction described in https://arxiv.org/abs/2403.08953. It avoids relying on a single hidden-variable resultant, whose numerical conditioning risks are documented by Noferini and Townsend at https://epubs.siam.org/doi/10.1137/15M1022513.

The solver rejects non-finite coefficients, conditions the origin using conic centers or the dominant quadratic/linear directions, uses long-double intermediates for quadratic/cubic roots, handles affine lines at infinity, refines non-singular candidates with the 2x2 Jacobian, and verifies residuals before returning points.

## Tests

Added regression coverage for:

- four generic real intersections;
- tangent intersections and rank-1 double-line pencil members;
- independent positive/negative equation scaling;
- translated ellipses and translated parabolas at large coordinates;
- two parabolas;
- no real intersections;
- NaN rejection through both public solver entry points;
- integration through LC_Quadratic::getIntersection.

Focused verification passed: 70 assertions across 18 quadratic test cases, plus an ASan/UBSan harness covering the projective cases.