### PR TITLE
Restore left margin in the Command Line dock widget

### DIFF
--- a/librecad/src/ui/dock_widgets/command_line/qg_commandwidget.ui
+++ b/librecad/src/ui/dock_widgets/command_line/qg_commandwidget.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout" rowstretch="10,0,0">
    <property name="leftMargin">
-    <number>0</number>
+    <number>2</number>
    </property>
    <property name="topMargin">
     <number>1</number>


### PR DESCRIPTION
Closes #2762.

## What

The Command Line dock widget's "Enter Command:" label and its input field were sitting flush against the widget's left edge, along with the command history/log pane above them - no left inset at all.

## Root cause

All three (log pane, label, input row) share one `QGridLayout` in `qg_commandwidget.ui`, and that layout has a single `leftMargin` property governing all of them. Commit `5f29d9b80` (#2540, a large batch of dock-widget spacing tweaks) zeroed that margin out. Before that commit it was `2`; the other three margins on the same layout (top/right/bottom) were untouched by that change and are still non-zero today.

## Fix

Restores `leftMargin` from `0` back to `2`, undoing just that one property. One-line diff.

## Verification

Built and ran the app locally (`cmake`/`ninja`, `librecad` target) - builds clean. I wasn't able to capture a pixel screenshot of the running dock widget in this environment (no Screen Recording/Accessibility permission available to the sandbox), so I'm relying on the fact that this is a single, well-understood Qt Designer layout property being reverted to its exact pre-regression value, not a new/untested mechanism - `QGridLayout::leftMargin` behavior is deterministic and this restores it to what every user saw before #2540 landed.
