### PR TITLE
Allow reusing block name after deletion

### DIFF
--- a/librecad/src/lib/engine/rs_blocklist.cpp
+++ b/librecad/src/lib/engine/rs_blocklist.cpp
@@ -222,6 +222,9 @@ RS_Block* RS_BlockList::find(const QString& name) {
 	// Todo : reduce this from O(N) to O(log(N)) complexity based on sorted list or hash
 	//DFS
 	for(RS_Block* b: blocks) {
+		if (b->isUndone()) {
+			continue;
+		}
 		if (b->getName()==name) {
 			return b;
 		}


### PR DESCRIPTION
## Problem

After deleting a block, creating a new block with the same name fails. This is the issue described in #1408.

### Root cause

When a block is deleted via `RS_ActionBlocksRemove`, it is soft-deleted (`setUndoState(true)`) but remains in `RS_BlockList::blocks`. However, `RS_BlockList::find()` does not skip undone blocks, so it finds the deleted block and `add()` rejects the new block because the name "already exists".

This also affects `newName()` which calls `find()` to generate unique names.

## Fix

Skip undone blocks in `find()` by checking `b->isUndone()`. This is the simplest fix — it benefits all callers (`add()`, `newName()`, `rename()`, etc.) in a single place.

## Comparison to PR #1408

PR #1408 (from 2021) addressed this by renaming the to-be-deleted block to a random string before deletion. That approach:
- Uses `rand()` with no seeding
- Has a potential infinite loop (`while (!randomBlockNameFound)`)

This PR fixes the root cause directly in `find()` instead.

Backport of #2750 for the 2.2.1 branch.

Closes #1408