### PR TITLE
Show the snap indicator when dragging a grip in Modify mode

### DIFF
--- a/librecad/src/actions/drawing/rs_actiondefault.cpp
+++ b/librecad/src/actions/drawing/rs_actiondefault.cpp
@@ -841,6 +841,7 @@ void RS_ActionDefault::onMouseMovingCompleted(const LC_MouseEvent* e) {
 void RS_ActionDefault::onMouseRightButtonPress([[maybe_unused]]int status, const LC_MouseEvent* e) {
     //cleanup
     goToNeutralStatus();
+    deleteSnapper();
     e->originalEvent->accept();
 }
 
@@ -963,6 +964,7 @@ void RS_ActionDefault::onMouseRightButtonRelease([[maybe_unused]]int status, [[m
     RS_DEBUG->print("RS_ActionDefault::mouseReleaseEvent()");
     //cleanup
     goToNeutralStatus();
+    deleteSnapper();
 }
 
 void RS_ActionDefault::goToNeutralStatus(){

--- a/librecad/src/actions/drawing/rs_actiondefault.cpp
+++ b/librecad/src/actions/drawing/rs_actiondefault.cpp
@@ -1044,6 +1044,15 @@ RS2::CursorType RS_ActionDefault::doGetMouseCursor(const int status){
     }
 }
 
+// Moving a whole entity or a reference/grip point both target a point via
+// the snapper, so the snap indicator should show for them (LibreCAD#2760).
+// Neutral/Dragging/SetCorner2/Panning stay excluded - that's what keeps
+// the indicator suppressed while defining a selection rectangle
+// (LibreCAD#2143), which is what isInVisualSnapStatus() was added for.
+bool RS_ActionDefault::isInVisualSnapStatus(int status) {
+    return status == Moving || status == MovingRef;
+}
+
 void RS_ActionDefault::clearHighLighting(){
     deleteHighlights();
     clearQuickInfoWidget();

--- a/librecad/src/actions/drawing/rs_actiondefault.cpp
+++ b/librecad/src/actions/drawing/rs_actiondefault.cpp
@@ -523,16 +523,24 @@ void RS_ActionDefault::onMouseMoveEvent([[maybe_unused]] const int status, const
             m_actionData->v2 = getSnapAngleAwarePoint(e, m_actionData->v1, mouse, true);
             updateCoordinateWidgetByRelZero(m_actionData->v2);
 
+            const RS_Vector &offset = m_actionData->v2 - m_actionData->v1;
+
+            // Move each clone individually and only then add it to m_preview,
+            // rather than adding all clones first and moving the whole
+            // container - m_preview may already contain entities that must
+            // stay fixed in place, e.g. the ortho/horizontal/vertical
+            // restriction guide lines RS_PreviewActionInterface::mouseMoveEvent()
+            // adds via visualizeOrdinaryRestrictions() before this handler
+            // runs, which m_preview->move(offset) would otherwise drag along
+            // with the selection.
             QList<RS_Entity*> selection;
             if (m_document->collectSelected(selection)) {
                 for (auto ent : std::as_const(selection)) {
                     RS_Entity* clone = getClone(ent);
+                    clone->move(offset);
                     m_preview->addEntity(clone);
                 }
             }
-
-            const RS_Vector &offset = m_actionData->v2 - m_actionData->v1;
-            m_preview->move(offset);
 
             auto *line = new RS_Line(m_actionData->v1, m_actionData->v2);
             m_preview->addEntity(line);
@@ -789,6 +797,7 @@ void RS_ActionDefault::onMouseMovingRefCompleted(const LC_MouseEvent* e) {
                         });
     }
     goToNeutralStatus();
+    deleteSnapper();
     redraw();
     m_movingJustCompleted = true;
 }

--- a/librecad/src/actions/drawing/rs_actiondefault.h
+++ b/librecad/src/actions/drawing/rs_actiondefault.h
@@ -79,6 +79,7 @@ protected:
     void updateQuickInfoWidget(RS_Entity *pEntity);
     void goToNeutralStatus();
     RS2::CursorType doGetMouseCursor(int status) override;
+    bool isInVisualSnapStatus(int status) override;
 
     void onMouseLeftButtonRelease(int status, const LC_MouseEvent* e) override;
     void onMouseRightButtonRelease(int status, const LC_MouseEvent* e) override;


### PR DESCRIPTION
Closes #2760.

## What

Dragging a grip/reference point of a selected entity (or the whole entity) no longer showed the snap indicator (e.g. an orange square, per the reporter's Snap-shape setting) at the snapped target point - even though the snap itself worked correctly and the drag landed exactly where it should.

## Root cause

`RS_Snapper::drawSnapper()` only adds the snap-indicator crosshair when `isSnapExpected()` - which delegates to the current action's `isInVisualSnapStatus(status)` - returns `true`. That gate defaults to `false`, and was introduced by #2540 specifically to fix #2143: before that, the indicator showed unconditionally, including during a plain rubber-band selection-rectangle drag, where it served no purpose.

#2540 went through the various draw/modify/info/pick action classes overriding `isInVisualSnapStatus()` to whitelist their own point-picking statuses - but missed `RS_ActionDefault`, the default action that (among other things) also handles dragging a selected entity's grip/reference point (`MovingRef` status) or the whole entity (`Moving` status). Both statuses resolve their target point through the same snapper used everywhere else - the snap computation was never affected, only the indicator's visibility.

## Fix

Adds the missing `isInVisualSnapStatus()` override to `RS_ActionDefault`, matching the exact pattern already used by every other action class (e.g. `LC_ActionModifyMove`): returns `true` for `Moving`/`MovingRef`, `false` for everything else (`Neutral`, `Dragging`, `SetCorner2`, `Panning`) - so the #2143 fix stays intact, and the indicator still doesn't show while defining a selection rectangle.

## Verification

Local `cmake`/`ninja` build of both the `librecad` app target and `librecad_tests` - both build clean. Full test suite unaffected: 806 cases / 40395 assertions, identical before and after this change (`QT_QPA_PLATFORM=offscreen ./librecad_tests`, exit 0).

## Update: two follow-up fixes (second commit)

A deep review of the first commit found two real bugs that were latent/unreachable before it (`RS_ActionDefault`'s `Moving`/`MovingRef` never used to draw into the snap overlay or the "ordinary restrictions" preview at all) and became live once those statuses started actually exercising code paths they were always supposed to reach:

- **Preview corruption**: dragging a whole entity with Shift/ortho-restriction held now visibly dragged the fixed restriction guide lines along with the moved entity. `RS_PreviewActionInterface::mouseMoveEvent()` adds those guide lines (anchored at the relative-zero point) to `m_preview` via `visualizeOrdinaryRestrictions()` before dispatching to the action, but `RS_ActionDefault`'s `Moving` case then called `m_preview->move(offset)` on the *whole* container after adding its own clones, moving the guide lines too. Fixed by moving each clone individually before adding it to `m_preview`, instead of moving the shared container wholesale.
- **Stuck crosshair**: completing a grip/reference-point drag (`MovingRef`) left the snap-indicator crosshair frozen on screen at the last drag position - `onMouseMovingRefCompleted()` never called `deleteSnapper()`, unlike its sibling `onMouseMovingCompleted()` (whole-entity drag), which does. Added the missing call.

Full test suite unaffected by these either: 806 cases / 40395 assertions, before and after.

## Update: one more follow-up fix (third commit)

A completeness pass on the second commit's fix found the same stuck-crosshair gap on two more exit paths: `onMouseRightButtonPress()` and `onMouseRightButtonRelease()` both ignore the current status and unconditionally call `goToNeutralStatus()`, which - like the already-fixed `onMouseMovingRefCompleted()` - never touches the snap overlay. Right-clicking to cancel a grip or entity drag left the crosshair frozen at the last drag position. Added the same `deleteSnapper()` call to both handlers.

Also found, and deliberately left out of scope (unrelated to this PR, pre-existing): the identical "whole-container preview move after guide lines already added" bug pattern in four other action classes (copy/paste, paste-transform, draw image, draw mtext) - flagged separately rather than folded into this fix.

Full test suite unaffected: 806 cases / 40395 assertions, before and after.
