### PR TITLE
[2.2.1] Fix line-points prompt text

### DIFF
--- a/librecad/src/actions/lc_actiondrawlinepoints.cpp
+++ b/librecad/src/actions/lc_actiondrawlinepoints.cpp
@@ -499,7 +499,7 @@ void LC_ActionDrawLinePoints::updateMouseButtonHints(){
             updateMouseWidgetTR("Specify edge points mode\n[none|start|end|both|distance]","Back");
             break;
         case SetFixDistance:
-            updateMouseWidgetTR("Specify fixed distance between points\nor[x|y|p|number|edges]","Back");
+            updateMouseWidgetTR("Specify fixed distance between points\nor [x|y|p|number|edges]","Back");
             break;
         case SetDistance: {
             bool toX = direction == DIRECTION_X;
@@ -518,7 +518,7 @@ void LC_ActionDrawLinePoints::updateMouseButtonHints(){
                 msg += "|" + getCommand("x");
                 msg += "|" + getCommand("y");
                 QString angleStr = RS_Math::doubleToString(angle, 1);
-                updateMouseWidget(tr("Specify  distance (angle %1 deg)\nor [%2]").arg(angleStr, msg),tr("Back"));
+                updateMouseWidget(tr("Specify distance (angle %1 deg)\nor [%2]").arg(angleStr, msg),tr("Back"));
             }
             break;
         }
@@ -579,4 +579,3 @@ void LC_ActionDrawLinePoints::setMajorStatus(){
 void LC_ActionDrawLinePoints::createOptionsWidget(){
     m_optionWidget = std::make_unique<LC_LinePointsOptions>(nullptr);
 }
-

--- a/librecad/ts/librecad_ru.ts
+++ b/librecad/ts/librecad_ru.ts
@@ -256,7 +256,7 @@ or [%2]</source>
     </message>
     <message>
         <location filename="../src/actions/lc_actiondrawlinepoints.cpp" line="521"/>
-        <source>Specify  distance (angle %1 deg)
+        <source>Specify distance (angle %1 deg)
 or [%2]</source>
         <translation>Укажите расстояние (угол %1 град.)
 или [%2]</translation>


### PR DESCRIPTION
## Summary

Backport the applicable prompt fixes from the old PR #2442 to the 2.2.1 code layout:

- remove the extra space in the line-points distance prompt
- add the missing space before the line-points command list
- keep the existing Russian translation while updating its source key to the corrected prompt

The older 2.2.1 branch does not contain the newer rectangle and menu-assignment sources from the master PR, so those fixes are intentionally limited to the master port.

## Verification

- qmake/Qt 5 application build completed successfully
- `git diff --check`
- `xmllint --noout librecad/ts/librecad_ru.ts`
- confirmed no targeted source typos remain
