### PR TITLE
fix(libdxfrw): avoid Solaris sun macro collision

### DIFF
--- a/libraries/libdxfrw/src/drw_base.h
+++ b/libraries/libdxfrw/src/drw_base.h
@@ -24,6 +24,13 @@
 #include <utility>
 #include <vector>
 
+// Solaris/Illumos may predefine `sun` as a numeric platform macro.  It
+// collides with valid libdxfrw identifiers such as DRW_Sun parameters and
+// locals, so remove the non-standard macro before exposing the C++ API.
+#ifdef sun
+# undef sun
+#endif
+
 #ifdef DRW_ASSERTS
 # define drw_assert(a) assert(a)
 #else

--- a/libraries/libdxfrw/src/drw_base.h
+++ b/libraries/libdxfrw/src/drw_base.h
@@ -24,13 +24,6 @@
 #include <utility>
 #include <vector>
 
-// Solaris/Illumos may predefine `sun` as a numeric platform macro.  It
-// collides with valid libdxfrw identifiers such as DRW_Sun parameters and
-// locals, so remove the non-standard macro before exposing the C++ API.
-#ifdef sun
-# undef sun
-#endif
-
 #ifdef DRW_ASSERTS
 # define drw_assert(a) assert(a)
 #else

--- a/libraries/libdxfrw/src/intern/dwgwriter15.cpp
+++ b/libraries/libdxfrw/src/intern/dwgwriter15.cpp
@@ -912,22 +912,22 @@ bool dwgWriter15::writeAcDbPlaceholder(
     return true;
 }
 
