### PR TITLE
[2.2.1] Fix active-layer state and macOS UI regressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -946,6 +946,7 @@ endif()
 set_target_properties(librecad PROPERTIES
 WIN32_EXECUTABLE ON
 MACOSX_BUNDLE ON
+MACOSX_BUNDLE_GUI_IDENTIFIER "com.librecad.app"
    AUTOUIC_OPTIONS "--connections string")
 set_property(TARGET librecad PROPERTY AUTOUIC_OPTIONS --connections string)
 find_package(Freetype REQUIRED)

--- a/librecad/src/lib/engine/rs_graphic.cpp
+++ b/librecad/src/lib/engine/rs_graphic.cpp
@@ -504,6 +504,10 @@ bool RS_Graphic::loadTemplate(const QString &filename, RS2::FormatType type) {
     // import template file:
     ret = RS_FileIO::instance()->fileImport(*this, filename, type);
 
+    if (ret) {
+        layerList.ensureActiveLayerIsVisible();
+    }
+
     setModified(false);
     layerList.setModified(false);
     blockList.setModified(false);
@@ -536,6 +540,7 @@ bool RS_Graphic::open(const QString &filename, RS2::FormatType type) {
     ret = RS_FileIO::instance()->fileImport(*this, filename, type);
 
     if( ret) {
+        layerList.ensureActiveLayerIsVisible();
         setModified(false);
         layerList.setModified(false);
         blockList.setModified(false);

--- a/librecad/src/lib/engine/rs_graphic.h
+++ b/librecad/src/lib/engine/rs_graphic.h
@@ -81,11 +81,11 @@ public:
     RS_Layer* layerAt(unsigned i) {
         return layerList.at(i);
     }
-    bool activateLayer(const QString& name) {
-        return layerList.activate(name);
+    void activateLayer(const QString& name) {
+        layerList.activate(name);
     }
-    bool activateLayer(RS_Layer* layer) {
-        return layerList.activate(layer);
+    void activateLayer(RS_Layer* layer) {
+        layerList.activate(layer);
     }
     RS_Layer* getActiveLayer() {
         return layerList.getActive();

--- a/librecad/src/lib/engine/rs_graphic.h
+++ b/librecad/src/lib/engine/rs_graphic.h
@@ -81,11 +81,11 @@ public:
     RS_Layer* layerAt(unsigned i) {
         return layerList.at(i);
     }
-    void activateLayer(const QString& name) {
-        layerList.activate(name);
+    bool activateLayer(const QString& name) {
+        return layerList.activate(name);
     }
-    void activateLayer(RS_Layer* layer) {
-        layerList.activate(layer);
+    bool activateLayer(RS_Layer* layer) {
+        return layerList.activate(layer);
     }
     RS_Layer* getActiveLayer() {
         return layerList.getActive();

--- a/librecad/src/lib/engine/rs_layerlist.cpp
+++ b/librecad/src/lib/engine/rs_layerlist.cpp
@@ -79,11 +79,11 @@ QList<RS_Layer*>::const_iterator RS_LayerList::end()const
  * 
  * @param notify Notify listeners.
  */
-void RS_LayerList::activate(const QString& name, bool notify) {
+bool RS_LayerList::activate(const QString& name, bool notify) {
     RS_DEBUG->print("RS_LayerList::activate: %s, notify: %d begin",
                                     name.toLatin1().data(), notify);
 
-    activate(find(name), notify);
+    const bool activated = activate(find(name), notify);
     /*
     if (activeLayer==nullptr) {
         RS_DEBUG->print("activeLayer is nullptr");
@@ -93,6 +93,7 @@ void RS_LayerList::activate(const QString& name, bool notify) {
     */
 
     RS_DEBUG->print("RS_LayerList::activate: %s end", name.toLatin1().data());
+    return activated;
 }
 
 
@@ -102,8 +103,14 @@ void RS_LayerList::activate(const QString& name, bool notify) {
  * 
  * @param notify Notify listeners.
  */
-void RS_LayerList::activate(RS_Layer* layer, bool notify) {
+bool RS_LayerList::activate(RS_Layer* layer, bool notify) {
     RS_DEBUG->print("RS_LayerList::activate notify: %d begin", notify);
+
+    if (!isVisibleLayer(layer)) {
+        RS_DEBUG->print(RS_Debug::D_WARNING,
+                        "RS_LayerList::activate: refusing a null, foreign, or frozen layer");
+        return false;
+    }
 
     /*if (layer) {
         RS_DEBUG->print("RS_LayerList::activate: %s",
@@ -124,6 +131,7 @@ void RS_LayerList::activate(RS_Layer* layer, bool notify) {
     }
 
     RS_DEBUG->print("RS_LayerList::activate end");
+    return true;
 }
 
 
@@ -203,17 +211,17 @@ void RS_LayerList::remove(RS_Layer* layer) {
     // here the layer is removed from the list but not deleted
     layers.removeOne(layer);
 
+	setModified(true);
+
+    // Restore a valid current layer before listeners observe the removal.
+    if (activeLayer==layer) {
+        activeLayer = nullptr;
+        ensureActiveLayerIsVisible();
+    }
+
     for (int i=0; i<layerListListeners.size(); ++i) {
         RS_LayerListListener* l = layerListListeners.at(i);
         l->layerRemoved(layer);
-    }
-		
-	setModified(true);
-
-    // Do not leave a dangling active-layer pointer while the layer is gone.
-    if (activeLayer==layer) {
-        activeLayer = nullptr;
-        ensureActiveLayerIsEditable();
     }
 
     // now it's save to delete the layer
@@ -234,7 +242,7 @@ void RS_LayerList::edit(RS_Layer* layer, const RS_Layer& source) {
 
     *layer = source;
 
-    ensureActiveLayerIsEditable();
+    ensureActiveLayerIsVisible();
 
     fireEdit(layer);
 }
@@ -332,7 +340,7 @@ void RS_LayerList::toggle(RS_Layer* layer) {
 
     // set flags
     layer->toggle();
-    ensureActiveLayerIsEditable();
+    ensureActiveLayerIsVisible();
     setModified(true);
 
     // Notify listeners:
@@ -360,7 +368,6 @@ void RS_LayerList::toggleLock(RS_Layer* layer) {
     }
 
     layer->toggleLock();
-    ensureActiveLayerIsEditable();
     setModified(true);
 
     // Notify listeners:
@@ -433,7 +440,7 @@ void RS_LayerList::freezeAll(bool freeze) {
          }
     }
 
-    ensureActiveLayerIsEditable();
+    ensureActiveLayerIsVisible();
     fireLayerToggled();
 
 }
@@ -452,7 +459,6 @@ void RS_LayerList::lockAll(bool lock) {
              at(l)->lock(lock);
          }
     }
-    ensureActiveLayerIsEditable();
     fireLayerToggled();
 }
 
@@ -466,7 +472,6 @@ void RS_LayerList::toggleLockMulti(QList<RS_Layer*> toggleLayers){
         }
     }
 
-    ensureActiveLayerIsEditable();
     fireLayerToggled();
 }
 void RS_LayerList::togglePrintMulti(QList<RS_Layer*> toggleLayers){
@@ -506,7 +511,7 @@ void RS_LayerList::setFreezeMulti(QList<RS_Layer*> layersEnable, QList<RS_Layer*
             layer->freeze(true);
         }
     }
-    ensureActiveLayerIsEditable();
+    ensureActiveLayerIsVisible();
    fireLayerToggled();
 }
 
@@ -525,7 +530,6 @@ void RS_LayerList::setLockMulti(QList<RS_Layer*> layersToUnlock, QList<RS_Layer*
             layer->lock(true);
         }
     }
-    ensureActiveLayerIsEditable();
     fireLayerToggled();
 }
 
@@ -573,38 +577,38 @@ void RS_LayerList::toggleFreezeMulti(QList<RS_Layer*> toggleLayers){
             layer->toggle();
         }
     }
-    ensureActiveLayerIsEditable();
+    ensureActiveLayerIsVisible();
    fireLayerToggled();
 }
 
-bool RS_LayerList::isEditable(const RS_Layer* layer) const {
-    return layer != nullptr && !layer->isFrozen() && !layer->isLocked();
+bool RS_LayerList::isVisibleLayer(const RS_Layer* layer) const {
+    const auto it = std::find(layers.cbegin(), layers.cend(), layer);
+    return it != layers.cend() && !(*it)->isFrozen();
 }
 
-void RS_LayerList::ensureActiveLayerIsEditable() {
-    if (isEditable(activeLayer)) {
+void RS_LayerList::ensureActiveLayerIsVisible() {
+    if (isVisibleLayer(activeLayer)) {
         return;
     }
 
     for (RS_Layer* layer : layers) {
-        if (isEditable(layer)) {
+        if (isVisibleLayer(layer)) {
             activate(layer, true);
             return;
         }
     }
 
-    // Keep one layer editable when a batch operation would otherwise leave
-    // the document with no valid current layer.
-    if (activeLayer == nullptr && !layers.isEmpty()) {
-        activeLayer = layers.first();
+    // A drawing must retain one visible current layer. Prefer the existing
+    // current layer when it still belongs to this list; otherwise use the
+    // first layer. Lock state is deliberately independent of visibility.
+    RS_Layer* fallback = layers.contains(activeLayer) ? activeLayer : nullptr;
+    if (fallback == nullptr && !layers.isEmpty()) {
+        fallback = layers.first();
     }
-    if (activeLayer != nullptr) {
-        activeLayer->freeze(false);
-        activeLayer->lock(false);
-        for (auto *listener : layerListListeners) {
-            if (listener != nullptr) {
-                listener->layerActivated(activeLayer);
-            }
+    if (fallback != nullptr) {
+        fallback->freeze(false);
+        if (fallback != activeLayer) {
+            activate(fallback, true);
         }
     }
 }

--- a/librecad/src/lib/engine/rs_layerlist.cpp
+++ b/librecad/src/lib/engine/rs_layerlist.cpp
@@ -79,11 +79,11 @@ QList<RS_Layer*>::const_iterator RS_LayerList::end()const
  * 
  * @param notify Notify listeners.
  */
-bool RS_LayerList::activate(const QString& name, bool notify) {
+void RS_LayerList::activate(const QString& name, bool notify) {
     RS_DEBUG->print("RS_LayerList::activate: %s, notify: %d begin",
                                     name.toLatin1().data(), notify);
 
-    const bool activated = activate(find(name), notify);
+    activate(find(name), notify);
     /*
     if (activeLayer==nullptr) {
         RS_DEBUG->print("activeLayer is nullptr");
@@ -93,7 +93,6 @@ bool RS_LayerList::activate(const QString& name, bool notify) {
     */
 
     RS_DEBUG->print("RS_LayerList::activate: %s end", name.toLatin1().data());
-    return activated;
 }
 
 
@@ -103,13 +102,11 @@ bool RS_LayerList::activate(const QString& name, bool notify) {
  * 
  * @param notify Notify listeners.
  */
-bool RS_LayerList::activate(RS_Layer* layer, bool notify) {
+void RS_LayerList::activate(RS_Layer* layer, bool notify) {
     RS_DEBUG->print("RS_LayerList::activate notify: %d begin", notify);
 
     if (!isVisibleLayer(layer)) {
-        RS_DEBUG->print(RS_Debug::D_WARNING,
-                        "RS_LayerList::activate: refusing a null, foreign, or frozen layer");
-        return false;
+        return;
     }
 
     /*if (layer) {
@@ -131,7 +128,6 @@ bool RS_LayerList::activate(RS_Layer* layer, bool notify) {
     }
 
     RS_DEBUG->print("RS_LayerList::activate end");
-    return true;
 }
 
 
@@ -213,7 +209,7 @@ void RS_LayerList::remove(RS_Layer* layer) {
 
 	setModified(true);
 
-    // Restore a valid current layer before listeners observe the removal.
+    // Select a survivor before notifying listeners.
     if (activeLayer==layer) {
         activeLayer = nullptr;
         ensureActiveLayerIsVisible();
@@ -593,14 +589,11 @@ void RS_LayerList::ensureActiveLayerIsVisible() {
 
     for (RS_Layer* layer : layers) {
         if (isVisibleLayer(layer)) {
-            activate(layer, true);
+            activate(layer);
             return;
         }
     }
 
-    // A drawing must retain one visible current layer. Prefer the existing
-    // current layer when it still belongs to this list; otherwise use the
-    // first layer. Lock state is deliberately independent of visibility.
     RS_Layer* fallback = layers.contains(activeLayer) ? activeLayer : nullptr;
     if (fallback == nullptr && !layers.isEmpty()) {
         fallback = layers.first();
@@ -608,7 +601,7 @@ void RS_LayerList::ensureActiveLayerIsVisible() {
     if (fallback != nullptr) {
         fallback->freeze(false);
         if (fallback != activeLayer) {
-            activate(fallback, true);
+            activate(fallback);
         }
     }
 }

--- a/librecad/src/lib/engine/rs_layerlist.cpp
+++ b/librecad/src/lib/engine/rs_layerlist.cpp
@@ -105,7 +105,7 @@ void RS_LayerList::activate(const QString& name, bool notify) {
 void RS_LayerList::activate(RS_Layer* layer, bool notify) {
     RS_DEBUG->print("RS_LayerList::activate notify: %d begin", notify);
 
-    if (!isVisibleLayer(layer)) {
+    if (!layers.contains(layer) || layer->isFrozen()) {
         return;
     }
 
@@ -577,32 +577,29 @@ void RS_LayerList::toggleFreezeMulti(QList<RS_Layer*> toggleLayers){
    fireLayerToggled();
 }
 
-bool RS_LayerList::isVisibleLayer(const RS_Layer* layer) const {
-    const auto it = std::find(layers.cbegin(), layers.cend(), layer);
-    return it != layers.cend() && !(*it)->isFrozen();
-}
-
 void RS_LayerList::ensureActiveLayerIsVisible() {
-    if (isVisibleLayer(activeLayer)) {
+    if (layers.contains(activeLayer) && !activeLayer->isFrozen()) {
         return;
     }
 
+    RS_Layer* fallback = nullptr;
     for (RS_Layer* layer : layers) {
-        if (isVisibleLayer(layer)) {
-            activate(layer);
-            return;
+        if (!layer->isFrozen()) {
+            fallback = layer;
+            break;
         }
     }
 
-    RS_Layer* fallback = layers.contains(activeLayer) ? activeLayer : nullptr;
-    if (fallback == nullptr && !layers.isEmpty()) {
-        fallback = layers.first();
-    }
-    if (fallback != nullptr) {
-        fallback->freeze(false);
-        if (fallback != activeLayer) {
-            activate(fallback);
+    if (fallback == nullptr) {
+        fallback = layers.contains(activeLayer) ? activeLayer
+                                                : (layers.isEmpty() ? nullptr : layers.first());
+        if (fallback == nullptr) {
+            return;
         }
+        fallback->freeze(false);
+    }
+    if (fallback != activeLayer) {
+        activate(fallback);
     }
 }
 

--- a/librecad/src/lib/engine/rs_layerlist.cpp
+++ b/librecad/src/lib/engine/rs_layerlist.cpp
@@ -47,6 +47,7 @@ RS_LayerList::RS_LayerList() {
  */
 void RS_LayerList::clear() {
     layers.clear();
+	activeLayer = nullptr;
 	setModified(true);
 }
 
@@ -209,9 +210,10 @@ void RS_LayerList::remove(RS_Layer* layer) {
 		
 	setModified(true);
 
-    // activate an other layer if necessary:
+    // Do not leave a dangling active-layer pointer while the layer is gone.
     if (activeLayer==layer) {
-        activate(layers.first());
+        activeLayer = nullptr;
+        ensureActiveLayerIsEditable();
     }
 
     // now it's save to delete the layer
@@ -231,6 +233,8 @@ void RS_LayerList::edit(RS_Layer* layer, const RS_Layer& source) {
     }
 
     *layer = source;
+
+    ensureActiveLayerIsEditable();
 
     fireEdit(layer);
 }
@@ -328,6 +332,7 @@ void RS_LayerList::toggle(RS_Layer* layer) {
 
     // set flags
     layer->toggle();
+    ensureActiveLayerIsEditable();
     setModified(true);
 
     // Notify listeners:
@@ -355,6 +360,7 @@ void RS_LayerList::toggleLock(RS_Layer* layer) {
     }
 
     layer->toggleLock();
+    ensureActiveLayerIsEditable();
     setModified(true);
 
     // Notify listeners:
@@ -427,6 +433,7 @@ void RS_LayerList::freezeAll(bool freeze) {
          }
     }
 
+    ensureActiveLayerIsEditable();
     fireLayerToggled();
 
 }
@@ -445,6 +452,7 @@ void RS_LayerList::lockAll(bool lock) {
              at(l)->lock(lock);
          }
     }
+    ensureActiveLayerIsEditable();
     fireLayerToggled();
 }
 
@@ -458,6 +466,7 @@ void RS_LayerList::toggleLockMulti(QList<RS_Layer*> toggleLayers){
         }
     }
 
+    ensureActiveLayerIsEditable();
     fireLayerToggled();
 }
 void RS_LayerList::togglePrintMulti(QList<RS_Layer*> toggleLayers){
@@ -497,6 +506,7 @@ void RS_LayerList::setFreezeMulti(QList<RS_Layer*> layersEnable, QList<RS_Layer*
             layer->freeze(true);
         }
     }
+    ensureActiveLayerIsEditable();
    fireLayerToggled();
 }
 
@@ -515,6 +525,7 @@ void RS_LayerList::setLockMulti(QList<RS_Layer*> layersToUnlock, QList<RS_Layer*
             layer->lock(true);
         }
     }
+    ensureActiveLayerIsEditable();
     fireLayerToggled();
 }
 
@@ -562,7 +573,40 @@ void RS_LayerList::toggleFreezeMulti(QList<RS_Layer*> toggleLayers){
             layer->toggle();
         }
     }
+    ensureActiveLayerIsEditable();
    fireLayerToggled();
+}
+
+bool RS_LayerList::isEditable(const RS_Layer* layer) const {
+    return layer != nullptr && !layer->isFrozen() && !layer->isLocked();
+}
+
+void RS_LayerList::ensureActiveLayerIsEditable() {
+    if (isEditable(activeLayer)) {
+        return;
+    }
+
+    for (RS_Layer* layer : layers) {
+        if (isEditable(layer)) {
+            activate(layer, true);
+            return;
+        }
+    }
+
+    // Keep one layer editable when a batch operation would otherwise leave
+    // the document with no valid current layer.
+    if (activeLayer == nullptr && !layers.isEmpty()) {
+        activeLayer = layers.first();
+    }
+    if (activeLayer != nullptr) {
+        activeLayer->freeze(false);
+        activeLayer->lock(false);
+        for (auto *listener : layerListListeners) {
+            if (listener != nullptr) {
+                listener->layerActivated(activeLayer);
+            }
+        }
+    }
 }
 
 
@@ -619,4 +663,3 @@ void RS_LayerList::setModified(bool m) {
 void RS_LayerList::slotUpdateLayerList(){
     setModified(true);
 }
-

--- a/librecad/src/lib/engine/rs_layerlist.h
+++ b/librecad/src/lib/engine/rs_layerlist.h
@@ -141,6 +141,9 @@ public:
 
 private:
 
+    bool isEditable(const RS_Layer* layer) const;
+    void ensureActiveLayerIsEditable();
+
     void fireLayerToggled();
 	//! layers in the graphic
     QList<RS_Layer*> layers;

--- a/librecad/src/lib/engine/rs_layerlist.h
+++ b/librecad/src/lib/engine/rs_layerlist.h
@@ -142,7 +142,6 @@ public:
 
 private:
 
-    bool isVisibleLayer(const RS_Layer* layer) const;
     void ensureActiveLayerIsVisible();
 
     friend class RS_Graphic;

--- a/librecad/src/lib/engine/rs_layerlist.h
+++ b/librecad/src/lib/engine/rs_layerlist.h
@@ -33,6 +33,7 @@
 
 class RS_Layer;
 class RS_LayerListListener;
+class RS_Graphic;
 class QG_LayerWidget;
 
 /**
@@ -65,8 +66,8 @@ public:
     QList<RS_Layer*>::const_iterator begin()const;
     QList<RS_Layer*>::const_iterator end()const;
 
-    void activate(const QString& name, bool notify = false);
-    void activate(RS_Layer* layer, bool notify = false);
+    bool activate(const QString& name, bool notify = false);
+    bool activate(RS_Layer* layer, bool notify = false);
     //! @return The active layer of NULL if no layer is activated.
     RS_Layer* getActive() {
         return activeLayer;
@@ -141,8 +142,10 @@ public:
 
 private:
 
-    bool isEditable(const RS_Layer* layer) const;
-    void ensureActiveLayerIsEditable();
+    bool isVisibleLayer(const RS_Layer* layer) const;
+    void ensureActiveLayerIsVisible();
+
+    friend class RS_Graphic;
 
     void fireLayerToggled();
 	//! layers in the graphic

--- a/librecad/src/lib/engine/rs_layerlist.h
+++ b/librecad/src/lib/engine/rs_layerlist.h
@@ -66,8 +66,8 @@ public:
     QList<RS_Layer*>::const_iterator begin()const;
     QList<RS_Layer*>::const_iterator end()const;
 
-    bool activate(const QString& name, bool notify = false);
-    bool activate(RS_Layer* layer, bool notify = false);
+    void activate(const QString& name, bool notify = false);
+    void activate(RS_Layer* layer, bool notify = false);
     //! @return The active layer of NULL if no layer is activated.
     RS_Layer* getActive() {
         return activeLayer;

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -760,8 +760,8 @@ void QC_ApplicationWindow::loadPlugins() {
                     }
                 }
             } else {
-                QMessageBox::information(this, "Info", pluginLoader.errorString());
-                RS_DEBUG->print("QC_ApplicationWindow::loadPlugin: %s", pluginLoader.errorString().toLatin1().data());
+                RS_DEBUG->print(RS_Debug::D_WARNING, "QC_ApplicationWindow::loadPlugin: %s",
+                                pluginLoader.errorString().toLatin1().data());
             }
         }
     }
@@ -1828,7 +1828,8 @@ void QC_ApplicationWindow::slotFileOpen() {
     QG_FileDialog dlg(this);
     QString fileName = dlg.getOpenFile(&type);
     RS_DEBUG->print("QC_ApplicationWindow::slotFileOpen() 003");
-    slotFileOpen(fileName, type);
+    if (!fileName.isEmpty())
+        slotFileOpen(fileName, type);
     RS_DEBUG->print("QC_ApplicationWindow::slotFileOpen(): OK");
 }
 

--- a/librecad/src/ui/lc_layertreewidget.cpp
+++ b/librecad/src/ui/lc_layertreewidget.cpp
@@ -382,12 +382,14 @@ void LC_LayerTreeWidget::update(){
 void LC_LayerTreeWidget::activateLayer(RS_Layer *layer){
     RS_DEBUG->print("QG_LayerWidget::activateLayer() begin");
 
-    if (!layer || !layerList || layer->isFrozen() || layer->isLocked()){
+    if (!layer || !layerList){
         RS_DEBUG->print(RS_Debug::D_ERROR, "QG_LayerWidget::activateLayer: nullptr layer or layerList");
         return;
     }
 
-    layerList->activate(layer, false);
+    if (!layerList->activate(layer, false)) {
+        return;
+    }
     update();
     layerTreeView->viewport()->update();
 
@@ -836,10 +838,10 @@ void LC_LayerTreeWidget::hideOtherThanSelectedLayers(){
             RS_Layer* layer = layersToShow.at(i);
             layersToHide.removeAll(layer);
         }
-        if (count > 0){
-            layerList->activate(layersToShow.at(0), false);
-        }
         manageLayersVisibilityFlag(layersToShow, layersToHide, false);
+        if (count > 0){
+            activateLayer(layersToShow.at(0));
+        }
     }
 }
 /**
@@ -1027,7 +1029,6 @@ void LC_LayerTreeWidget::layerEdited(RS_Layer *){
 void LC_LayerTreeWidget::layerRemoved(RS_Layer *){
     RS_DEBUG->print("LC_LayerTreeWidget::layerRemoved()");
     update();
-    activateLayer(layerList->at(0));
 }
 
 void LC_LayerTreeWidget::layerToggled(RS_Layer *){
@@ -1954,4 +1955,3 @@ void LC_LayerTreeWidget::invokeSettingsDialog(){
         update();
     }
 }
-

--- a/librecad/src/ui/lc_layertreewidget.cpp
+++ b/librecad/src/ui/lc_layertreewidget.cpp
@@ -382,7 +382,7 @@ void LC_LayerTreeWidget::update(){
 void LC_LayerTreeWidget::activateLayer(RS_Layer *layer){
     RS_DEBUG->print("QG_LayerWidget::activateLayer() begin");
 
-    if (!layer || !layerList){
+    if (!layer || !layerList || layer->isFrozen() || layer->isLocked()){
         RS_DEBUG->print(RS_Debug::D_ERROR, "QG_LayerWidget::activateLayer: nullptr layer or layerList");
         return;
     }
@@ -1954,5 +1954,4 @@ void LC_LayerTreeWidget::invokeSettingsDialog(){
         update();
     }
 }
-
 

--- a/librecad/src/ui/lc_layertreewidget.cpp
+++ b/librecad/src/ui/lc_layertreewidget.cpp
@@ -387,7 +387,8 @@ void LC_LayerTreeWidget::activateLayer(RS_Layer *layer){
         return;
     }
 
-    if (!layerList->activate(layer, false)) {
+    layerList->activate(layer, false);
+    if (layerList->getActive() != layer) {
         return;
     }
     update();
@@ -1955,3 +1956,4 @@ void LC_LayerTreeWidget::invokeSettingsDialog(){
         update();
     }
 }
+

--- a/librecad/src/ui/qg_layerwidget.cpp
+++ b/librecad/src/ui/qg_layerwidget.cpp
@@ -400,7 +400,7 @@ void QG_LayerWidget::restoreSelections() {
 void QG_LayerWidget::activateLayer(RS_Layer* layer, bool updateScroll) {
     RS_DEBUG->print("QG_LayerWidget::activateLayer() begin");
 
-    if (!layer || !layerList) {
+    if (!layer || !layerList || layer->isFrozen() || layer->isLocked()) {
         RS_DEBUG->print(RS_Debug::D_ERROR, "QG_LayerWidget::activateLayer: nullptr layer or layerList");
         return;
     }

--- a/librecad/src/ui/qg_layerwidget.cpp
+++ b/librecad/src/ui/qg_layerwidget.cpp
@@ -400,12 +400,14 @@ void QG_LayerWidget::restoreSelections() {
 void QG_LayerWidget::activateLayer(RS_Layer* layer, bool updateScroll) {
     RS_DEBUG->print("QG_LayerWidget::activateLayer() begin");
 
-    if (!layer || !layerList || layer->isFrozen() || layer->isLocked()) {
+    if (!layer || !layerList) {
         RS_DEBUG->print(RS_Debug::D_ERROR, "QG_LayerWidget::activateLayer: nullptr layer or layerList");
         return;
     }
 
-    layerList->activate(layer);
+    if (!layerList->activate(layer)) {
+        return;
+    }
 
     if (!layerModel) {
         RS_DEBUG->print(RS_Debug::D_ERROR, "QG_LayerWidget::activateLayer: nullptr layerModel");

--- a/librecad/src/ui/qg_layerwidget.cpp
+++ b/librecad/src/ui/qg_layerwidget.cpp
@@ -405,7 +405,8 @@ void QG_LayerWidget::activateLayer(RS_Layer* layer, bool updateScroll) {
         return;
     }
 
-    if (!layerList->activate(layer)) {
+    layerList->activate(layer);
+    if (layerList->getActive() != layer) {
         return;
     }
 

--- a/librecad/src/ui/qg_layerwidget.h
+++ b/librecad/src/ui/qg_layerwidget.h
@@ -121,7 +121,6 @@ public:
   void layerEdited(RS_Layer *) override { update(); }
   void layerRemoved(RS_Layer *) override {
         update();
-        activateLayer(layerList->at(0));
     }
     void layerToggled(RS_Layer*) override {
         update();


### PR DESCRIPTION
## Summary
- backport the `RS_LayerList` current-layer invariant to 2.2.1
- reject null, foreign, and frozen layers; lock state remains independent
- recover a visible current layer after visibility changes, removal, and import
- keep both legacy layer widgets synchronized when activation is rejected
- give the macOS application bundle a stable identifier so native file dialogs open correctly
- treat cancellation of File > Open as a no-op instead of attempting to open an empty path
- report incompatible or invalid optional plugins through the warning log without a modal message box

## Correctness
- every pointer and name activation passes through the model guard
- recovery chooses an existing visible layer, or thaws one layer if none is visible
- recovery never changes lock state
- the state transitions match the master regression test
- file opening is dispatched only after the native dialog returns a non-empty filename
- plugin loading continues after failures while preserving the full Qt diagnostic at `D_WARNING`

## Verification
- focused active-layer regression test: 24 assertions passed
- full CMake/Qt 5 application build
- full qmake/Qt 5 application and plugin build
- controlled macOS native-file-dialog probe
- `git diff --check`

## References
- [Locked layers may be current and accept new objects](https://help.autodesk.com/cloudhelp/2026/PTB/AutoCAD-LT-ActiveX-Reference/files/GUID-49CA344E-0F8C-4AB2-8336-9E696F8BD5D7.htm)
- [A frozen layer cannot be current](https://help.autodesk.com/cloudhelp/2022/ENU/AutoCAD-Core/files/GUID-2C75A883-10CA-4B6C-96AC-BCD7A7794614.htm)