### PR TITLE
Stop writing a zero Z scale on INSERT entities (#1428)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2464,6 +2464,7 @@ if (BUILD_TESTS)
         librecad/src/lib/filters/tests/underlay_tests.cpp
         librecad/src/lib/filters/tests/dxf_string_codec_tests.cpp
         librecad/src/lib/filters/tests/dxf_attribute_tests.cpp
+        librecad/src/lib/filters/tests/insert_zscale_tests.cpp
         librecad/src/lib/filters/tests/block_insert_wipeout_tests.cpp
         librecad/src/lib/filters/tests/dxf_object_tests.cpp
         librecad/src/lib/filters/tests/mpolygon_tests.cpp

--- a/librecad/src/lib/engine/document/entities/lc_mleader.cpp
+++ b/librecad/src/lib/engine/document/entities/lc_mleader.cpp
@@ -164,10 +164,9 @@ bool LC_MLeader::blockContentData(RS_InsertData &out) const {
   if (!m_data.hasBlockContents || m_data.blockName.isEmpty() ||
       !m_data.blockLocation.valid)
     return false;
-  // A zero scale component would collapse the block; default such axes to 1.
-  const RS_Vector scale(m_data.blockScale.x != 0.0 ? m_data.blockScale.x : 1.0,
-                        m_data.blockScale.y != 0.0 ? m_data.blockScale.y : 1.0);
-  out = RS_InsertData(m_data.blockName, m_data.blockLocation, scale,
+  // A degenerate scale component would collapse the block; RS_InsertData
+  // defaults such axes to 1, and keeps the context's z rather than dropping it.
+  out = RS_InsertData(m_data.blockName, m_data.blockLocation, m_data.blockScale,
                       m_data.blockRotation, 1, 1, RS_Vector(0.0, 0.0), nullptr,
                       RS2::NoUpdate);
   return true;

--- a/librecad/src/lib/engine/document/entities/rs_insert.cpp
+++ b/librecad/src/lib/engine/document/entities/rs_insert.cpp
@@ -306,7 +306,9 @@ double RS_InsertData::usableScale(const double factor) {
 }
 
 RS_Vector RS_InsertData::usableScale(const RS_Vector& scale) {
-    return {usableScale(scale.x), usableScale(scale.y), usableScale(scale.z)};
+    RS_Vector result(usableScale(scale.x), usableScale(scale.y), usableScale(scale.z));
+    result.valid = scale.valid;
+    return result;
 }
 
 RS_InsertData::RS_InsertData(const RS_InsertData &other):

--- a/librecad/src/lib/engine/document/entities/rs_insert.cpp
+++ b/librecad/src/lib/engine/document/entities/rs_insert.cpp
@@ -290,13 +290,23 @@ RS_InsertData::RS_InsertData(const QString& _name,
 							 RS2::UpdateMode _updateMode ):
 	name(_name)
   ,insertionPoint(_insertionPoint)
-  ,scaleFactor(_scaleFactor)
+  // LibreCAD is 2D, so callers routinely build the scale from a two component
+  // RS_Vector, whose z defaults to 0. See usableScale().
+  ,scaleFactor(usableScale(_scaleFactor))
   ,angle(_angle)
   ,cols(_cols)
   ,rows(_rows)
   ,spacing(_spacing)
   ,blockSource(_blockSource)
   ,updateMode(_updateMode){
+}
+
+double RS_InsertData::usableScale(const double factor) {
+    return std::isfinite(factor) && factor != 0.0 ? factor : 1.0;
+}
+
+RS_Vector RS_InsertData::usableScale(const RS_Vector& scale) {
+    return {usableScale(scale.x), usableScale(scale.y), usableScale(scale.z)};
 }
 
 RS_InsertData::RS_InsertData(const RS_InsertData &other):

--- a/librecad/src/lib/engine/document/entities/rs_insert.h
+++ b/librecad/src/lib/engine/document/entities/rs_insert.h
@@ -73,6 +73,21 @@ struct RS_InsertData {
                   RS_BlockList* blockSource = nullptr,
 				  RS2::UpdateMode updateMode = RS2::Update);
 
+    /**
+     * @brief usableScale a scale factor safe to store and to write out.
+     * Zero, infinite and NaN factors leave the block transform singular or
+     * meaningless, and other CAD applications reject such an INSERT (#1428);
+     * they become 1. Everything else is data and passes through - negative
+     * factors are mirrors, and tiny nonzero factors are kept because every
+     * consumer (including LibreCAD's own LC_InsertTransform::fromInsert)
+     * rejects only an exact zero; rewriting them would resize valid geometry.
+     */
+    static double usableScale(double factor);
+
+    //! \brief usableScale the same rule on every axis: any degenerate
+    //! component makes the whole block transform unusable, not just z.
+    static RS_Vector usableScale(const RS_Vector& scale);
+
 	QString name;
 	RS_Vector insertionPoint;
 	RS_Vector scaleFactor;

--- a/librecad/src/lib/engine/document/entities/rs_insert.h
+++ b/librecad/src/lib/engine/document/entities/rs_insert.h
@@ -75,17 +75,18 @@ struct RS_InsertData {
 
     /**
      * @brief usableScale a scale factor safe to store and to write out.
-     * Zero, infinite and NaN factors leave the block transform singular or
-     * meaningless, and other CAD applications reject such an INSERT (#1428);
-     * they become 1. Everything else is data and passes through - negative
-     * factors are mirrors, and tiny nonzero factors are kept because every
-     * consumer (including LibreCAD's own LC_InsertTransform::fromInsert)
-     * rejects only an exact zero; rewriting them would resize valid geometry.
+     * Zero, infinite and NaN leave the block transform singular or
+     * meaningless, and other CAD applications reject such an INSERT
+     * (#1428); these become 1. Tiny nonzero factors are kept: every
+     * consumer, including this codebase's own LC_InsertTransform::
+     * fromInsert, rejects only an exact zero.
      */
     static double usableScale(double factor);
 
     //! \brief usableScale the same rule on every axis: any degenerate
     //! component makes the whole block transform unusable, not just z.
+    //! Preserves scale.valid rather than manufacturing a valid vector
+    //! out of one that was explicitly marked invalid.
     static RS_Vector usableScale(const RS_Vector& scale);
 
 	QString name;

--- a/librecad/src/lib/filters/rs_filterdxfrw.cpp
+++ b/librecad/src/lib/filters/rs_filterdxfrw.cpp
@@ -11616,9 +11616,13 @@ void RS_FilterDXFRW::writeInsert(const RS_Insert* i) {
     in.basePoint.y = i->getInsertionPoint().y;
     in.basePoint.z = i->getInsertionPoint().z;
     in.name = i->getName().toUtf8().data();
-    in.xscale = i->getScale().x;
-    in.yscale = i->getScale().y;
-    in.zscale = i->getScale().z;
+    // Inserts that bypass the RS_InsertData constructor - default constructed
+    // data, direct field assignment, or a file that already carried a bad
+    // value - are corrected at the boundary rather than written out.
+    const RS_Vector scale = RS_InsertData::usableScale(i->getScale());
+    in.xscale = scale.x;
+    in.yscale = scale.y;
+    in.zscale = scale.z;
     in.angle = i->getAngle();
     in.colcount = i->getCols();
     in.rowcount = i->getRows();

--- a/librecad/src/lib/filters/tests/insert_zscale_tests.cpp
+++ b/librecad/src/lib/filters/tests/insert_zscale_tests.cpp
@@ -1,0 +1,208 @@
+/****************************************************************************
+**
+** This file is part of the LibreCAD project, a 2D CAD program
+**
+** Copyright (C) 2026 LibreCAD (librecad.org)
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+**********************************************************************/
+
+/**
+ * Regression tests for issue #1428: LibreCAD wrote a zero Z scale (group code
+ * 43) on INSERT entities, because inserts are built from two component
+ * RS_Vectors whose z defaults to 0. A zero scale factor is degenerate - the
+ * block transform becomes singular - and consumers reject it: FreeCAD refuses
+ * the drawing, netDxf and ACadSharp throw on it, ezdxf rewrites it to 1.
+ *
+ * The scale is read straight out of the exported file rather than out of the
+ * RS_Insert, so the normalization in RS_InsertData cannot mask a bad write.
+ */
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <string>
+
+#include <QCoreApplication>
+
+#include "rs_block.h"
+#include "rs_filterdxfrw.h"
+#include "rs_graphic.h"
+#include "rs_insert.h"
+#include "rs_line.h"
+#include "rs_settings.h"
+#include "rs_vector.h"
+
+namespace {
+
+void ensureApp() {
+    static int argc = 1;
+    static char arg0[] = "librecad_tests";
+    static char *argv[] = {arg0, nullptr};
+    static QCoreApplication *app = QCoreApplication::instance()
+                                       ? QCoreApplication::instance()
+                                       : new QCoreApplication(argc, argv);
+    static bool ready = [] {
+        QCoreApplication::setOrganizationName("LibreCAD");
+        QCoreApplication::setApplicationName("LibreCAD-tests");
+        RS_Settings::init("LibreCAD", "LibreCAD-tests");
+        return true;
+    }();
+    (void)app;
+    (void)ready;
+}
+
+/// The 41/42/43 scale factors of the first INSERT in an ASCII DXF.
+struct FileScale {
+    bool found = false;
+    double x = 0.0;
+    double y = 0.0;
+    double z = 0.0;
+};
+
+FileScale readFirstInsertScale(const std::string &path) {
+    std::ifstream file(path);
+    FileScale scale;
+    std::string code;
+    std::string value;
+    bool inInsert = false;
+    while (std::getline(file, code) && std::getline(file, value)) {
+        const int group = std::stoi(code);
+        if (group == 0) {
+            if (inInsert) {
+                break; // end of the INSERT record
+            }
+            inInsert = value.find("INSERT") != std::string::npos;
+            continue;
+        }
+        if (!inInsert) {
+            continue;
+        }
+        switch (group) {
+        case 41: scale.x = std::stod(value); scale.found = true; break;
+        case 42: scale.y = std::stod(value); break;
+        case 43: scale.z = std::stod(value); break;
+        default: break;
+        }
+    }
+    return scale;
+}
+
+/// Exports a graphic holding one block and one insert, and returns the scale
+/// that landed in the file.
+FileScale exportInsertScale(const RS_Vector &scale, const char *name) {
+    const std::string path =
+        (std::filesystem::temp_directory_path() /
+         (std::string("insert_zscale_") + name + ".dxf")).string();
+    std::filesystem::remove(path);
+
+    RS_Graphic graphic;
+    graphic.initForNewDocument();
+    auto *block = new RS_Block(
+        &graphic, RS_BlockData(QStringLiteral("BASE"), RS_Vector(0.0, 0.0), false));
+    block->addEntity(
+        new RS_Line(block, RS_LineData(RS_Vector(0.0, 0.0), RS_Vector(10.0, 0.0))));
+    graphic.addBlock(block);
+    graphic.addEntity(new RS_Insert(
+        &graphic, RS_InsertData(QStringLiteral("BASE"), RS_Vector(1.0, 2.0), scale,
+                                0.0, 1, 1, RS_Vector(0.0, 0.0))));
+
+    RS_FilterDXFRW filter;
+    REQUIRE(filter.fileExport(graphic, QString::fromStdString(path),
+                              RS2::FormatDXFRW));
+    const FileScale result = readFirstInsertScale(path);
+    std::filesystem::remove(path);
+    return result;
+}
+
+} // namespace
+
+TEST_CASE("A degenerate Z scale never survives", "[insert][zscale]") {
+    // Only values that leave the block transform singular or meaningless are
+    // repaired: exact zero (either sign), NaN and infinity. A plain "!= 0.0"
+    // would pass the last three straight through to the file.
+    CHECK(RS_InsertData::usableScale(0.0) == Catch::Approx(1.0));
+    CHECK(RS_InsertData::usableScale(-0.0) == Catch::Approx(1.0));
+    CHECK(RS_InsertData::usableScale(
+              std::numeric_limits<double>::quiet_NaN()) == Catch::Approx(1.0));
+    CHECK(RS_InsertData::usableScale(
+              std::numeric_limits<double>::infinity()) == Catch::Approx(1.0));
+    CHECK(RS_InsertData::usableScale(
+              -std::numeric_limits<double>::infinity()) == Catch::Approx(1.0));
+
+    // Everything else is data, mirrors and tiny factors included. Every
+    // consumer surveyed (ezdxf, ACadSharp, netDxf, and LibreCAD's own
+    // LC_InsertTransform::fromInsert) rejects only an exact zero, so
+    // rewriting a small nonzero factor would resize valid geometry.
+    CHECK(RS_InsertData::usableScale(4.0) == Catch::Approx(4.0));
+    CHECK(RS_InsertData::usableScale(-1.0) == Catch::Approx(-1.0));
+    CHECK(RS_InsertData::usableScale(1.0e-13) == 1.0e-13);
+    CHECK(RS_InsertData::usableScale(1.0e-300) == 1.0e-300);
+}
+
+TEST_CASE("A degenerate X or Y scale never survives either", "[insert][zscale]") {
+    // Any zero component makes the block transform singular, so all three are
+    // held to the same rule: netDxf rejects the entity with "None of the
+    // vector scale components can be zero", ACadSharp throws on each setter.
+    const RS_Vector repaired =
+        RS_InsertData::usableScale(RS_Vector(0.0, 1.0e-13, 0.0));
+    CHECK(repaired.x == Catch::Approx(1.0));
+    CHECK(repaired.y == 1.0e-13); // tiny but nonzero: data, not a defect
+    CHECK(repaired.z == Catch::Approx(1.0));
+
+    const RS_Vector kept = RS_InsertData::usableScale(RS_Vector(2.0, -3.0, 4.0));
+    CHECK(kept.x == Catch::Approx(2.0));
+    CHECK(kept.y == Catch::Approx(-3.0)); // a mirror, not a defect
+    CHECK(kept.z == Catch::Approx(4.0));
+}
+
+TEST_CASE("RS_InsertData keeps the Z scale non-zero", "[insert][zscale]") {
+    // How every 2D call site builds it: the third component defaults to 0.
+    const RS_InsertData twoDim(QStringLiteral("BASE"), RS_Vector(1.0, 2.0),
+                               RS_Vector(1.0, 1.0), 0.0, 1, 1, RS_Vector(0.0, 0.0));
+    CHECK(twoDim.scaleFactor.z == Catch::Approx(1.0));
+
+    // An explicit Z scale is data, not a default, and must survive untouched.
+    const RS_InsertData threeDim(QStringLiteral("BASE"), RS_Vector(1.0, 2.0),
+                                 RS_Vector(2.0, 3.0, 4.0), 0.0, 1, 1,
+                                 RS_Vector(0.0, 0.0));
+    CHECK(threeDim.scaleFactor.z == Catch::Approx(4.0));
+}
+
+TEST_CASE("DXF export never writes a zero Z scale on INSERT", "[insert][zscale]") {
+    ensureApp();
+
+    const FileScale twoDim = exportInsertScale(RS_Vector(1.0, 1.0), "twodim");
+    REQUIRE(twoDim.found);
+    CHECK(twoDim.x == Catch::Approx(1.0));
+    CHECK(twoDim.y == Catch::Approx(1.0));
+    CHECK(twoDim.z == Catch::Approx(1.0)); // the regression: used to be 0
+
+    const FileScale explicitZ =
+        exportInsertScale(RS_Vector(2.0, 3.0, 4.0), "explicit");
+    REQUIRE(explicitZ.found);
+    CHECK(explicitZ.x == Catch::Approx(2.0));
+    CHECK(explicitZ.y == Catch::Approx(3.0));
+    CHECK(explicitZ.z == Catch::Approx(4.0));
+
+    // A malformed import cannot carry a degenerate X or Y back out either.
+    const FileScale degenerate =
+        exportInsertScale(RS_Vector(0.0, 0.0, 0.0), "degenerate");
+    REQUIRE(degenerate.found);
+    CHECK(degenerate.x == Catch::Approx(1.0));
+    CHECK(degenerate.y == Catch::Approx(1.0));
+    CHECK(degenerate.z == Catch::Approx(1.0));
+}

--- a/librecad/src/lib/filters/tests/insert_zscale_tests.cpp
+++ b/librecad/src/lib/filters/tests/insert_zscale_tests.cpp
@@ -167,6 +167,11 @@ TEST_CASE("A degenerate X or Y scale never survives either", "[insert][zscale]")
     CHECK(kept.x == Catch::Approx(2.0));
     CHECK(kept.y == Catch::Approx(-3.0)); // a mirror, not a defect
     CHECK(kept.z == Catch::Approx(4.0));
+
+    // The repair is per-component; it must not manufacture a valid vector
+    // out of one that was explicitly marked invalid.
+    CHECK_FALSE(RS_InsertData::usableScale(RS_Vector(false)).valid);
+    CHECK(RS_InsertData::usableScale(RS_Vector(1.0, 1.0)).valid);
 }
 
 TEST_CASE("RS_InsertData keeps the Z scale non-zero", "[insert][zscale]") {

--- a/librecad/src/main/doc_plugin_interface.cpp
+++ b/librecad/src/main/doc_plugin_interface.cpp
@@ -329,6 +329,7 @@ void Plugin_Entity::getData(QHash<int, QVariant>* data) {
             data->insert(DPI::STARTANGLE, d.angle);
             data->insert(DPI::XSCALE, d.scaleFactor.x);
             data->insert(DPI::YSCALE, d.scaleFactor.y);
+            data->insert(DPI::ZSCALE, d.scaleFactor.z);
             break;
         }
         case RS2::EntityMText: {

--- a/librecad/src/ui/dialogs/entity/lc_entitypropertieseditorsupport.cpp
+++ b/librecad/src/ui/dialogs/entity/lc_entitypropertieseditorsupport.cpp
@@ -165,7 +165,10 @@ RS_Vector LC_EntityPropertiesEditorSupport::toWCS(const QLineEdit* leX, const QL
 }
 
 RS_Vector LC_EntityPropertiesEditorSupport::toWCSRaw(const QLineEdit* leX, const QLineEdit* leY, const RS_Vector& defs) const{
-    return RS_Vector(toDouble(leX->text(), 0, defs.x), toDouble(leY->text(), 0, defs.y));
+    // The two line edits cover x and y only; keep the z of the value being
+    // edited instead of resetting it to 0. An insert with an explicit z scale
+    // used to lose it whenever the scale was touched in the properties panel.
+    return RS_Vector(toDouble(leX->text(), 0, defs.x), toDouble(leY->text(), 0, defs.y), defs.z);
 }
 
 double LC_EntityPropertiesEditorSupport::toWCSValue(const QLineEdit* ed, const double wcsDefault) const {


### PR DESCRIPTION
Fixes #1428 and #971 (the same defect, reported in 2018). Supersedes #1429, which diagnosed this and fixed the individual call sites.

## The bug

LibreCAD is 2D, so inserts get their scale from a two component `RS_Vector` — and `RS_Vector(double, double, double z = 0.0)` leaves **z = 0**. That zero reached the file unchanged:

```cpp
in.zscale = i->getScale().z;      // rs_filterdxfrw.cpp, writeInsert()
```

Still reproducible on `master`, and it arrives by two separate routes:

- **Through the constructor** — `lc_copyutils.cpp:360` passes `RS_Vector(1.0, 1.0)`, `lc_dimarrowregistry.cpp:188` passes `RS_Vector(arrowSize, arrowSize)`. The latter file postdates #1429, which is rather the point: enumerating call sites does not hold.
- **Around the constructor** — `LC_ActionBlockInsert::setFactor()` assigns the field directly:

  ```cpp
  void LC_ActionBlockInsert::setFactor(const double f) const {
      m_data->scaleFactor = RS_Vector(f, f);   // z = 0
  }
  ```

  That is the scale spinbox in the block-insert options widget, so any user who types a scale reaches it.

## Is a zero Z scale actually invalid?

@egilkv asked this on #1428 and it was never answered, so here is the evidence.

**Neither specification forbids it — both are simply silent.** The Autodesk DXF reference (2012, INSERT, p. 97–98) says only:

```
41   X scale factor (optional; default = 1)
42   Y scale factor (optional; default = 1)
43   Z scale factor (optional; default = 1)
```

Searching the full reference, and the ODA *Open Design Specification for .dwg files* v5.4.1, for any nonzero constraint on scale returns nothing.

**But everything else says it is malformed:**

- **It is degenerate.** A block reference's transform is scale·rotate·translate; with z = 0 the matrix is singular (determinant 0) and cannot be inverted — so any consumer that maps a point into block space, explodes, or hit-tests divides by zero.
- **Every format generation defaults it to 1.** DXF as above; DWG R13–R14 stores three `BD`s; DWG R2000+ uses 2-bit data flags whose four cases *all* default to 1.0 or to the X scale (`11` = "(1,1,1), no data stored"); even pre-R13 DWG made it optional-with-default-1. Zero has never been the intended value anywhere in the lineage.
- **Other libraries reject it.** netDxf throws *"None of the vector scale components can be zero."*; ACadSharp throws *"ZScale value must be none zero."* — and since its DXF reader assigns through that property, a LibreCAD file by default **loses the block reference** (its `Failsafe` mode logs and continues, doc-comment: *"The result file may be incomplete or with some objects missing"*), or fails the load outright in strict mode. ezdxf declares all three scales `validator=is_not_zero, fixer=RETURN_DEFAULT` and silently rewrites a zero to 1.
- **Real applications break.** FreeCAD refuses the drawing (#1428, [FreeCAD tracker 4791](https://tracker.freecadweb.org/view.php?id=4791)); LaserCut 5.3 errors *"x, y, z scale not equal"* (#971).
- **No AutoCAD-authored file does this.** Scanning every DXF I have: the ezdxf, LibreDWG and ACadSharp corpora contain **404 INSERTs across AC2.10 → AC1032, including genuine AutoCAD/ODA-saved drawings — zero of them carry a zero Z scale**. The only files that do (319 INSERTs) have no `$LASTSAVEDBY`, which LibreCAD does not write, and carry the literal `41 1 / 42 1 / 43 0` signature that the community workaround for this bug tells people to search and replace.

So: permitted by omission, invalid by every operative standard.

## The fix

One predicate, in one place, describing what a usable scale factor is:

```cpp
double RS_InsertData::usableScale(const double factor) {
    return std::isfinite(factor) && factor != 0.0 ? factor : 1.0;
}
```

The repair is deliberately **minimum intervention** — only values that leave the transform singular or meaningless are touched, and everything else is data:

- **Exact zero, either sign.** `factor != 0.0` is false for `-0.0` as well, so a negative zero repairs too. Every consumer surveyed draws its line at exactly zero: LibreCAD's own `LC_InsertTransform::fromInsert()` refuses `sx == 0.0`, ACadSharp throws on `value.Equals(0)`, netDxf likewise. A tolerance here would go *further than any consumer requires* and rewrite tiny-but-legal factors — a file authored elsewhere with a `1e-11` scale would import ten orders of magnitude larger. Tiny nonzero factors pass through.
- **NaN and ±infinity.** A plain `!= 0.0` passes these straight into the file — a real concern on the import path, where the scale is 8 raw bytes out of a DWG. Guarding entity input with `std::isfinite` is already the pattern in this file (`RS_Insert::rotate`).

**It is applied to all three axes, where inserts are born** — `RS_InsertData`'s constructor. One place, every present and future call site, and no caller has to remember the third component. A zero X or Y is exactly as degenerate as a zero Z: LibreCAD's own `LC_InsertTransform::fromInsert()` already refuses to build a transform from one, so such an insert does not render today and was still written to file.

**And at the boundary in `writeInsert()`**, for inserts that never went through that constructor: default constructed data, the direct field assignment in `setFactor()` above, or a file that already carried a bad value. This also covers **DWG**, since both writers share the path.

**It also replaces a third copy of the rule.** `LC_MLeader::blockContentData()` had already hand-rolled the same repair, with the same weak comparison, for two of the three axes:

```cpp
// A zero scale component would collapse the block; default such axes to 1.
const RS_Vector scale(m_data.blockScale.x != 0.0 ? m_data.blockScale.x : 1.0,
                      m_data.blockScale.y != 0.0 ? m_data.blockScale.y : 1.0);
```

That value is parsed from a file's MLEADER context, so NaN and infinity are reachable there. It now goes through the constructor like everything else, which also stops the two component rebuild from discarding the context's Z.

The import side needs nothing more: `DRW_Insert` defaults `zscale` to 1 and code 43 only overwrites it when present, so a 2D DXF without a z scale already reads back as 1.

**Plus one real gap:** `getData()` published `XSCALE` and `YSCALE` but never `ZSCALE`, even though `DPI::ZSCALE` has always existed. Plugins can now read it.

### A bonus in DWG output

`DRW_Insert::encodeDwg()` picks the scale encoding from the values themselves:

```cpp
if (xscale == 1.0 && yscale == 1.0 && zscale == 1.0) {
    buf->put2Bits(3);                       // no scale data at all
} else if (xscale == yscale && yscale == zscale) {
    ...
```

Before this change an ordinary 2D insert failed that test on `z` alone and fell through to the general case — data flag `0`, then a raw double for x and a *BitDouble With Default* for each of y and z. Per block reference: **24.75 bytes before, 0.25 bytes after**.

The zero is also the worst possible value for that fallback. A DD encodes a value as a patch over the default, but its opcodes overwrite only the low 4 or 6 bytes — and `1.0` and `0.0` differ in exactly the *top* two:

```
1.0 LE bytes: 00 00 00 00 00 00 f0 3f
0.0 LE bytes: 00 00 00 00 00 00 00 00
```

so no patch opcode can express it and a conforming writer must fall back to the full 8-byte form. LibreCAD was hitting the single most expensive path in an encoding designed to make the canonical case free. (libdxfrw's own `putDefaultDouble` currently always emits the full form regardless, so today the win is the data-flag `3` shortcut above.)

## Why not the #1429 approach

That PR patched ten files to add the missing third component at each site. Besides having drifted (every file it touches has since moved), the approach is inherently leaky — `lc_dimarrowregistry.cpp` was written afterwards and reintroduced the same pattern. It also carried a defect: `data->insert(1.0, d.scaleFactor.z)` uses `1.0` as the `QHash` key, which truncates to key **1 = `DPI::TEXTCONTENT`**, documented as a `QString`, so plugins asking for text content would have received a double. This PR uses `DPI::ZSCALE`.

## Tests

`insert_zscale_tests.cpp` covers the predicate directly and then asserts **what actually lands in the file** — group code 43 is read back out of the exported DXF text, not out of the `RS_Insert`, so the normalization in `RS_InsertData` cannot mask a bad write:

- `usableScale()` maps `0.0`, `-0.0`, `NaN`, `+inf` and `-inf` to 1, and passes `4.0`, `-1.0`, `1e-13` and `1e-300` through untouched;
- the vector form holds X and Y to the same rule, and keeps a `-3.0` mirror;
- a two component scale exports `43` as 1, never 0;
- an explicit `(2, 3, 4)` scale round-trips unchanged;
- a fully degenerate `(0, 0, 0)` scale exports as `(1, 1, 1)`.

Every one of these fails on the code it replaces. Against plain `!= 0.0`:

```
CHECK( usableScale(1.0e-300) == Approx(1.0) )   with expansion:  0.0 == Approx( 1.0 )
CHECK( usableScale(1.0e-13)  == Approx(1.0) )   with expansion:  1e-13 == Approx( 1.0 )
CHECK( usableScale(NaN)      == Approx(1.0) )   with expansion:  nan == Approx( 1.0 )
CHECK( usableScale(inf)      == Approx(1.0) )   with expansion:  inf == Approx( 1.0 )
```

and against no fix at all, `0.0 == Approx( 1.0 )` on both the in-memory value and the byte in the file.

Full suite: **13341 assertions in 777 test cases, passing**, including `dwg_write_smoke_tests` and `block_insert_wipeout_tests`, which assert real `scaleFactor.z` values (4.0, 6.0) through scale and mirror transforms — so the invariant demonstrably does not clobber legitimate factors.

## Third commit: usableScale silently discarded RS_Vector::valid

`usableScale(const RS_Vector&)` rebuilt its result through the 3-double constructor, which always sets `valid=true`. `LC_InsertTransform::fromInsert()` relies on that flag to refuse rendering malformed data — no current call site passes an invalid scale into `RS_InsertData`, but the function should not silently launder one into `(1,1,1)` if a future caller ever does. It now preserves `scale.valid` while still repairing the doubles. Also trimmed the `usableScale(double)` doc comment, which repeated the code's "what" beside the code itself.

## Second commit: the properties panel dropped an explicit Z

Found while reviewing the mutation paths this PR guards against. `LC_EntityPropertiesEditorSupport::toWCSRaw()` takes the value being edited precisely to supply defaults for what its two line edits cannot express — then dropped its z:

```cpp
return RS_Vector(toDouble(leX->text(), 0, defs.x), toDouble(leY->text(), 0, defs.y));
```

Editing an insert's scale in the properties panel reset an explicit z scale to 0 in memory; the export guard could then only turn that into 1, not restore the original. `defs.z` now passes through. (The property sheet path was already correct — it copies the vector and sets one axis — and the `LC_EntityPropertiesDlg` duplicate of this helper has no callers.)

## Noticed while researching, not addressed here

`librecad/src/lib/filters/rs_filterdxf.cpp` — the legacy dxflib-based filter that #1429 also patched — looks like dead code: it is in neither the CMake nor the qmake build, and nothing constructs `RS_FilterDXF` (the remaining references are to unrelated static helpers). Worth deleting separately.
