### PR TITLE
Preserve fixed print preview scale and placement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2395,6 +2395,7 @@ if (BUILD_TESTS)
         librecad/src/lib/math/tests/rs_math_tests.cpp
         librecad/src/lib/math/tests/lc_quadratic_tests.cpp
         librecad/src/lib/creation/tests/rs_creation_null_entity_tests.cpp
+        librecad/src/actions/print_preview/tests/rs_actionprintpreview_tests.cpp
         librecad/src/lib/modification/tests/lc_division_tests.cpp
         librecad/src/lib/modification/tests/rs_modification_trim_tests.cpp
         librecad/src/lib/filters/tests/dwg_buffer_round_trip_tests.cpp

--- a/librecad/src/actions/print_preview/rs_actionprintpreview.cpp
+++ b/librecad/src/actions/print_preview/rs_actionprintpreview.cpp
@@ -55,35 +55,28 @@ namespace {
  */
 RS_ActionPrintPreview::RS_ActionPrintPreview(LC_ActionContext* actionContext)
     : RS_ActionInterface("ActionFilePrintPreview", actionContext, RS2::ActionFilePrintPreview),
-      m_actionData(std::make_unique<ActionData>()) {
-    const bool fixed = LC_GET_ONE_BOOL("PrintPreview", "PrintScaleFixed");
-
-    if (!fixed) {
-        fit();
-        updateOptions();
-    }
-    setPaperScaleFixed(fixed);
-}
+      m_actionData(std::make_unique<ActionData>()) {}
 
 void RS_ActionPrintPreview::doSaveOptions() {
      save("ScaleLineWidth", isLineWidthScaling());
      save("BlackWhiteSet", isBlackWhite());
      save("PrintScaleFixed", isPaperScaleFixed());
-     save("PrintScaleValue", getScale());
 }
 
-// fixme - sand - storing scale and fixed in settings is obious suxx as they are part of drawing setttings...
-// fixme - sand - yet it will be reworked anywath with support of layouts later - so let it be as it was
+// Fixed mode is a global preference, while scale and placement belong to the
+// document. Layout support should eventually own all three values explicitly.
 void RS_ActionPrintPreview::doLoadOptions() {
     const bool scaleLineWidth = loadBool("ScaleLineWidth", true);
     const bool blackAndWhite = loadBool("BlackWhiteSet", false);
-    const double printScale = loadDouble("PrintScaleValue", 1.0);
-    const bool printScaleFixed = loadBool("PrintScaleFixed", false);
+    const bool legacyScaleFixed = LC_GET_ONE_BOOL("PrintPreview", "PrintScaleFixed");
+    const bool printScaleFixed = loadBool("PrintScaleFixed", legacyScaleFixed);
 
     setLineWidthScaling(scaleLineWidth);
     setBlackWhite(blackAndWhite);
     setPaperScaleFixed(printScaleFixed);
-    setScale(printScale, true);
+    if (!printScaleFixed) {
+        fit();
+    }
 }
 
 QStringList RS_ActionPrintPreview::readCustomRatios(const bool metric, int maxCount) {
@@ -345,6 +338,9 @@ void RS_ActionPrintPreview::fit() const {
 bool RS_ActionPrintPreview::setScale(const double newScale, const bool autoZoom) const {
     if (m_graphic != nullptr) {
         const LC_PlotSettings* ps = m_graphic->getPlotSettings();
+        if (ps->isPaperScaleFixed()) {
+            return false;
+        }
         const double oldScale = ps->getPaperScale();
         if (LC_LineMath::isSameValue(newScale, oldScale)) {
             return false;

--- a/librecad/src/actions/print_preview/tests/rs_actionprintpreview_tests.cpp
+++ b/librecad/src/actions/print_preview/tests/rs_actionprintpreview_tests.cpp
@@ -1,0 +1,182 @@
+/*
+ * ********************************************************************************
+ * This file is part of the LibreCAD project, a 2D CAD program
+ *
+ * Copyright (C) 2026 LibreCAD.org
+ * Copyright (C) 2026 Dongxu Li (github.com/dxli)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ * ********************************************************************************
+ */
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+
+#include <QApplication>
+#include <QSettings>
+
+#include "lc_actioncontext.h"
+#include "lc_graphicviewrenderer.h"
+#include "rs_actionprintpreview.h"
+#include "rs_graphic.h"
+#include "rs_graphicview.h"
+#include "rs_line.h"
+#include "rs_settings.h"
+
+namespace {
+
+QApplication& application() {
+    static int argc = 1;
+    static char name[] = "librecad-tests";
+    static char* argv[] = {name, nullptr};
+    static QApplication* app = [] {
+        auto* existing = qobject_cast<QApplication*>(QCoreApplication::instance());
+        return existing != nullptr ? existing : new QApplication(argc, argv);
+    }();
+    static bool settingsReady = [] {
+        QCoreApplication::setOrganizationName("LibreCAD");
+        QCoreApplication::setApplicationName("LibreCAD-tests");
+        RS_Settings::init("LibreCAD", "LibreCAD-tests");
+        return true;
+    }();
+    (void)settingsReady;
+    return *app;
+}
+
+class SettingGuard {
+public:
+    SettingGuard(RS_Settings* settings, QString group, QString key)
+        : m_settings(settings), m_group(std::move(group)), m_key(std::move(key)),
+          m_fullKey(QString("/%1/%2").arg(m_group, m_key)),
+          m_existed(settings->getSettings()->contains(m_fullKey)),
+          m_value(settings->getSettings()->value(m_fullKey)) {}
+
+    ~SettingGuard() {
+        auto groupGuard = m_settings->beginGroupGuard(m_group);
+        if (m_existed) {
+            m_settings->write(m_key, m_value);
+        }
+        else {
+            m_settings->write(m_key, QVariant{});
+            m_settings->remove(m_key);
+        }
+    }
+
+    void set(const bool value) const { m_settings->writeSingle(m_group, m_key, value); }
+    void set(const double value) const { m_settings->writeSingle(m_group, m_key, value); }
+
+    SettingGuard(const SettingGuard&) = delete;
+    SettingGuard& operator=(const SettingGuard&) = delete;
+
+private:
+    RS_Settings* m_settings;
+    QString m_group;
+    QString m_key;
+    QString m_fullKey;
+    bool m_existed;
+    QVariant m_value;
+};
+
+class PrintPreviewTestView final : public RS_GraphicView {
+public:
+    PrintPreviewTestView() : RS_GraphicView(nullptr) {
+        getViewPort()->setSize(getWidth(), getHeight());
+        setRenderer(std::make_unique<LC_GraphicViewRenderer>(getViewPort(), this));
+    }
+
+    int getWidth() const override { return 640; }
+    int getHeight() const override { return 480; }
+    void redraw([[maybe_unused]] RS2::RedrawMethod method = RS2::RedrawAll,
+                [[maybe_unused]] bool immediately = false) override {}
+    void adjustOffsetControls() override {}
+    void adjustZoomControls() override {}
+    void setMouseCursor([[maybe_unused]] RS2::CursorType cursor) override {}
+    void updateGridStatusWidget([[maybe_unused]] QString status) override {}
+};
+
+void addTestGeometry(RS_Graphic& graphic) {
+    graphic.addEntity(new RS_Line(&graphic, RS_Vector{0.0, 0.0}, RS_Vector{100.0, 100.0}));
+    graphic.calculateBorders();
+}
+
+} // namespace
+
+TEST_CASE("fixed print preview preserves document scale and placement",
+          "[print_preview][issue2741]") {
+    (void)application();
+    SettingGuard legacyFixed{RS_SETTINGS, "PrintPreview", "PrintScaleFixed"};
+    SettingGuard currentFixed{RS_SETTINGS, "ActionFilePrintPreview", "PrintScaleFixed"};
+    SettingGuard savedScale{RS_SETTINGS, "ActionFilePrintPreview", "PrintScaleValue"};
+    legacyFixed.set(false);
+    currentFixed.set(true);
+    savedScale.set(0.125);
+
+    RS_Graphic graphic;
+    graphic.initForNewDocument();
+    addTestGeometry(graphic);
+    constexpr double documentScale = 2.5;
+    const RS_Vector documentBase{17.0, -9.0};
+    graphic.getPlotSettings()->setPaperScale(documentScale);
+    graphic.setPaperInsertionBase(documentBase);
+
+    PrintPreviewTestView view;
+    view.setDocument(&graphic);
+    LC_ActionContext context;
+    context.setDocumentAndView(&graphic, &view);
+    auto action = std::make_unique<RS_ActionPrintPreview>(&context);
+    action->postCreateInit();
+
+    CHECK(action->isPaperScaleFixed());
+    CHECK(action->getScale() == Catch::Approx(documentScale));
+    CHECK(graphic.getPaperInsertionBase() == documentBase);
+
+    CHECK_FALSE(action->setScale(0.25, false));
+    CHECK(action->getScale() == Catch::Approx(documentScale));
+    CHECK(graphic.getPaperInsertionBase() == documentBase);
+}
+
+TEST_CASE("automatic print preview fits once after loading options",
+          "[print_preview][issue2741]") {
+    (void)application();
+    SettingGuard legacyFixed{RS_SETTINGS, "PrintPreview", "PrintScaleFixed"};
+    SettingGuard currentFixed{RS_SETTINGS, "ActionFilePrintPreview", "PrintScaleFixed"};
+    SettingGuard savedScale{RS_SETTINGS, "ActionFilePrintPreview", "PrintScaleValue"};
+    legacyFixed.set(true);
+    currentFixed.set(false);
+    savedScale.set(0.125);
+
+    RS_Graphic graphic;
+    graphic.initForNewDocument();
+    addTestGeometry(graphic);
+    graphic.getPlotSettings()->setPaperScale(2.5);
+    graphic.setPaperInsertionBase(RS_Vector{17.0, -9.0});
+
+    const RS_Vector printArea = graphic.getPlotSettings()->getPrintAreaSize(false);
+    const double expectedScale = std::min(printArea.x, printArea.y) / 100.0;
+
+    PrintPreviewTestView view;
+    view.setDocument(&graphic);
+    LC_ActionContext context;
+    context.setDocumentAndView(&graphic, &view);
+    auto action = std::make_unique<RS_ActionPrintPreview>(&context);
+    action->postCreateInit();
+
+    CHECK_FALSE(action->isPaperScaleFixed());
+    CHECK(action->getScale() == Catch::Approx(expectedScale));
+    CHECK(action->getScale() != Catch::Approx(0.125));
+}

--- a/librecad/src/ui/main/qc_applicationwindow.cpp
+++ b/librecad/src/ui/main/qc_applicationwindow.cpp
@@ -1464,15 +1464,9 @@ void QC_ApplicationWindow::openPrintPreview(QC_MDIWindow* parent) {
                 const bool bigger = plotSettings->isBiggerThanPaper(graphic->getSize());
                 const bool fixed = plotSettings->isPaperScaleFixed();
 
-                graphic->fitToPage();
-
-                // Calling zoomPage() after fitToPage() always fits
-                // preview paper in preview window. The only reason not
-                // to call zoomPage() is when drawing is bigger than paper,
-                // plus it is fixed. In that case, not calling zoomPage()
-                // prevents displaying empty paper (when drawing is actually
-                // outside the paper and the preview window) and displays
-                // full drawing and smaller paper inside it.
+                // The preview action has already fitted non-fixed drawings.
+                // Do not fit here: fixed previews must preserve the document's
+                // paper scale and $PINSBASE placement.
                 if (bigger && fixed) {
                     RS_DEBUG->print("%s: don't call zoomPage()", __func__);
                 }


### PR DESCRIPTION
## Summary
- load print-preview options before initializing preview geometry, with the current settings group taking precedence and a legacy fallback
- preserve document-owned `$PSVPSCALE` and `$PINSBASE` while fixed scale is enabled
- reject scale changes transactionally while plotting is locked
- remove the duplicate application-window `fitToPage()` call
- add focused fixed and automatic preview regression coverage

## Root cause
Print-preview initialization had two owners. The action conditionally fitted from the legacy `PrintPreview` setting, then the application window fitted unconditionally. On upgraded profiles, the action legacy and current settings could also disagree. Either path could recenter the drawing and overwrite `$PINSBASE` even though the user selected fixed scale.

The 2.2.1 maintenance branch has a companion Qt 5 renderer repair for the PDF hairline symptom.

Fixes #2741

## Validation
- fresh Qt 6 CMake Debug build of `librecad_tests`
- `librecad_tests [print_preview]`: 2 test cases, 9 assertions passed
- full suite: 768/772 cases passed; the four failures are the pre-existing settings-migration cases at `rs_settings_migration_tests.cpp:237`, which reproduce independently in isolation