### PR TITLE
Honor horizontal text alignment in angular dimensions (#1396)

### DIFF
--- a/librecad/src/lib/engine/document/entities/lc_dimarc.cpp
+++ b/librecad/src/lib/engine/document/entities/lc_dimarc.cpp
@@ -200,12 +200,10 @@ void LC_DimArc::doUpdateDim() {
 
         constexpr double deg360{M_PI * 2.0};
 
-        constexpr double degTolerance{1.0E-3};
-
         /* With regards to Quadrants #1 and #2 */
-        if (((textAngle_preliminary >= -degTolerance) && (textAngle_preliminary <= (M_PI + degTolerance)))
-            || ((textAngle_preliminary <= -(M_PI - degTolerance)) && (textAngle_preliminary >= -(deg360 +
-                degTolerance)))) {
+        if (((textAngle_preliminary >= -g_dimTextQuadrantTolerance) && (textAngle_preliminary <= (M_PI + g_dimTextQuadrantTolerance)))
+            || ((textAngle_preliminary <= -(M_PI - g_dimTextQuadrantTolerance)) && (textAngle_preliminary >= -(deg360 +
+                g_dimTextQuadrantTolerance)))) {
             textPosOffset.setPolar(getDimensionLineGap() * getGeneralScale(), textAngle_preliminary);
             textAngle = textAngle_preliminary + M_PI + M_PI_2;
         }
@@ -293,18 +291,16 @@ void LC_DimArc::doUpdateDim() {
 
     //TODO: the current algorithm to find dimArc1/dimArc2 angles could be
     // costly.
-    constexpr double deltaOffset{1.0E-2};
-
     while (!textRectRotated.inArea(dimArc1->getEndpoint())
         && (dimArc1->getAngle2() < RS_MAXDOUBLE)
         && (dimArc1->getAngle2() > RS_MINDOUBLE)) {
-        dimArc1->setAngle2(dimArc1->getAngle2() + deltaOffset);
+        dimArc1->setAngle2(dimArc1->getAngle2() + g_dimArcTextStep);
     }
 
     while (!textRectRotated.inArea(dimArc2->getStartpoint())
         && (dimArc2->getAngle1() < RS_MAXDOUBLE)
         && (dimArc2->getAngle1() > RS_MINDOUBLE)) {
-        dimArc2->setAngle1(dimArc2->getAngle1() - deltaOffset);
+        dimArc2->setAngle1(dimArc2->getAngle1() - g_dimArcTextStep);
     }
 
     dimArc1->setPen(pen);

--- a/librecad/src/lib/engine/document/entities/rs_dimangular.cpp
+++ b/librecad/src/lib/engine/document/entities/rs_dimangular.cpp
@@ -30,6 +30,7 @@
 #include<iostream>
 
 #include "lc_linemath.h"
+#include "lc_rect.h"
 #include "rs_arc.h"
 #include "rs_constructionline.h"
 #include "rs_debug.h"
@@ -272,24 +273,72 @@ void RS_DimAngular::doUpdateDim() {
     double textAngle{0.0};
     double angle1{textPos.angleTo(dimCenter) - M_PI_2};
 
-    // rotate text so it's readable from the bottom or right (ISO)
-    // quadrant 1 & 4
-    if (angle1 > M_PI_2 * 3.0 + 0.001 || angle1 < M_PI_2 + 0.001) {
-        distV.setPolar(av.gap(), angle1 + M_PI_2);
-        textAngle = angle1;
-    }
-    // quadrant 2 & 3
-    else {
-        distV.setPolar(av.gap(), angle1 - M_PI_2);
-        textAngle = angle1 + M_PI;
-    }
+    // $DIMTIH: horizontal text is left unrotated on the arc, and the arc is
+    // broken around it below. Otherwise it is aligned with the arc and moved
+    // clear of it.
+    const bool horizontalText = getInsideHorizontalText();
+    if (!horizontalText) {
+        // rotate text so it's readable from the bottom or right (ISO)
+        // quadrant 1 & 4
+        if (angle1 > M_PI_2 * 3.0 + g_dimTextQuadrantTolerance || angle1 < M_PI_2 + g_dimTextQuadrantTolerance) {
+            distV.setPolar(av.gap(), angle1 + M_PI_2);
+            textAngle = angle1;
+        }
+        // quadrant 2 & 3
+        else {
+            distV.setPolar(av.gap(), angle1 - M_PI_2);
+            textAngle = angle1 + M_PI;
+        }
 
-    // move text away from dimension line:
-    textPos += distV;
+        // move text away from dimension line:
+        textPos += distV;
+    }
 
     auto text = createDimText(textPos, av.txt(), textAngle);
     if (drawFrameAroundText) {
         addBoundsAroundText(dimgap, text);
+    }
+
+    if (horizontalText) {
+        breakArcAroundText(arc, arcData, textPos, text->getUsedTextWidth(), av);
+    }
+}
+
+/**
+ * @brief Break the dimension arc so horizontal text is not drawn over
+ *
+ * @param arc  the dimension arc, reused as the piece before the text
+ * @param arcData  the unbroken arc, used to create the piece after the text
+ * @param textPos  center of the text, on the middle of the arc
+ * @param textWidth  width of the text label
+ * @param av  DXF variables, for the gap kept around the text
+ */
+void RS_DimAngular::breakArcAroundText(RS_Arc* arc, const RS_ArcData& arcData, const RS_Vector& textPos,
+                                       const double textWidth, const LC_DimAngularVars& av) {
+    const RS_Vector textHalfSize{textWidth / 2.0 + av.gap(), av.txt() / 2.0 + av.gap()};
+    const lc::geo::Area textRect{textPos - textHalfSize, textPos + textHalfSize};
+
+    // The text may be wider than the whole arc, leaving nothing to keep on
+    // either side of it. Keep the arc unbroken rather than collapsing it, as a
+    // piece with equal angles would be drawn as a full circle.
+    if (textRect.inArea(arc->getStartpoint()) || textRect.inArea(arc->getEndpoint())) {
+        return;
+    }
+
+    // The text is centered on the arc, so neither piece grows past the middle.
+    const int maxSteps{static_cast<int>(std::abs(arc->getAngleLength()) / (2.0 * g_dimArcTextStep))};
+
+    RS_Arc* arc2 = addDimArc(arcData);
+
+    // Collapse each piece onto its own end of the arc, then grow it towards
+    // the text until it reaches it, so the text is left free.
+    arc->setAngle2(arc->getAngle1());
+    for (int i = 0; i < maxSteps && !textRect.inArea(arc->getEndpoint()); ++i) {
+        arc->setAngle2(arc->getAngle2() + g_dimArcTextStep);
+    }
+    arc2->setAngle1(arc2->getAngle2());
+    for (int i = 0; i < maxSteps && !textRect.inArea(arc2->getStartpoint()); ++i) {
+        arc2->setAngle1(arc2->getAngle1() - g_dimArcTextStep);
     }
 }
 

--- a/librecad/src/lib/engine/document/entities/rs_dimangular.h
+++ b/librecad/src/lib/engine/document/entities/rs_dimangular.h
@@ -196,6 +196,8 @@ private:
                        const LC_DimAngularVars& av);
     void arrow(const RS_Vector& point, double angle, double direction, bool outsideArrows,
                const LC_DimAngularVars& av);
+    void breakArcAroundText(RS_Arc* arc, const RS_ArcData& arcData, const RS_Vector& textPos, double textWidth,
+                            const LC_DimAngularVars& av);
 
     RS_Vector   dimDir1s;
     RS_Vector   dimDir1e;

--- a/librecad/src/lib/engine/document/entities/rs_dimension.h
+++ b/librecad/src/lib/engine/document/entities/rs_dimension.h
@@ -38,6 +38,20 @@ class RS_Color;
 class RS_Line;
 
 /**
+ * Angular step used when walking a dimension arc to find where it meets the
+ * text label, by RS_DimAngular and LC_DimArc.
+ */
+constexpr double g_dimArcTextStep = 1.0E-2;
+
+/**
+ * Angle by which the quadrant tests that decide the reading direction of
+ * dimension text are widened, so text sitting exactly on a quadrant boundary
+ * picks a stable side. Not a numerical tolerance - it is far larger than
+ * RS_TOLERANCE_ANGLE.
+ */
+constexpr double g_dimTextQuadrantTolerance = 1.0E-3;
+
+/**
  * Holds the data that is common to all dimension entities.
  */
 struct RS_DimensionData : public RS_Flags {


### PR DESCRIPTION
Angular dimensions ignore the drawing's text alignment setting. Fixes the second bug reported in #1396 / #1409; supersedes #1427, which fixed this against the 2021 code and no longer applies.

## The bug

`RS_DimAngular::doUpdateDim()` never consulted `getInsideHorizontalText()`. It unconditionally ran the quadrant-rotation logic and passed the resulting angle to `createDimText()`, so the label was always aligned with the arc no matter what `$DIMTIH` said.

Angular was the only dimension type left out — `RS_Dimension::createDimensionLine()` dispatches on the same setting for linear dimensions, `LC_DimArc` honors it for arc-length dimensions, and `$DIMTIH` is read from DXF into the style (`rs_filterdxfrw.cpp`, group code 73). Note the policy defaults to `DRAW_HORIZONTALLY`, so this affects ordinary drawings, not just ones that set the variable explicitly.

## The change

Two things, both scoped to the horizontal case:

- **Leave the label unrotated.** The rotation block is now gated on `!horizontalText`; the text keeps `textAngle = 0` and stays at the arc's midpoint instead of being pushed clear of it.
- **Break the arc around the text**, so it isn't drawn straight through the label — the behaviour linear dimensions already get by splitting their dimension line, and the thing @jbergengh asked for in [#1409](https://github.com/LibreCAD/LibreCAD/pull/1409#issuecomment-975885935) ("The dimension lines should have a gap around the numerical value instead of overwriting the text").

The break follows `LC_DimArc`'s approach: the existing arc is trimmed back until its endpoint reaches the text box, and a second arc runs from the text to the far end. One difference — because the text sits on the middle of the arc, half the sweep is a hard upper bound on both walks, so the loops are bounded by a step count instead of `LC_DimArc`'s open-ended `RS_MAXDOUBLE`/`RS_MINDOUBLE` guards.

Aligned text is untouched: same rotation, same offset, same single unbroken arc as before.

61 insertions across the two files, no changes to shared code. Written against the current `addDimArc()` / `createDimText()` helpers rather than raw `setPen`/`setLayer`/`addEntity` calls, which is why #1427 could not simply be rebased — that file has since been refactored so those helpers resolve the pen internally.

## Verification

A throwaway Catch2 test (not included in the commit) built the same dimension twice, differing only in the orientation policy, and inspected the generated child entities:

```
aligned     arcs=1  textAngle=5.30144
horizontal  arcs=2  textAngle=0
```

So aligned text stays rotated over a single arc, horizontal text is unrotated with the arc split in two — exactly the intended difference, and no change to the aligned path.

Full existing suite: **13309 assertions in 773 test cases, all passing**, plus a clean release build.
