### PR TITLE
Fix SIGSEGV from dangling modification listener on print preview close

### DIFF
--- a/librecad/src/ui/main/qc_mdiwindow.cpp
+++ b/librecad/src/ui/main/qc_mdiwindow.cpp
@@ -94,9 +94,19 @@ QC_MDIWindow::QC_MDIWindow(RS_Document* doc, QWidget* parent, const bool printPr
  */
 QC_MDIWindow::~QC_MDIWindow() {
     try {
+        // Always unregister as a modification listener, regardless of
+        // isCleanUp(): RS_GraphicView::beginClose() sets that flag
+        // unconditionally on every window close (not just full application
+        // shutdown, which is what the guard below is actually meant to
+        // detect), so gating this on it left a dangling QC_MDIWindow*
+        // in RS_Document::m_modificationListeners on every normal close.
+        // For a print-preview window - which shares its parent's document -
+        // the very next print-preview open then walks that list and derefs
+        // the freed pointer. See issue #2764.
+        removeWidgetsListeners();
+
         if (!(m_graphicView != nullptr && m_graphicView->isCleanUp())) {
             //do not clear layer/block lists, if application is being closed
-            removeWidgetsListeners();
             if (m_owner) {
                 delete m_document;
             }


### PR DESCRIPTION
Closes #2764.

## What

Repeatedly opening and closing print preview crashed the application (reported: 3 clicks on the toolbar toggle icon).

## Root cause

`~QC_MDIWindow()` only called `removeWidgetsListeners()` - which unregisters the window from `RS_Document::m_modificationListeners` - when `!isCleanUp()`. `RS_GraphicView::beginClose()` sets that flag unconditionally on every window close, not just full application shutdown (which the guard was actually meant to detect), so the unregister step was being skipped on every single close.

A print-preview `QC_MDIWindow` shares its parent document rather than owning its own, so the leaked listener registration survives the print-preview window's own destruction. The very next print-preview open re-triggers `RS_Graphic::setModified()` as part of its own initialization (`openPrintPreview` -> `postCreateInit` -> `doLoadOptions` -> `fit` -> `fitToPage` -> `setPaperScale`), which walks `m_modificationListeners` and dereferences the now-freed `QC_MDIWindow*` - a use-after-free that crashes with SIGSEGV.

## Fix

Makes `removeWidgetsListeners()` run unconditionally in the destructor, no longer gated on `isCleanUp()`. The call is cheap (a single `QList::removeAll()`) and safe in every close scenario, including real application shutdown - print-preview windows are always closed before their parent (and its document) in `doClose()`, and owning windows delete their own document immediately afterward in the same destructor. One-line functional change (plus a comment explaining why).

## Verification

The reporter attached a real crash log from their build, which pointed straight at this:

```
RS_Graphic::fireGraphicModified  <- SIGSEGV, fault address 0x10
RS_Graphic::setModified
LC_PlotSettings::setPaperScale
RS_Graphic::fitToPage
RS_ActionPrintPreview::fit
RS_ActionPrintPreview::doLoadOptions
LC_ActionOptionsBase::loadOptions
RS_ActionInterface::postCreateInit
QC_ApplicationWindow::openPrintPreview
QC_ApplicationWindow::slotFilePrintPreview
... (QAction/QToolButton click dispatch)
```

I reproduced the exact crash locally with a debug build: open print preview, close it, force the `Qt::WA_DeleteOnClose`-scheduled deletion to actually complete (rather than just leaving it queued), then reopen - reliably crashed before this change, clean after it.

I also checked the two closest-looking prior fix candidates in this area (an unguarded window-activation `qobject_cast`, and an unrelated leaked-MDI-window/duplicate-layer-listener issue) and confirmed both were already fixed before the exact commit the original report was built from - they're unrelated to this bug.

Full local test suite: 806 cases / 40395 assertions, identical before and after this change (`QT_QPA_PLATFORM=offscreen ./librecad_tests`, exit 0).

I did attempt to add an automated regression test that constructs the real `QC_ApplicationWindow` singleton and drives the toggle through the actual signal/slot path - it reliably reproduced the crash before the fix and passed after it, in isolation. However running it alongside the full existing suite (806+ other test cases in the same process) caused a SIGSEGV during process teardown that also reproduces with the fix applied and appears unrelated to this change - constructing that heavyweight singleton doesn't currently coexist safely with the rest of the shared test binary's cumulative global state, at either explicit or implicit teardown. I didn't want to introduce a new source of CI flakiness while fixing this bug, so I left it out; happy to follow up separately if there's an established pattern for isolating/resetting that singleton within `librecad_tests` that I'm missing.
