### PR TITLE
Allow reusing block name after deletion

### DIFF
--- a/librecad/src/lib/engine/document/blocks/rs_blocklist.cpp
+++ b/librecad/src/lib/engine/document/blocks/rs_blocklist.cpp
@@ -222,6 +222,9 @@ const RS_Block* RS_BlockList::find(const QString& name) const {
     // emit decomposed (NFD) Unicode still matches a composed (NFC) lookup.
     const QString k = name.normalized(QString::NormalizationForm_C);
     for (const RS_Block* b : std::as_const(m_blocks)) {
+        if (b->isDeleted()) {
+            continue;
+        }
         if (b->getName().normalized(QString::NormalizationForm_C) == k) {
             return b;
         }
@@ -243,6 +246,9 @@ RS_Block* RS_BlockList::findCaseInsensitive(const QString& name) const {
     //DFS
     const QString k = name.normalized(QString::NormalizationForm_C);
     for (RS_Block* b : m_blocks) {
+        if (b->isDeleted()) {
+            continue;
+        }
         if (b->getName().normalized(QString::NormalizationForm_C)
                 .compare(k, Qt::CaseInsensitive) == 0) {
             return b;


### PR DESCRIPTION
## Problem

After deleting a block, creating a new block with the same name fails. This is the issue described in #1408.

### Root cause

When a block is deleted, it is soft-deleted (flagged with `RS2::FlagDeleted`) but remains in `RS_BlockList::m_blocks`. However, `RS_BlockList::find()` does not skip deleted blocks, so it finds the deleted block and `add()` rejects the new block because the name "already exists".

This also affects `newName()` which calls `find()` to generate unique names.

## Fix

Skip deleted blocks in `find()` and `findCaseInsensitive()` by checking `b->isDeleted()`. This is the simplest fix — it benefits all callers (`add()`, `newName()`, `rename()`, etc.) in a single place.

## Comparison to PR #1408

PR #1408 (from 2021) addressed this by renaming the to-be-deleted block to a random string before deletion. That approach:
- Targets a much older codebase (pre `LC_DocumentModificationBatch` refactor)
- Uses `rand()` with no seeding
- Has a potential infinite loop (`while (!randomBlockNameFound)`)

This PR fixes the root cause directly in `find()` instead.

Closes #1408