### PR TITLE
Fix print preview state and PDF hairlines on 2.2.1

### DIFF
--- a/librecad/src/actions/rs_actionprintpreview.cpp
+++ b/librecad/src/actions/rs_actionprintpreview.cpp
@@ -60,8 +60,14 @@ RS_ActionPrintPreview::RS_ActionPrintPreview(RS_EntityContainer& container,
     RS_SETTINGS->beginGroup("/PrintPreview");
     bool fixed = (RS_SETTINGS->readNumEntry("/PrintScaleFixed", 0) != 0);
     RS_SETTINGS->endGroup();
-    fit();
+
+    // A fixed scale and insertion base are drawing settings.  Lock them
+    // before any automatic fitting so reopening preview cannot overwrite
+    // $PSVPSCALE or $PINSBASE.
     setPaperScaleFixed(fixed);
+    if (!fixed) {
+        fit();
+    }
     showOptions();
 }
 
@@ -283,6 +289,9 @@ void RS_ActionPrintPreview::fit() {
 
 bool RS_ActionPrintPreview::setScale(double f, bool autoZoom) {
     if (graphic) {
+        if (graphic->getPaperScaleFixed()) {
+            return false;
+        }
         if(std::abs(f - graphic->getPaperScale()) < RS_TOLERANCE )
             return false;
         graphic->setPaperScale(f);

--- a/librecad/src/lib/gui/rs_painterqt.cpp
+++ b/librecad/src/lib/gui/rs_painterqt.cpp
@@ -228,15 +228,15 @@ public:
         painter.save();
         // set pen
         RS_Pen& rsPen = painter.getRsPen();
-        Qt::PenStyle styleToUse = rsPen.getLineType() == RS2::SolidLine ? Qt::SolidLine : Qt::CustomDashLine;
+        const Qt::PenStyle styleToUse = rsToQtLineType(rsPen.getLineType());
         QPen qPen = painter.pen();
-        qPen.setStyle(styleToUse);
-        qPen.setColor(rsPen.getColor());
         if (rsPen.getLineType() == RS2::NoPen)
         {
             qPen.setStyle(Qt::NoPen);
         } else if (styleToUse == Qt::CustomDashLine)
         {
+            qPen.setStyle(Qt::CustomDashLine);
+            qPen.setColor(rsPen.getColor());
             QVector<qreal> dashPattern = rsToQDashPattern(rsPen.getLineType(),
                                                           qPen.widthF(),
                                                           painter.getDpmm());
@@ -255,7 +255,13 @@ public:
             qPen.setJoinStyle(Qt::RoundJoin);
             qPen.setCapStyle(Qt::RoundCap);
         }
-        painter.QPainter::setPen(qPen);
+        // setPen() already configured solid pens.  Reapplying a copied
+        // cosmetic pen makes Qt 5.15.2's PDF engine turn hairlines into
+        // sub-pixel filled outlines instead of PDF 0-width strokes.
+        if (rsPen.getLineType() == RS2::NoPen
+            || styleToUse == Qt::CustomDashLine) {
+            painter.QPainter::setPen(qPen);
+        }
     }
 
     ~PainterGuard()
@@ -1150,4 +1156,3 @@ void RS_PainterQt::drawText(const QRect& rect, const QString& text, QRect* bound
 {
     QPainter::drawText(rect, Qt::AlignTop | Qt::AlignLeft | Qt::TextDontClip, text, boundingBox);
 }
-

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -2802,15 +2802,9 @@ void QC_ApplicationWindow::slotFilePrintPreview(bool on)
                     bool bigger = graphic->isBiggerThanPaper();
                     bool fixed = graphic->getPaperScaleFixed();
 
-                    graphic->fitToPage();
-
-                    // Calling zoomPage() after fitToPage() always fits
-                    // preview paper in preview window. The only reason not
-                    // to call zoomPage() is when drawing is bigger than paper,
-                    // plus it is fixed. In that case, not calling zoomPage()
-                    // prevents displaying empty paper (when drawing is actually
-                    // outside the paper and the preview window) and displays
-                    // full drawing and smaller paper inside it.
+                    // The preview action has already fitted automatic previews.
+                    // A second fit would recenter a fixed preview and overwrite
+                    // the drawing's $PINSBASE placement.
                     if (bigger && fixed) {
                         RS_DEBUG->print("%s: don't call zoomPage()", __func__);
                     } else {


### PR DESCRIPTION
## Summary
- preserve the document-owned fixed print scale and placement when reopening print preview
- remove the duplicate preview fit that recentered fixed drawings
- reject scale changes while the paper scale is locked
- preserve solid cosmetic pens across per-primitive paint-state guards so Qt 5 PDF output retains visible hairlines

## Root cause
The 2.2.1 preview action called `fit()` before loading the fixed state into the graphic, then the application window called `fitToPage()` a second time. Both paths could recenter the drawing and overwrite `$PINSBASE`; the first could also replace `$PSVPSCALE`.

For Qt 5.15.2 PDF output, reapplying a copied zero-width solid `QPen` inside `PainterGuard` produces tiny filled outlines rather than PDF hairline strokes. Keeping the already configured solid pen avoids that conversion while retaining the dash and no-pen paths.

Fixes #2741

## Validation
- Qt 5.15.19 CMake Debug build
- qmake parsed the complete project successfully
- rendered the issue DXF through `dxf2pdf`; the generated PDF emits `0 w` hairline strokes and matches the known-good Qt 5.15.10 rendering at the same DPI
- the local macOS offscreen console run writes the PDF, then hits an existing widget-teardown crash outside this diff