### PR TITLE
Force the built-in color dialog for the "Custom" color picker

### DIFF
--- a/librecad/src/ui/components/comboboxes/qg_colorbox.cpp
+++ b/librecad/src/ui/components/comboboxes/qg_colorbox.cpp
@@ -312,7 +312,9 @@ void QG_ColorBox::slotColorChanged(const int index) {
     }
 
     if (itemText(index) == tr("Custom")) {
-        const auto selectedColor = RS_Color(QColorDialog::getColor(*m_currentColor, this));
+        const auto selectedColor = RS_Color(QColorDialog::getColor(*m_currentColor, this,
+                                                                     tr("Select Color"),
+                                                                     QColorDialog::DontUseNativeDialog));
         if (selectedColor.isValid()) {
             *m_currentColor = selectedColor;
             const int current = addCustomColor(selectedColor);


### PR DESCRIPTION
Closes #2397.

## What

Selecting "Custom" in any pen/layer color dropdown (e.g. editing a layer's color in the Layers Tree, per the repro in #2397) closed the application instantly on GTK-based Linux desktop environments. The reporter confirmed it does *not* reproduce on KDE Plasma.

## Root cause

`QG_ColorBox` is the color-picker widget used almost everywhere a color is chosen in LibreCAD - pen toolbar, entity/dimension properties, the pen palette, and the Layers Tree's add/edit layer dialogs. Its `QColorDialog::getColor()` call was the **one** color-picker call site in the whole codebase missing the `QColorDialog::DontUseNativeDialog` flag:

```
librecad/src/ui/components/comboboxes/qg_colorbox.cpp:315
    const auto selectedColor = RS_Color(QColorDialog::getColor(*m_currentColor, this));
```

Six sibling call sites already pass that flag: `lc_dlgiconssetup.cpp`, `lc_widgetoptionsdialog.cpp`, `qg_dlgoptionsgeneral.cpp`, `lc_layertreeoptionsdialog.cpp`, `lc_penpaletteoptionsdialog.cpp`, `colorwizard.cpp`.

Without it, Qt falls back to whatever native color dialog the active `QPlatformTheme` plugin supplies. On GTK-based desktops that's typically a real native GTK (or xdg-desktop-portal) color chooser nested inside Qt's own modal event loop - a known-fragile combination across GTK/Qt version pairs. KDE Plasma's platform theme doesn't override color-dialog creation the same way, so it falls back to Qt's own stable implementation and never hits the bug - matching the reporter's KDE-vs-GTK observation exactly.

## Fix

Adds the same `tr("Select Color"), QColorDialog::DontUseNativeDialog` arguments already used at the six other call sites, forcing Qt's own built-in color dialog everywhere a `QG_ColorBox` is used. No loss of functionality - Qt's built-in `QColorDialog` supports the same custom-color picking on every platform.

## Verification

Local `cmake`/`ninja` build of both the `librecad` app target and `librecad_tests` - both build clean. Full test suite unaffected: 806 cases / 40395 assertions, identical before and after this change (`QT_QPA_PLATFORM=offscreen ./librecad_tests`, exit 0). I don't have a GTK-based Linux desktop available to directly reproduce the native-dialog crash itself, so I can't visually confirm the before/after on the actual failure surface - but the fix is a one-line addition matching an established, already-proven pattern used at six other call sites in this same codebase, none of which have ever been reported to hit this issue.
