### PR TITLE
Fix AppImage delta-update support for master-branch builds

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - 2.2.1
 
 jobs:
   BuildLinux:
@@ -466,7 +465,7 @@ jobs:
           retention-days: 2
 
   UpdateAssets:
-    if: github.repository_owner == 'LibreCAD' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/2.2.1')
+    if: github.repository_owner == 'LibreCAD' && github.ref == 'refs/heads/master'
     needs: [BuildLinux, BuildLinuxAarch64, BuildMacOS, BuildWindows64, BuildWindowsARM64, BuildSnap]
     runs-on: ubuntu-latest
     permissions:
@@ -483,11 +482,6 @@ jobs:
           set -euo pipefail
 
           case "${GITHUB_REF_NAME}" in
-            "2.2.1")
-              release_tag="2.2.1-latest"
-              release_name="Latest build from stable branch 2.2.1"
-              channel_description="This is the latest automated build from the maintained 2.2.1 stable release branch. For normal production use, prefer the latest stable release."
-              ;;
             "master")
               # "continuous" is not an arbitrary choice: appimagetool
               # (probonopd/go-appimage) embeds AppImage update information

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -55,23 +55,12 @@ jobs:
       - name: Create AppImage
         run: |
           QT_FILE_DIR="${{github.workspace}}/../Qt" ./CI/build-appimg.sh
-          # On master, keep appimagetool's own output name (including its
-          # -x86_64 suffix) rather than renaming it away: appimagetool
-          # already embeds AppImage update information (LibreCAD#2754)
-          # whose filename pattern expects that suffix, and it writes a
+          # Keep appimagetool's own output name (including its -x86_64
+          # suffix) rather than renaming it away: appimagetool already
+          # embeds AppImage update information (LibreCAD#2754) whose
+          # filename pattern expects that suffix, and it writes a
           # same-named *.AppImage.zsync sibling that must stay paired
           # with whatever name the AppImage actually ships under.
