### PR TITLE
Compare INSERT scales by representation, not by ==

### DIFF
--- a/libraries/libdxfrw/src/drw_entities.cpp
+++ b/libraries/libdxfrw/src/drw_entities.cpp
@@ -130,6 +130,18 @@ bool differsFromUnitWeight(double weight) {
     return std::fabs(weight - 1.0) > 1e-12;
 }
 
+//! \brief Compare two doubles by stored representation.
+//! For values a compact DWG form restores verbatim, the match has to be exact:
+//! dataFlags 3 makes the reader return exactly 1.0 and dataFlags 2 makes it
+//! return xscale for y and z (see DRW_Insert::parseDwg), so picking those forms
+//! on a tolerant match would silently round the scale that gets written. This
+//! asks the question that is actually meant - "will the reader reconstruct this
+//! value?" - without floating point comparison semantics, and as a side effect
+//! keeps -0.0 distinct from 0.0, which `==` does not.
+bool sameStoredDouble(double a, double b) {
+    return std::memcmp(&a, &b, sizeof a) == 0;
+}
+
 void putHardPointerHandle(dwgBufferW *buf, std::uint32_t ref) {
     dwgHandle h;
     h.code = 5;
@@ -2303,11 +2315,20 @@ bool DRW_Insert::encodeDwg(DRW::Version version, dwgBufferW *buf, std::uint32_t 
     //   2 → uniform scale (xscale RD only; yscale=zscale=xscale)
     //   1 → xscale defaults to 1, yscale/zscale as DD against xscale
     //   0 → xscale RD; yscale/zscale as DD against xscale
-    if (xscale == 1.0 && yscale == 1.0 && zscale == 1.0) {
+    if (sameStoredDouble(xscale, 1.0) && sameStoredDouble(yscale, 1.0)
+        && sameStoredDouble(zscale, 1.0)) {
         buf->put2Bits(3);
-    } else if (xscale == yscale && yscale == zscale) {
+    } else if (sameStoredDouble(xscale, yscale) && sameStoredDouble(yscale, zscale)) {
         buf->put2Bits(2);
         buf->putRawDouble(xscale);
+    } else if (sameStoredDouble(xscale, 1.0)) {
+        // xscale is exactly 1.0 (parseDwg leaves it at its 1.0 default and
+        // never reads it in this branch), so it can be omitted; y and z are
+        // independent and go through the same DD-against-1.0 path parseDwg
+        // reads them with.
+        buf->put2Bits(1);
+        buf->putDefaultDouble(1.0, yscale);
+        buf->putDefaultDouble(1.0, zscale);
     } else {
         // Use dataFlags=0 (general case): RD x + DD y + DD z.
         buf->put2Bits(0);

--- a/librecad/src/lib/filters/tests/dwg_entity_encode_round_trip_tests.cpp
+++ b/librecad/src/lib/filters/tests/dwg_entity_encode_round_trip_tests.cpp
@@ -1916,3 +1916,93 @@ TEST_CASE("DRW_PointCloud::encodeDwg refuses stub body",
     dwgBufferW w;
     CHECK_FALSE(DrwEntityEncodeTestAccess::encode(pc, DRW::AC1024, &w));
 }
+
+// The compact scale forms (dataFlags 3 and 2) are lossless substitutions: the
+// reader restores exactly 1.0, or exactly xscale for y and z.  Selecting them
+// on a tolerant comparison would silently round the scale that is written, so
+// these two cases pin the encoder to a bit-exact match.
+TEST_CASE("DRW_Insert::encodeDwg takes the compact scale form only when exact",
+          "[dwg-write][entity-encode][insert-scale]") {
+    auto roundTrip = [](double sx, double sy, double sz, std::size_t& size) {
+        DRW_Insert src;
+        src.handle = 0x41;
+        src.color = 7;
+        src.ltypeScale = 1.0;
+        src.name = "BASE";
+        src.basePoint = DRW_Coord{1.0, 2.0, 0.0};
+        src.xscale = sx;
+        src.yscale = sy;
+        src.zscale = sz;
+        src.angle = 0.0;
+        src.extPoint = DRW_Coord{0.0, 0.0, 1.0};
+        DrwEntityEncodeTestAccess::layerH(src).ref = 0x12;
+
+        dwgBufferW w;
+        REQUIRE(DrwEntityEncodeTestAccess::encode(src, DRW::AC1015, &w));
+        auto bytes = snapshot(w);
+        size = bytes.size();
+
+        dwgBuffer r(bytes.data(), bytes.size());
+        DRW_Insert dst;
+        REQUIRE(DrwEntityEncodeTestAccess::parse(dst, DRW::AC1015, &r));
+        return dst;
+    };
+
+    std::size_t unitSize = 0;
+    const DRW_Insert unit = roundTrip(1.0, 1.0, 1.0, unitSize);
+    CHECK(unit.xscale == 1.0);
+    CHECK(unit.yscale == 1.0);
+    CHECK(unit.zscale == 1.0);
+
+    // One ULP above 1.0 is not 1.0, and must survive as itself.
+    const double justOver = std::nextafter(1.0, 2.0);
+    REQUIRE(justOver != 1.0);
+    std::size_t nearSize = 0;
+    const DRW_Insert near = roundTrip(justOver, 1.0, 1.0, nearSize);
+    CHECK(near.xscale == justOver);   // not collapsed to 1.0
+    CHECK(near.yscale == 1.0);
+    CHECK(near.zscale == 1.0);
+
+    // And the exact case really is the cheaper encoding, so the shortcut works.
+    CHECK(unitSize < nearSize);
+
+    // The uniform-scale form (dataFlags 2) needs the same exactness: x matches
+    // y bit-exact, but z is one ULP off, so this must NOT take the compact
+    // path - that would restore z as x's value instead of its own.
+    const double zJustOver = std::nextafter(2.0, 3.0);
+    REQUIRE(zJustOver != 2.0);
+    std::size_t uniformSize = 0;
+    const DRW_Insert notQuiteUniform = roundTrip(2.0, 2.0, zJustOver, uniformSize);
+    CHECK(notQuiteUniform.xscale == 2.0);
+    CHECK(notQuiteUniform.yscale == 2.0);
+    CHECK(notQuiteUniform.zscale == zJustOver);   // not collapsed onto x/y
+
+    // A genuinely uniform scale still gets the compact form (smaller than
+    // the near-uniform case above, which falls through to the general form).
+    std::size_t trueUniformSize = 0;
+    const DRW_Insert trueUniform = roundTrip(2.0, 2.0, 2.0, trueUniformSize);
+    CHECK(trueUniform.xscale == 2.0);
+    CHECK(trueUniform.yscale == 2.0);
+    CHECK(trueUniform.zscale == 2.0);
+    CHECK(trueUniformSize < uniformSize);
+
+    // dataFlags 1 (x defaults to 1, y/z independent) needs the same
+    // exactness for x: parseDwg only omits reading x, and leaves it at its
+    // constructed default, when dataFlags says so - so encodeDwg may only
+    // take that form when x really is 1.0, bit for bit.
+    std::size_t xDefaultSize = 0;
+    const DRW_Insert xDefault = roundTrip(1.0, 3.0, 4.0, xDefaultSize);
+    CHECK(xDefault.xscale == 1.0);
+    CHECK(xDefault.yscale == 3.0);
+    CHECK(xDefault.zscale == 4.0);
+
+    // General form has to write x explicitly, so the dataFlags-1 shortcut
+    // must be smaller for the same y/z.
+    std::size_t xNotDefaultSize = 0;
+    const DRW_Insert xNotDefault =
+        roundTrip(std::nextafter(1.0, 2.0), 3.0, 4.0, xNotDefaultSize);
+    CHECK(xNotDefault.xscale == std::nextafter(1.0, 2.0)); // not collapsed to 1.0
+    CHECK(xNotDefault.yscale == 3.0);
+    CHECK(xNotDefault.zscale == 4.0);
+    CHECK(xDefaultSize < xNotDefaultSize);
+}


### PR DESCRIPTION
`DRW_Insert::encodeDwg()` chose the compact DWG scale encodings with bare floating point equality:

```cpp
if (xscale == 1.0 && yscale == 1.0 && zscale == 1.0) {
    buf->put2Bits(3);                       // no scale data at all
} else if (xscale == yscale && yscale == zscale) {
```

## The comparison must be exact — and nothing said so

That is the real problem here. Both compact forms are *lossless substitutions*, and the reader is what defines them:

```cpp
if (dataFlags == 3){
    //none default value 1,1,1              // restores exactly 1.0
} else if (dataFlags == 2){
    xscale = buf->getRawDouble();
    yscale = zscale = xscale;               // restores exactly xscale
}
```

So the encoder may only take those branches when the reader will hand back the identical value. Relax the test to a tolerance and the writer silently rounds the scale it stores.

Left as a bare `==`, that requirement is invisible — and the obvious "don't compare floats with `==`" cleanup is a data-corrupting change. Verified by making the helper tolerant (`std::fabs(a - b) < 1e-12`) and rebuilding:

```
CHECK( near.xscale == justOver )
with expansion:  1.0 == 1.00000000000000022
```

A scale one ULP above 1.0 was written to the DWG as 1.0.

## The change

Both tests now go through a named helper, next to the existing `differsFromUnitWeight` in the same anonymous namespace:

```cpp
bool sameStoredDouble(double a, double b) {
    return std::memcmp(&a, &b, sizeof a) == 0;
}
```

It asks the question actually meant — *will the reader reconstruct this value?* — rather than performing a floating point comparison, and the comment records why exactness is required so the next reader does not "fix" it. As a side effect it keeps `-0.0` distinct from `0.0`, which `==` does not, so a uniform scale of `-0.0` no longer collapses onto a stored `0.0`.

Behaviour is unchanged for every value that is not a negative zero: this is the same decision, expressed so its constraint is legible.

## While reviewing: a third, dead branch

The encoder's own comment documents four `dataFlags` forms:

```cpp
//   3 → all scales default to 1.0 (no emit)
//   2 → uniform scale (xscale RD only; yscale=zscale=xscale)
//   1 → xscale defaults to 1, yscale/zscale as DD against xscale
//   0 → xscale RD; yscale/zscale as DD against xscale
```

but the `if`/`else if`/`else` chain only ever emitted 3, 2, or 0 - form 1 existed solely on the reader side (`parseDwg`'s own `dataFlags == 1` branch), presumably kept for interop with other DWG writers that do use it. An insert with `xscale == 1.0` exactly but a non-uniform `yscale`/`zscale` - a block scaled in Y only, say - always fell to the general form, writing `xscale` explicitly even though it never needed to be.

Implemented it, following the same exactness discipline as the other two:

```cpp
} else if (sameStoredDouble(xscale, 1.0)) {
    buf->put2Bits(1);
    buf->putDefaultDouble(1.0, yscale);
    buf->putDefaultDouble(1.0, zscale);
}
```

placed after the uniform-scale check (so it can't shadow it - the two conditions only ever overlap when all three scales are already 1.0, which the first branch has already claimed) and before the general fallback. Saves the 8-byte raw `xscale` write whenever x is exactly 1.0 and the scale isn't uniform.

## Test

The encoder makes three comparisons now, and the first version of this PR only pinned one of them. `DRW_Insert::encodeDwg takes the compact scale form only when exact` now covers both:

- **the all-ones form (dataFlags 3):** a scale of `std::nextafter(1.0, 2.0)` survives as itself instead of collapsing to 1.0, and the true all-ones case still produces the smaller encoding.
- **the uniform-scale form (dataFlags 2):** X and Y bit-exact at `2.0`, Z one ULP off (`std::nextafter(2.0, 3.0)`) - Z must survive as itself, not collapse onto X/Y. A genuinely uniform `(2.0, 2.0, 2.0)` still takes the smaller encoding.

The second case exists because the first test case can't distinguish "the comparison is exact" from "the comparison exists at all" for the uniform branch - `justOver` differs from *both* Y and Z at once, so even a mutation that silently dropped the Z half of `sameStoredDouble(xscale, yscale) && sameStoredDouble(yscale, zscale)` (leaving only the X/Y check) passed the original test and the entire rest of the suite. Verified by making that exact mutation: the new test fails with `2.0 == 2.00000000000000044` (Z silently collapsed onto X/Y) and `34 < 34` (the near-miss wrongly took the cheaper encoding). Reverting the mutation restores both to green.

- **the x-defaults-to-1 form (dataFlags 1):** `x = 1.0` exactly, `y = 3.0`, `z = 4.0` - takes the new branch and produces a smaller encoding than the same values with `x` one ULP off `1.0` (which correctly falls through to the general form instead of dropping x). Verified the same way: an unconditional `else if (true)` in place of the exactness check breaks this assertion along with the ones the all-ones check already guards, and an `else if (sameStoredDouble(xscale, xscale))`-style always-true mistake would too.

## Verification

Built locally on both build systems, from a clean configure at `adb94b095`:

- **CMake** — 0 errors; `LibreCAD.app` and `librecad_tests` link.
- **qmake** — 0 errors; `drw_entities.cpp` recompiled, app relinked.

Tests: `[insert-scale]` 35 assertions, `[entity-encode]` 922 assertions / 55 cases, `[dwg-write]` 2348 assertions / 119 cases — all passing. (The one test case carries all three tags, so its own 35 assertions count once under each.)
