### PR TITLE
Windows: fix lc_svgicons.dll missing from installer

### DIFF
--- a/libraries/lciconengine/lciconengine.pro
+++ b/libraries/lciconengine/lciconengine.pro
@@ -34,6 +34,15 @@ DISTFILES += src/lc_svgicons.json
 
 win32:RC_FILE = src/lc_svgicons.rc
 
+# Without this, the plugin builds to qmake's default output location and
+# never reaches windows\iconengines\ - windeployqt only knows about Qt's own
+# plugins (e.g. qsvgicon.dll, which does land there), not this custom one,
+# so nothing else copies it into the deployed tree or the NSIS installer.
+# Matches the DESTDIR convention every other plugin .pro already uses
+# (see plugins/*/*.pro), just pointed at Qt's iconengines plugin category
+# instead of LibreCAD's own resources/plugins.
+win32: DESTDIR = ../../windows/iconengines
+
 win32-msvc*: QMAKE_LFLAGS_RELEASE += /RELEASE
 
 target.path += $$[QT_INSTALL_PLUGINS]/iconengines


### PR DESCRIPTION
Fixes #2785.

## What

`lc_svgicons.dll` (the custom SVG icon-engine plugin, `libraries/lciconengine`) never made it into the Windows installer - only Qt's own `qsvgicon.dll` was present under `iconengines\`, so icon styling doesn't work on a fresh Windows install.

## Root cause

`scripts/build-windows.bat` builds via qmake/nmake, then runs `windeployqt6.exe` on `windows\LibreCAD.exe`, then NSIS (`nsis-msvc.nsi`) copies the entire `windows\` tree recursively into the installer. Every other qmake plugin project (`plugins/*/*.pro`) sets an explicit `win32: DESTDIR = ../../windows/...` so its build output actually lands under `windows\` for that pipeline to pick up. `libraries/lciconengine/lciconengine.pro` never had one, so `lc_svgicons.dll` built to qmake's default output location instead and was silently left behind - `windeployqt` only knows about Qt's own plugins (which is why `qsvgicon.dll` *does* show up), not LibreCAD's custom one.

The `target.path` / `INSTALLS += target` rule already in the .pro file doesn't help here either, since the Windows build script only runs `nmake release`, never `nmake install`.

## Fix

Add `win32: DESTDIR = ../../windows/iconengines`, matching the DESTDIR convention every sibling plugin `.pro` already uses, pointed at Qt's `iconengines` plugin category (the folder Qt itself searches, and where `qsvgicon.dll` already lands) rather than LibreCAD's own `resources/plugins` folder used by the sample/divide/etc. plugins.

No installer-script change needed - `nsis-msvc.nsi`'s existing `File /r ... "..\..\windows\*.*"` already copies the whole tree recursively, so it picks this up automatically once the DLL is actually being built into the right place.

## Scope

Windows only, matching the confirmed report ("at least, under windows"). Linux/macOS official builds go through the project's CMake build, whose `install(TARGETS ... LIBRARY DESTINATION bin/iconengines)` rule for this same target isn't affected by this qmake-specific gap.

## Verification

Confirmed via qmake6 (macOS) that the file still parses correctly (`qmake6 lciconengine.pro`, exit 0, generates a valid Makefile) - the `win32:` scope naturally doesn't execute on this platform, so this only checks syntax, not the actual deployed output. I don't have a Windows environment available to build/package and confirm `windows\iconengines\lc_svgicons.dll` end-to-end - would appreciate a test build to confirm.