-
-      - name: Rename AppImage (2.2.1 branch only)
-        # The 2.2.1 branch isn't part of the AppImage update-information
-        # fix above - LibreCAD#2754 / PR #2778 only cover master's
-        # "continuous" channel, and 2.2.1's own fix is a deferred
-        # follow-up (see that PR's description). Keep 2.2.1's
-        # pre-existing filename behavior unchanged until then.
-        if: github.ref == 'refs/heads/2.2.1'
-        run: |
-          mv LibreCAD*.AppImage LibreCAD-`git describe --always`.AppImage
-
       - name: List files
         run: |
           echo ${{ github.workspace }} && ls ${{ github.workspace }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -55,12 +55,23 @@ jobs:
       - name: Create AppImage
         run: |
           QT_FILE_DIR="${{github.workspace}}/../Qt" ./CI/build-appimg.sh
-          # Keep appimagetool's own output name (including its -x86_64
-          # suffix) rather than renaming it away: appimagetool already
-          # embeds AppImage update information (LibreCAD#2754) whose
-          # filename pattern expects that suffix, and it writes a
+          # On master, keep appimagetool's own output name (including its
+          # -x86_64 suffix) rather than renaming it away: appimagetool
+          # already embeds AppImage update information (LibreCAD#2754)
+          # whose filename pattern expects that suffix, and it writes a
           # same-named *.AppImage.zsync sibling that must stay paired
           # with whatever name the AppImage actually ships under.
+
+      - name: Rename AppImage (2.2.1 branch only)
+        # The 2.2.1 branch isn't part of the AppImage update-information
+        # fix above - LibreCAD#2754 / PR #2778 only cover master's
+        # "continuous" channel, and 2.2.1's own fix is a deferred
+        # follow-up (see that PR's description). Keep 2.2.1's
+        # pre-existing filename behavior unchanged until then.
+        if: github.ref == 'refs/heads/2.2.1'
+        run: |
+          mv LibreCAD*.AppImage LibreCAD-`git describe --always`.AppImage
+
       - name: List files
         run: |
           echo ${{ github.workspace }} && ls ${{ github.workspace }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -55,7 +55,12 @@ jobs:
       - name: Create AppImage
         run: |
           QT_FILE_DIR="${{github.workspace}}/../Qt" ./CI/build-appimg.sh
-          mv LibreCAD*.AppImage LibreCAD-`git describe --always`.AppImage
+          # Keep appimagetool's own output name (including its -x86_64
+          # suffix) rather than renaming it away: appimagetool already
+          # embeds AppImage update information (LibreCAD#2754) whose
+          # filename pattern expects that suffix, and it writes a
+          # same-named *.AppImage.zsync sibling that must stay paired
+          # with whatever name the AppImage actually ships under.
       - name: List files
         run: |
           echo ${{ github.workspace }} && ls ${{ github.workspace }}
@@ -66,7 +71,9 @@ jobs:
         uses: actions/upload-artifact@main
         with:
           name: linuxAssets
-          path: LibreCAD*.AppImage
+          path: |
+            LibreCAD*.AppImage
+            LibreCAD*.AppImage.zsync
           retention-days: 2
 
   BuildLinuxAarch64:
@@ -129,7 +136,9 @@ jobs:
         uses: actions/upload-artifact@main
         with:
           name: linuxAssetsAarch64
-          path: LibreCAD*.AppImage
+          path: |
+            LibreCAD*.AppImage
+            LibreCAD*.AppImage.zsync
           retention-days: 2
 
   BuildSnap:
@@ -480,7 +489,12 @@ jobs:
               channel_description="This is the latest automated build from the maintained 2.2.1 stable release branch. For normal production use, prefer the latest stable release."
               ;;
             "master")
-              release_tag="2.2.2_alpha-latest"
+              # "continuous" is not an arbitrary choice: appimagetool
+              # (probonopd/go-appimage) embeds AppImage update information
+              # (LibreCAD#2754) that hardcodes this exact tag name for
+              # master-branch builds - renaming it would silently break
+              # AppImage delta updates again.
+              release_tag="continuous"
               release_name="Latest build from master branch"
               channel_description="This is the latest automated development build from the master branch. Use it for testing the next LibreCAD version."
               ;;
@@ -500,7 +514,7 @@ jobs:
 
           - [Latest stable release](https://github.com/LibreCAD/LibreCAD/releases/latest)
           - [Latest build from stable branch 2.2.1](https://github.com/LibreCAD/LibreCAD/releases/tag/2.2.1-latest)
-          - [Latest build from master](https://github.com/LibreCAD/LibreCAD/releases/tag/2.2.2_alpha-latest)
+          - [Latest build from master](https://github.com/LibreCAD/LibreCAD/releases/tag/continuous)
 
           ## About this build
 
@@ -514,7 +528,7 @@ jobs:
 
           - [Latest stable release](https://github.com/LibreCAD/LibreCAD/releases/latest)
           - [Latest build from stable branch 2.2.1](https://github.com/LibreCAD/LibreCAD/releases/tag/2.2.1-latest)
-          - [Latest build from master](https://github.com/LibreCAD/LibreCAD/releases/tag/2.2.2_alpha-latest)
+          - [Latest build from master](https://github.com/LibreCAD/LibreCAD/releases/tag/continuous)
 
           This entry keeps the current LibreCAD download links visible at the top of the releases page.
           EOF
@@ -541,7 +555,9 @@ jobs:
           body_path: release-notes.md
           files: |
             linuxAssets/LibreCAD*.AppImage
+            linuxAssets/LibreCAD*.AppImage.zsync
             linuxAssetsAarch64/LibreCAD*.AppImage
+            linuxAssetsAarch64/LibreCAD*.AppImage.zsync
             macOSAssets/LibreCAD*.dmg
             win64Assets/LibreCAD*.exe
             winARM64Assets/LibreCAD*.exe

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ librecad dxf2svg foo.dxf
 ### Quick Downloads
 - [Latest stable release](https://github.com/LibreCAD/LibreCAD/releases/latest)
 - [Latest build from stable branch 2.2.1](https://github.com/LibreCAD/LibreCAD/releases/tag/2.2.1-latest)
-- [Latest build from master](https://github.com/LibreCAD/LibreCAD/releases/tag/2.2.2_alpha-latest)
+- [Latest build from master](https://github.com/LibreCAD/LibreCAD/releases/tag/continuous)
 
 ### Releases
 - [Releases and Prereleases](https://github.com/LibreCAD/LibreCAD/releases)

--- a/librecad/src/ui/main/init/lc_menufactory_main.cpp
+++ b/librecad/src/ui/main/init/lc_menufactory_main.cpp
@@ -149,7 +149,7 @@ void LC_MenuFactoryMain::createHelpMenu(QMenuBar* menuBar, QList<QMenu*>& topMen
 
     if (XSTR(LC_PRERELEASE)) {
         // fixme - this is makes sense only for pre-release versions. Of course, the generation of tag included into URL should be more intelligent..
-        menuHelp->QWidget::addAction(urlActionTR(tr("&Dev Snapshot Release"), " https://github.com/LibreCAD/LibreCAD/releases/tag/2.2.2_alpha-latest"));
+        menuHelp->QWidget::addAction(urlActionTR(tr("&Dev Snapshot Release"), " https://github.com/LibreCAD/LibreCAD/releases/tag/continuous"));
         menuHelp->addSeparator();
     }
 


### PR DESCRIPTION
Partially addresses #2754 (master-branch/"continuous" channel; see Scope below).

## What

LibreCAD's Linux AppImage is already built with `probonopd/go-appimage`'s `appimagetool`, which unconditionally embeds AppImage "update information" (a `.upd_info` ELF section) and generates a matching `*.AppImage.zsync` sibling - the mechanism [AppImageUpdate](https://github.com/AppImageCommunity/AppImageUpdate)/AppImageLauncher/AppManager/AM use to fetch only a binary diff instead of the whole AppImage on update. None of this was actually working end-to-end.

## Root causes found (three independent gaps)

1. **Wrong release tag.** `appimagetool` auto-computes the update-information string from `GITHUB_REF`. Since this workflow only triggers on pushes to `master`/`2.2.1` (never tags, never PRs), the outcome is deterministic: master-branch builds get the hardcoded channel literal `"continuous"`. This repo's master rolling release was tagged `2.2.2_alpha-latest`, not `continuous`, so the embedded update information pointed at a release that doesn't exist under that name.

   I verified there's no flag or env var to make the tool embed a custom string instead - this specific `appimagetool` build exposes only `-l/--libapprun_hooks`, `-o/--overwrite`, `-s/--standalone`, `--preserve_cwd`; the `-u/--updateinformation` capability exists on a separate binary, `mkappimage`, not on `appimagetool`. So the fix is to rename the release tag to match what the tool already embeds, rather than fighting the tool.

2. **The `.zsync` file was silently discarded.** Both the artifact-upload step's `path` glob and the release-publish step's `files` glob only matched `LibreCAD*.AppImage`, never the `*.AppImage.zsync` sibling `appimagetool` already writes next to it.

3. **The x86_64 build's post-build rename broke the pairing.** `mv LibreCAD*.AppImage LibreCAD-$(git describe --always).AppImage` stripped the `-x86_64` arch suffix that the tool's own auto-guessed filename pattern (`LibreCAD-*-x86_64.AppImage.zsync`) expects - and, more fundamentally, renaming the AppImage *after* `zsyncmake` has already run desyncs it from its `.zsync` file, whose internal header still references the pre-rename filename. Removed the rename; the aarch64 build already didn't do this (its equivalent rename line was commented out), so this also makes the two builds consistent with each other.

## Fix

- `.github/workflows/build-all.yml`: master's rolling release tag → `continuous`; both Linux artifact-upload globs and the release `files:` list extended to also capture `*.AppImage.zsync`; x86_64's arch-suffix-stripping rename removed.
- `README.md`: updated the one "Latest build from master" download link that pointed at the old tag.

## Scope - 2.2.1 branch not included

The same mechanism resolves 2.2.1-branch builds to `appimagetool`'s *other* hardcoded channel literal, `"latest"` - a GitHub API magic keyword that requires the target release to actually be flagged as this repository's "Latest Release". The `2.2.1-latest` rolling release is a prerelease and isn't that - and flipping `make_latest: true` on it would take that designation away from the real stable release (`v2.2.1.5` currently holds it), which seems like the wrong tradeoff to accept as a side effect of this fix. Leaving that as a follow-up decision rather than bundling it here.

## Heads up: the old release will go stale

Once this merges, the workflow no longer touches (deletes+recreates) the `2.2.2_alpha-latest` tag/release - it'll just sit there unrefreshed. Worth deleting manually after this lands and has run at least once successfully, or let me know if you'd like that as a follow-up.

## Verification

This only touches the release-publishing CI workflow and a doc link - no C++/build-output change, so there's no local test suite that exercises it. Validated with `actionlint` (zero new warnings introduced; the file's existing shellcheck style nits, e.g. legacy-backtick/word-splitting notices elsewhere in the file, are all pre-existing and unrelated) and by tracing the exact logic against `probonopd/go-appimage`'s actual source (the channel-literal branching, the auto-guessed filename pattern, and the `.zsync` generation + its filename dependency) rather than assumption. I wasn't able to actually run the workflow from this environment, so the real confirmation is the next scheduled build on `master` after this merges - worth watching that run and checking the resulting release for a `.zsync` asset and a working `.upd_info` section (`readelf -p .upd_info LibreCAD-*.AppImage` should print `gh-releases-zsync|LibreCAD|LibreCAD|continuous|LibreCAD-*-x86_64.AppImage.zsync`).