-void dwgWriter15::emitSunObject(std::uint32_t handle, const DRW_Sun& sun) {
+void dwgWriter15::emitSunObject(std::uint32_t handle, const DRW_Sun& sunData) {
     dwgBufferW& body = beginObject(handle);
     dwgBufferW *sb, *hb;
     emitRecordPreamble(body, m_version, DRW_Sun::kDwgClassNum, handle,
                        m_objectStrings, m_objectHandles, sb, hb);
     DRW_UNUSED(sb);
-    (void)sun.encodeDwg(m_version, &body, hb);  // (void): void emitter; object serializes into in-memory buffer (no failure path)
+    (void)sunData.encodeDwg(m_version, &body, hb);  // (void): void emitter; object serializes into in-memory buffer (no failure path)
 
     finishObject();
 }
 
-bool dwgWriter15::writeSun(const DRW_Sun& sun) {
+bool dwgWriter15::writeSun(const DRW_Sun& sunData) {
     if (m_version < DRW::AC1021)
         return false;
 
-    DRW_Sun object = sun;
+    DRW_Sun object = sunData;
     if (object.handle == 0) {
         object.handle = m_handles.next();
     } else {

--- a/libraries/libdxfrw/src/intern/dwgwriter15.h
+++ b/libraries/libdxfrw/src/intern/dwgwriter15.h
@@ -95,7 +95,7 @@ public:
     void addAppId(const DRW_AppId& ai);
     bool replayRawObject(const DRW_UnsupportedObject& object);
     bool writeAcDbPlaceholder(const DRW_AcDbPlaceholder& placeholder);
-    bool writeSun(const DRW_Sun& sun);
+    bool writeSun(const DRW_Sun& sunData);
     bool writeMLeaderStyle(const DRW_MLeaderStyle& style);
     bool writeDictionary(const DRW_Dictionary& dictionary);
     bool writeXRecord(const DRW_XRecord& xrecord);
@@ -194,7 +194,7 @@ protected:
     void emitDimstyleRecord(std::uint32_t handle, const DRW_Dimstyle& ds);
     void emitAcDbPlaceholderObject(std::uint32_t handle,
                                    const DRW_AcDbPlaceholder& placeholder);
-    void emitSunObject(std::uint32_t handle, const DRW_Sun& sun);
+    void emitSunObject(std::uint32_t handle, const DRW_Sun& sunData);
     void emitMLeaderStyleObject(std::uint32_t handle, const DRW_MLeaderStyle& style);
     void emitDictionaryObject(std::uint32_t handle, const DRW_Dictionary& dictionary);
     void emitXRecordObject(std::uint32_t handle, const DRW_XRecord& xrecord);

--- a/libraries/libdxfrw/src/libdxfrw.cpp
+++ b/libraries/libdxfrw/src/libdxfrw.cpp
@@ -6821,7 +6821,7 @@ bool dxfRW::processFieldList() {
 bool dxfRW::processSun() {
     DRW_DBG("dxfRW::processSun");
     int code;
-    DRW_Sun sun;
+    DRW_Sun sunObject;
     DRW_RawDxfObject raw;
     raw.name = nextentity;
     while (reader->readRec(&code)) {
@@ -6829,13 +6829,13 @@ bool dxfRW::processSun() {
         if (0 == code) {
             nextentity = reader->getString();
             DRW_DBG(nextentity); DRW_DBG("\n");
-            iface->addSun(sun);
+            iface->addSun(sunObject);
             iface->addRawDxfObject(raw);
             return true;  //found new entity or ENDSEC, terminate
         }
 
         captureRawGroup(raw, code);
-        if (!sun.parseCode(code, reader)) {
+        if (!sunObject.parseCode(code, reader)) {
             return setError( DRW::BAD_CODE_PARSED);
         }
     }

--- a/librecad/src/lib/engine/document/lc_dwgadvancedmetadata.h
+++ b/librecad/src/lib/engine/document/lc_dwgadvancedmetadata.h
@@ -796,7 +796,7 @@ public:
         size_t vport = 0;
         size_t visualStyle = 0;
         size_t light = 0;
-        size_t sun = 0;
+        size_t sunCount = 0;
         size_t odaCovered = 0;
         size_t crossReferenceSourced = 0;
         size_t rawOnly = 0;
@@ -2312,21 +2312,21 @@ public:
         m_lights.push_back(record);
     }
 
-    void addSun(const DRW_Sun& sun) {
+    void addSun(const DRW_Sun& sunData) {
         SunRecord record;
-        record.handle = sun.handle;
-        record.parentHandle = sun.parentHandle;
-        record.classVersion = sun.m_classVersion;
-        record.isOn = sun.m_isOn;
-        record.color = sun.m_color;
-        record.intensity = sun.m_intensity;
-        record.hasShadow = sun.m_hasShadow;
-        record.julianDay = sun.m_julianDay;
-        record.milliseconds = sun.m_milliseconds;
-        record.isDaylightSavings = sun.m_isDaylightSavings;
-        record.shadowType = sun.m_shadowType;
-        record.shadowMapSize = sun.m_shadowMapSize;
-        record.shadowSoftness = sun.m_shadowSoftness;
+        record.handle = sunData.handle;
+        record.parentHandle = sunData.parentHandle;
+        record.classVersion = sunData.m_classVersion;
+        record.isOn = sunData.m_isOn;
+        record.color = sunData.m_color;
+        record.intensity = sunData.m_intensity;
+        record.hasShadow = sunData.m_hasShadow;
+        record.julianDay = sunData.m_julianDay;
+        record.milliseconds = sunData.m_milliseconds;
+        record.isDaylightSavings = sunData.m_isDaylightSavings;
+        record.shadowType = sunData.m_shadowType;
+        record.shadowMapSize = sunData.m_shadowMapSize;
+        record.shadowSoftness = sunData.m_shadowSoftness;
         m_suns.push_back(record);
         for (ViewRecord& view : m_views) {
             if (view.sunHandle == record.handle)
@@ -6458,7 +6458,7 @@ private:
                 ++counts.light;
                 break;
             case VisualMetadataSource::Sun:
-                ++counts.sun;
+                ++counts.sunCount;
                 break;
         }
     }

--- a/librecad/src/lib/filters/rs_filterdxfrw.cpp
+++ b/librecad/src/lib/filters/rs_filterdxfrw.cpp
@@ -922,21 +922,21 @@ DRW_Field fieldFromMetadata(
 }
 
 DRW_Sun sunFromMetadata(const LC_DwgAdvancedMetadata::SunRecord& record) {
-    DRW_Sun sun;
-    sun.handle = record.handle;
-    sun.parentHandle = static_cast<int>(record.parentHandle);
-    sun.m_classVersion = record.classVersion;
-    sun.m_isOn = record.isOn;
-    sun.m_color = record.color;
-    sun.m_intensity = record.intensity;
-    sun.m_hasShadow = record.hasShadow;
-    sun.m_julianDay = record.julianDay;
-    sun.m_milliseconds = record.milliseconds;
-    sun.m_isDaylightSavings = record.isDaylightSavings;
-    sun.m_shadowType = record.shadowType;
-    sun.m_shadowMapSize = record.shadowMapSize;
-    sun.m_shadowSoftness = record.shadowSoftness;
-    return sun;
+    DRW_Sun sunObject;
+    sunObject.handle = record.handle;
+    sunObject.parentHandle = static_cast<int>(record.parentHandle);
+    sunObject.m_classVersion = record.classVersion;
+    sunObject.m_isOn = record.isOn;
+    sunObject.m_color = record.color;
+    sunObject.m_intensity = record.intensity;
+    sunObject.m_hasShadow = record.hasShadow;
+    sunObject.m_julianDay = record.julianDay;
+    sunObject.m_milliseconds = record.milliseconds;
+    sunObject.m_isDaylightSavings = record.isDaylightSavings;
+    sunObject.m_shadowType = record.shadowType;
+    sunObject.m_shadowMapSize = record.shadowMapSize;
+    sunObject.m_shadowSoftness = record.shadowSoftness;
+    return sunObject;
 }
 
 DRW_MLeaderStyle mleaderStyleFromMetadata(
@@ -7126,8 +7126,8 @@ void RS_FilterDXFRW::writeDwgClasses() {
                 || record.handle == 0) {
                 continue;
             }
-            DRW_Sun sun = sunFromMetadata(record);
-            if (m_dwgW->registerSunObjectClass(&sun))
+            DRW_Sun sunObject = sunFromMetadata(record);
+            if (m_dwgW->registerSunObjectClass(&sunObject))
                 nativeSunHandles.insert(record.handle);
         }
         for (const auto& record : metadata.mleaderStyles()) {
@@ -8641,9 +8641,9 @@ void RS_FilterDXFRW::writeObjects() {
                     || record.handle == 0) {
                     continue;
                 }
-                DRW_Sun sun = sunFromMetadata(record);
-                remapEntry(sun);
-                if (m_dwgW->writeSun(&sun)) {
+                DRW_Sun sunObject = sunFromMetadata(record);
+                remapEntry(sunObject);
+                if (m_dwgW->writeSun(&sunObject)) {
                     ++nativeSunObjects;
                 } else {
                     hasBlockedReplay = true;
@@ -9521,9 +9521,9 @@ void RS_FilterDXFRW::writeObjects() {
         for (const auto &record : metadata.suns()) {
             if (!emitTyped(record.handle, record.replayState))
                 continue;
-            DRW_Sun sun = sunFromMetadata(record);
-            sun.parentHandle = resolveOwner(record.parentHandle);
-            m_dxfW->writeSun(&sun);
+            DRW_Sun sunObject = sunFromMetadata(record);
+            sunObject.parentHandle = resolveOwner(record.parentHandle);
+            m_dxfW->writeSun(&sunObject);
         }
         for (const auto &record : metadata.scales()) {
             if (!emitTyped(record.handle, record.replayState))

--- a/librecad/src/lib/filters/tests/dwg_write_smoke_tests.cpp
+++ b/librecad/src/lib/filters/tests/dwg_write_smoke_tests.cpp
@@ -2315,8 +2315,8 @@ public:
             REQUIRE(m_writer->writeSun(&m_sun));
     }
 
-    void addSun(const DRW_Sun& sun) override {
-        m_suns.push_back(sun);
+    void addSun(const DRW_Sun& sunData) override {
+        m_suns.push_back(sunData);
     }
 };
 
@@ -4225,18 +4225,18 @@ TEST_CASE("dwgRW writes and reads SUN metadata",
         }
 
         REQUIRE(readIface.m_suns.size() == 1);
-        const DRW_Sun& sun = readIface.m_suns.front();
-        CHECK(sun.m_classVersion == 1u);
-        CHECK(sun.m_isOn);
-        CHECK(sun.m_color == 4u);
-        CHECK(sun.m_intensity == 2.75);
-        CHECK(sun.m_hasShadow);
-        CHECK(sun.m_julianDay == 2460001);
-        CHECK(sun.m_milliseconds == 43210000);
-        CHECK(sun.m_isDaylightSavings);
-        CHECK(sun.m_shadowType == 1u);
-        CHECK(sun.m_shadowMapSize == 512u);
-        CHECK(sun.m_shadowSoftness == 6u);
+        const DRW_Sun& sunData = readIface.m_suns.front();
+        CHECK(sunData.m_classVersion == 1u);
+        CHECK(sunData.m_isOn);
+        CHECK(sunData.m_color == 4u);
+        CHECK(sunData.m_intensity == 2.75);
+        CHECK(sunData.m_hasShadow);
+        CHECK(sunData.m_julianDay == 2460001);
+        CHECK(sunData.m_milliseconds == 43210000);
+        CHECK(sunData.m_isDaylightSavings);
+        CHECK(sunData.m_shadowType == 1u);
+        CHECK(sunData.m_shadowMapSize == 512u);
+        CHECK(sunData.m_shadowSoftness == 6u);
 
         std::remove(path.c_str());
     }

--- a/librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
+++ b/librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
@@ -1432,9 +1432,9 @@ TEST_CASE("DXF data-only OBJECTS round-trip their body values via the raw net "
   // correctly-valued body groups (validates capture fix + routing together).
   {
     const auto &meta = graphic.dwgAdvancedMetadata();
-    const DRW_RawDxfObject *sun = findRaw(meta, "SUN");
-    REQUIRE(sun != nullptr);
-    const DRW_Variant *intensity = group(*sun, 40);
+    const DRW_RawDxfObject *sunObject = findRaw(meta, "SUN");
+    REQUIRE(sunObject != nullptr);
+    const DRW_Variant *intensity = group(*sunObject, 40);
     REQUIRE(intensity != nullptr);
     CHECK(intensity->type() == DRW_Variant::DOUBLE);
     CHECK(intensity->d_val() == 0.75);
@@ -1480,9 +1480,9 @@ TEST_CASE("DXF data-only OBJECTS round-trip their body values via the raw net "
   }
   {
     const auto &meta = graphic2.dwgAdvancedMetadata();
-    const DRW_RawDxfObject *sun = findRaw(meta, "SUN");
-    REQUIRE(sun != nullptr);
-    const DRW_Variant *intensity = group(*sun, 40);
+    const DRW_RawDxfObject *sunObject = findRaw(meta, "SUN");
+    REQUIRE(sunObject != nullptr);
+    const DRW_Variant *intensity = group(*sunObject, 40);
     REQUIRE(intensity != nullptr);
     CHECK(intensity->d_val() == 0.75);  // double value survives DXF->DXF
     const DRW_RawDxfObject *dvar = findRaw(meta, "DICTIONARYVAR");

--- a/librecad/src/lib/filters/tests/entity_metadata_tests.cpp
+++ b/librecad/src/lib/filters/tests/entity_metadata_tests.cpp
@@ -219,21 +219,21 @@ TEST_CASE("DWG advanced metadata caches raw and semantic sidecars",
   light.m_extendedLightRadius = 13.0;
   metadata.addLight(light);
 
-  DRW_Sun sun;
-  sun.handle = 0x9Au;
-  sun.parentHandle = 0x9Bu;
-  sun.m_classVersion = 2u;
-  sun.m_isOn = true;
-  sun.m_color = 0x445566u;
-  sun.m_intensity = 1.25;
-  sun.m_hasShadow = true;
-  sun.m_julianDay = 2460000;
-  sun.m_milliseconds = 43200000;
-  sun.m_isDaylightSavings = true;
-  sun.m_shadowType = 1u;
-  sun.m_shadowMapSize = 512u;
-  sun.m_shadowSoftness = 6u;
-  metadata.addSun(sun);
+  DRW_Sun sunObject;
+  sunObject.handle = 0x9Au;
+  sunObject.parentHandle = 0x9Bu;
+  sunObject.m_classVersion = 2u;
+  sunObject.m_isOn = true;
+  sunObject.m_color = 0x445566u;
+  sunObject.m_intensity = 1.25;
+  sunObject.m_hasShadow = true;
+  sunObject.m_julianDay = 2460000;
+  sunObject.m_milliseconds = 43200000;
+  sunObject.m_isDaylightSavings = true;
+  sunObject.m_shadowType = 1u;
+  sunObject.m_shadowMapSize = 512u;
+  sunObject.m_shadowSoftness = 6u;
+  metadata.addSun(sunObject);
 
   DRW_MLeaderStyle style;
   style.handle = 0xA0u;
@@ -1606,10 +1606,10 @@ TEST_CASE("DWG advanced metadata maps VIEW UCS and VPORT document items",
   ucs.yAxisDirection = DRW_Coord{0.0, 1.0, 0.0};
   metadata.addUcs(ucs);
 
-  DRW_Sun sun;
-  sun.handle = 0x540u;
-  sun.parentHandle = 0x503u;
-  metadata.addSun(sun);
+  DRW_Sun sunObject;
+  sunObject.handle = 0x540u;
+  sunObject.parentHandle = 0x503u;
+  metadata.addSun(sunObject);
 
   DRW_Vport vport;
   vport.name = "*ACTIVE";
@@ -1705,15 +1705,15 @@ TEST_CASE("DWG advanced metadata summarizes visual and light records",
   light.m_color = 0x0A0B0Cu;
   metadata.addLight(light);
 
-  DRW_Sun sun;
-  sun.handle = 0x640u;
-  sun.parentHandle = 0x605u;
-  sun.m_isOn = true;
-  sun.m_intensity = 1.5;
-  sun.m_color = 0x00FFFFu;
-  sun.m_julianDay = 2451545;
-  sun.m_milliseconds = 43200000;
-  metadata.addSun(sun);
+  DRW_Sun sunObject;
+  sunObject.handle = 0x640u;
+  sunObject.parentHandle = 0x605u;
+  sunObject.m_isOn = true;
+  sunObject.m_intensity = 1.5;
+  sunObject.m_color = 0x00FFFFu;
+  sunObject.m_julianDay = 2451545;
+  sunObject.m_milliseconds = 43200000;
+  metadata.addSun(sunObject);
 
   const auto summaries = metadata.visualMetadataSummaries();
   REQUIRE(summaries.size() == 5u);
@@ -1753,7 +1753,7 @@ TEST_CASE("DWG advanced metadata summarizes visual and light records",
   CHECK(counts.vport == 1u);
   CHECK(counts.visualStyle == 1u);
   CHECK(counts.light == 1u);
-  CHECK(counts.sun == 1u);
+  CHECK(counts.sunCount == 1u);
   CHECK(counts.odaCovered == 2u);
   CHECK(counts.crossReferenceSourced == 2u);
   CHECK(counts.rawOnly == 1u);

--- a/librecad/src/lib/filters/tests/family_exposure_tests.cpp
+++ b/librecad/src/lib/filters/tests/family_exposure_tests.cpp
@@ -96,9 +96,9 @@ TEST_CASE("RS_FilterDXFRW point-cloud and PR-4c overrides store metadata-only",
   rs.handle = 0x106;
   filter.addRenderSettings(rs);
 
-  DRW_SunStudy sun;
-  sun.handle = 0x107;
-  filter.addSunStudy(sun);
+  DRW_SunStudy sunStudy;
+  sunStudy.handle = 0x107;
+  filter.addSunStudy(sunStudy);
 
   DRW_DbColor color;
   color.handle = 0x108;


### PR DESCRIPTION
Fixes #2780.

Solaris and Illumos define `sun` as a numeric object-like preprocessor macro. It collides with ordinary C++ identifiers such as `DRW_Sun sun`, producing errors like `expected unqualified-id before numeric constant`.

The first revision used a public-header `#undef sun`. After reviewing the Solaris compiler behavior, this PR avoids changing the caller's macro environment and instead renames all standalone `sun` locals, parameters, and the internal summary counter. Method names, DWG/DXF type names, diagnostic text, and test tags are unchanged.

This also avoids depending on compiler-specific `-Usun` or `+p` flags, so the source fix applies consistently to CMake, qmake, GCC, Clang, and Solaris Studio builds.

Verification:
- Repository-wide C++ identifier scan: no standalone `sun` identifiers remain.
- C++17 libdxfrw syntax compilation with `-Dsun=1`.
- C++17 LibreCAD filter syntax compilation with `-Dsun=1`.
- Existing focused DWG suite: 1,917 assertions in 63 test cases.

References:
- Oracle Solaris Studio C++ predefined names: https://docs.oracle.com/cd/E37069_01/html/E37075/bkace.html
- Oracle Solaris Studio C++ `-U` option: https://docs.oracle.com/cd/E37069_01/html/E37075/bkamw.html
