### PR TITLE
Fix tool buttons staying checked when another tool is chosen (2.2.1)

### DIFF
--- a/librecad/src/actions/rs_actiondrawimage.cpp
+++ b/librecad/src/actions/rs_actiondrawimage.cpp
@@ -77,7 +77,7 @@ void RS_ActionDrawImage::init(int status) {
 
         setStatus(SetTargetPoint);
     } else {
-        setFinished();
+        finish();
         //RS_DIALOGFACTORY->requestToolBar(RS2::ToolBarMain);
     }
 }

--- a/librecad/src/actions/rs_actiondrawtext.cpp
+++ b/librecad/src/actions/rs_actiondrawtext.cpp
@@ -69,7 +69,7 @@ void RS_ActionDrawText::init(int status) {
 			showOptions();
 		} else {
 			hideOptions();
-			setFinished();
+			finish();
 		}
 	}
 		break;

--- a/librecad/src/lib/gui/rs_eventhandler.cpp
+++ b/librecad/src/lib/gui/rs_eventhandler.cpp
@@ -24,6 +24,7 @@
 **
 **********************************************************************/
 
+#include <algorithm>
 #include <QRegExp>
 #include <QAction>
 #include <QMouseEvent>
@@ -113,8 +114,6 @@ RS_EventHandler::~RS_EventHandler() {
     defaultAction.reset();
 
     RS_DEBUG->print("RS_EventHandler::~RS_EventHandler: Deleting all actions..");
-    for(const auto& [actionName, qAction]: m_toQAction)
-        qAction->setChecked(false);
     RS_DEBUG->print("RS_EventHandler::~RS_EventHandler: Deleting all actions..: OK");
     RS_DEBUG->print("RS_EventHandler::~RS_EventHandler: OK");
 }
@@ -170,15 +169,6 @@ void RS_EventHandler::mouseReleaseEvent(QMouseEvent* e) {
 
         current->mouseReleaseEvent(e);
 
-        // action may be completed by click. Check this and if it so, uncheck the action
-        if (current->getStatus() < 0){
-            if (m_toQAction.count(current->getName()) == 1) {
-                m_toQAction[current->getName()]->setChecked(false);
-                m_toQAction.erase(current->getName());
-	    }
-	}
-
-
         // Clean up actions - one might be finished now
         cleanUp();
         e->accept();
@@ -230,9 +220,6 @@ void RS_EventHandler::mouseEnterEvent() {
         debugActions();
         LC_LOG<<__func__<<"(): resume: "<<currentActions.last()->getName();
         currentActions.last()->resume();
-        if (m_toQAction.count(currentActions.last()->getName()) == 1) {
-            m_toQAction[currentActions.last()->getName()]->setChecked(true);
-        }
     } else {
         if (defaultAction) {
             defaultAction->resume();
@@ -478,6 +465,22 @@ void RS_EventHandler::setCurrentAction(RS_ActionInterface* action) {
     }
 
     RS_DEBUG->print("RS_EventHandler::setCurrentAction %s", action->getName().toLatin1().data());
+
+    // RS_ActionSelect finishes and starts the modify action once the selection is
+    // done, with its finished helper RS_ActionSelectSingle still on top of the
+    // stack: the modify action inherits the QAction, so the button stays checked
+    // until the whole job is done.
+    if (m_pendingQAction == nullptr) {
+        for (auto it = currentActions.rbegin(); it != currentActions.rend() && (*it)->isFinished(); ++it) {
+            auto found = m_toQAction.find(it->get());
+            if (found != m_toQAction.end() && (*it)->rtti() == RS2::ActionSelect) {
+                m_pendingQAction = found->second;
+                m_toQAction.erase(found);
+                break;
+            }
+        }
+    }
+
     // Predecessor of the new action or NULL:
     auto& predecessor = hasAction() ? currentActions.last() : defaultAction;
     // Suspend current action:
@@ -502,6 +505,10 @@ void RS_EventHandler::setCurrentAction(RS_ActionInterface* action) {
 
     // Set current action:
     currentActions.push_back(std::shared_ptr<RS_ActionInterface>(action));
+    if (m_pendingQAction != nullptr) {
+        m_toQAction[action] = m_pendingQAction;
+        m_pendingQAction = nullptr;
+    }
     //    RS_DEBUG->print("RS_EventHandler::setCurrentAction: current action is: %s -> %s",
     //                    predecessor->getName().toLatin1().data(),
     //                    currentActions.last()->getName().toLatin1().data());
@@ -524,8 +531,8 @@ void RS_EventHandler::setCurrentAction(RS_ActionInterface* action) {
     debugActions();
     RS_DEBUG->print("RS_GraphicView::setCurrentAction: OK");
     // For some actions: action->init() may call finish() within init()
-    // If so, the q_action shouldn't be checked
-
+    // If so, the QAction is released by cleanUp(), which also checks the
+    // QAction of the action which is current now.
 }
 
 
@@ -545,11 +552,13 @@ void RS_EventHandler::killSelectActions() {
             if (isActive(*it)) {
                 (*it)->finish();
             }
+            unlinkQAction(it->get());
             it= currentActions.erase(it);
         }else{
             it++;
         }
     }
+    updateQActions();
 }
 
 
@@ -569,10 +578,11 @@ void RS_EventHandler::killAllActions()
 		}
 	}
     currentActions.clear();
-    for (const auto& [actionName, qAction] : m_toQAction)
+    for (const auto& [action, qAction] : m_toQAction)
         qAction->setChecked(false);
 
     m_toQAction.clear();
+    setQAction(nullptr);
 
     if (!defaultAction->isFinished())
     {
@@ -599,15 +609,14 @@ bool RS_EventHandler::isValid(RS_ActionInterface* action) const{
  */
 bool RS_EventHandler::hasAction()
 {
-    auto it = std::remove_if(currentActions.begin(), currentActions.end(), isInactive);
-    for (auto it1 = it; it1 != currentActions.end(); ++it1) {
-	QString actionName = (*it1)->getName();
-        if (m_toQAction.count(actionName) == 1) {
-            m_toQAction[actionName]->setChecked(false);
-            m_toQAction.erase(actionName);
+    for (const auto& action : currentActions) {
+        if (isInactive(action)) {
+            unlinkQAction(action.get());
         }
     }
+    auto it = std::remove_if(currentActions.begin(), currentActions.end(), isInactive);
     currentActions.erase(it, currentActions.end());
+    updateQActions();
     return !currentActions.empty();
 }
 
@@ -621,9 +630,6 @@ void RS_EventHandler::cleanUp() {
     if(hasAction()){
         currentActions.last()->resume();
         currentActions.last()->showOptions();
-        if (m_toQAction.count(currentActions.last()->getName()) == 1) {
-            m_toQAction[currentActions.last()->getName()]->setChecked(true);
-        }
     } else {
 		if (defaultAction) {
             defaultAction->resume();
@@ -683,16 +689,55 @@ void RS_EventHandler::debugActions() const{
 
 void RS_EventHandler::setQAction(QAction* action)
 {
-    if (action==nullptr)
-        return;
+    // The QAction is triggered before the action handler creates the action,
+    // so the link is established by setCurrentAction()
+    QAction* dropped = m_pendingQAction;
+    m_pendingQAction = action;
+    if (dropped != nullptr && dropped != action) {
+        // no action was started for it: Qt toggled it when it was triggered,
+        // give it and the QAction of the current action the state of the invariant back
+        dropped->setChecked(dropped == currentQAction());
+        updateQActions();
+    }
+}
 
-    LC_ERR<<__func__<<"()"<<action->text() <<" : "<<action->icon().name();
+QAction* RS_EventHandler::currentQAction() const
+{
+    if (m_pendingQAction != nullptr) {
+        // about to be linked to the action started next
+        return m_pendingQAction;
+    }
     for (auto it = currentActions.rbegin(); it != currentActions.rend(); ++it) {
-        if (*it != nullptr && isActive(*it)) {
-    LC_ERR<<__func__<<"(): linked "<< (*it)->getName()<<" to "<<action->text() <<" : "<<action->icon().name();
-            m_toQAction.emplace((*it)->getName(), action);
-            break;
+        auto found = m_toQAction.find(it->get());
+        if (found != m_toQAction.end()) {
+            return found->second;
         }
+    }
+    return nullptr;
+}
+
+void RS_EventHandler::updateQActions()
+{
+    QAction* current = currentQAction();
+    for (const auto& [action, qAction] : m_toQAction) {
+        qAction->setChecked(qAction == current);
+    }
+}
+
+void RS_EventHandler::unlinkQAction(const RS_ActionInterface* action)
+{
+    auto it = m_toQAction.find(action);
+    if (it == m_toQAction.end()) {
+        return;
+    }
+    QAction* qAction = it->second;
+    m_toQAction.erase(it);
+    // the QAction stays checked if it is linked to another action, or if the user
+    // triggered it again and it is about to be linked to the action started next
+    const bool stillLinked = std::any_of(m_toQAction.begin(), m_toQAction.end(),
+                                         [qAction](const auto& link) { return link.second == qAction; });
+    if (!stillLinked && qAction != m_pendingQAction) {
+        qAction->setChecked(false);
     }
 }
 

--- a/librecad/src/lib/gui/rs_eventhandler.cpp
+++ b/librecad/src/lib/gui/rs_eventhandler.cpp
@@ -295,8 +295,7 @@ void RS_EventHandler::commandEvent(RS_CommandEvent* e) {
                 // send command event directly to current action:
                 if (hasAction()) {
                     LC_LOG<<"RS_EventHandler::commandEvent(RS_CommandEvent* e): sending cmd("<<qPrintable(e->getCommand()) <<") to action: "<<currentActions.last()->rtti();
-                    const auto current = currentActions.last();
-                    current->commandEvent(e);
+                    currentActions.last()->commandEvent(e);
                 }
 
             if(hasAction() && !e->isAccepted()){
@@ -311,8 +310,7 @@ void RS_EventHandler::commandEvent(RS_CommandEvent* e) {
                         case ',':
                         {
                             RS_CoordinateEvent ce(at);
-                            const auto current = currentActions.last();
-                            current->coordinateEvent(&ce);
+                            currentActions.last()->coordinateEvent(&ce);
                             e->accept();
                             break;
                         }
@@ -336,8 +334,7 @@ void RS_EventHandler::commandEvent(RS_CommandEvent* e) {
                         RS_DEBUG->print("RS_EventHandler::commandEvent: 005");
                         RS_CoordinateEvent ce(RS_Vector(x,y));
                         RS_DEBUG->print("RS_EventHandler::commandEvent: 006");
-						const auto current = currentActions.last();
-						current->coordinateEvent(&ce);
+						currentActions.last()->coordinateEvent(&ce);
 					} else
 						RS_DIALOGFACTORY->commandMessage(
 									"Expression Syntax Error");
@@ -355,8 +352,7 @@ void RS_EventHandler::commandEvent(RS_CommandEvent* e) {
                         if (ok1 && ok2) {
                             RS_CoordinateEvent ce(RS_Vector(x,y) + relative_zero);
 
-                            const auto current = currentActions.last();
-                            current->coordinateEvent(&ce);
+                            currentActions.last()->coordinateEvent(&ce);
                             //                            currentActions[actionIndex]->coordinateEvent(&ce);
 						} else
 							RS_DIALOGFACTORY->commandMessage(
@@ -377,8 +373,7 @@ void RS_EventHandler::commandEvent(RS_CommandEvent* e) {
 							RS_Vector pos{
 								RS_Vector::polar(r,RS_Math::deg2rad(a))};
                             RS_CoordinateEvent ce(pos);
-                            const auto current = currentActions.last();
-                            current->coordinateEvent(&ce);
+                            currentActions.last()->coordinateEvent(&ce);
 						} else
                                 RS_DIALOGFACTORY->commandMessage(
                                             "Expression Syntax Error");
@@ -397,8 +392,7 @@ void RS_EventHandler::commandEvent(RS_CommandEvent* e) {
 						if (ok1 && ok2) {
 							RS_Vector pos = RS_Vector::polar(r,RS_Math::deg2rad(a));
                             RS_CoordinateEvent ce(pos + relative_zero);
-                            const auto current = currentActions.last();
-                            current->coordinateEvent(&ce);
+                            currentActions.last()->coordinateEvent(&ce);
 						} else
                                 RS_DIALOGFACTORY->commandMessage(
                                             "Expression Syntax Error");
@@ -533,6 +527,8 @@ void RS_EventHandler::setCurrentAction(RS_ActionInterface* action) {
         m_toQAction[action] = m_pendingQAction;
         m_pendingQAction = nullptr;
     }
+    // check the QAction of the new action, release the one of the suspended action
+    updateQActions();
     //    RS_DEBUG->print("RS_EventHandler::setCurrentAction: current action is: %s -> %s",
     //                    predecessor->getName().toLatin1().data(),
     //                    currentActions.last()->getName().toLatin1().data());
@@ -602,13 +598,7 @@ void RS_EventHandler::killAllActions()
 		}
 	}
     currentActions.clear();
-    if (m_qActionStateActive) {
-        for (const auto& link : m_toQAction)
-            link.second->setChecked(false);
-        if (m_pendingQAction != nullptr)
-            m_pendingQAction->setChecked(false);
-    }
-
+    uncheckLinkedQActions();
     m_toQAction.clear();
     m_pendingQAction = nullptr;
 
@@ -644,7 +634,6 @@ bool RS_EventHandler::hasAction()
     }
     auto it = std::remove_if(currentActions.begin(), currentActions.end(), isInactive);
     currentActions.erase(it, currentActions.end());
-    updateQActions();
     return !currentActions.empty();
 }
 
@@ -723,7 +712,10 @@ void RS_EventHandler::debugActions() const{
 void RS_EventHandler::setQAction(QAction* action)
 {
     // The QAction is triggered before the action handler creates the action,
-    // so the link is established by setCurrentAction()
+    // so the link is established by setCurrentAction(). This relies on
+    // QActionGroup::triggered() (relayed here by QC_ApplicationWindow::relayAction())
+    // being delivered before the QAction's own triggered() slot in QG_ActionHandler,
+    // see the note in LC_ActionGroupManager.
     QAction* dropped = m_pendingQAction;
     m_pendingQAction = action;
     if (m_qActionStateActive && dropped != nullptr && dropped != action) {
@@ -764,17 +756,24 @@ void RS_EventHandler::updateQActions()
     }
 }
 
+void RS_EventHandler::uncheckLinkedQActions()
+{
+    if (!m_qActionStateActive) {
+        return;
+    }
+    for (const auto& link : m_toQAction) {
+        link.second->setChecked(false);
+    }
+    if (m_pendingQAction != nullptr) {
+        m_pendingQAction->setChecked(false);
+    }
+}
+
 void RS_EventHandler::setQActionStateActive(bool active)
 {
-    if (!active && m_qActionStateActive) {
-        for (const auto& link : m_toQAction) {
-            link.second->setChecked(false);
-        }
-        if (m_pendingQAction != nullptr) {
-            m_pendingQAction->setChecked(false);
-        }
+    if (!active) {
+        uncheckLinkedQActions();
     }
-
     m_qActionStateActive = active;
     updateQActions();
 }

--- a/librecad/src/lib/gui/rs_eventhandler.cpp
+++ b/librecad/src/lib/gui/rs_eventhandler.cpp
@@ -111,6 +111,7 @@ RS_EventHandler::RS_EventHandler(QObject* parent) : QObject(parent)
  */
 RS_EventHandler::~RS_EventHandler() {
     RS_DEBUG->print("RS_EventHandler::~RS_EventHandler");
+    setQActionStateActive(false);
     defaultAction.reset();
 
     RS_DEBUG->print("RS_EventHandler::~RS_EventHandler: Deleting all actions..");
@@ -144,7 +145,8 @@ void RS_EventHandler::enter() {
  */
 void RS_EventHandler::mousePressEvent(QMouseEvent* e) {
     if(hasAction()){
-        currentActions.last()->mousePressEvent(e);
+        const auto actions = currentActions;
+        actions.last()->mousePressEvent(e);
         e->accept();
     } else {
         if (defaultAction) {
@@ -164,7 +166,8 @@ void RS_EventHandler::mousePressEvent(QMouseEvent* e) {
  */
 void RS_EventHandler::mouseReleaseEvent(QMouseEvent* e) {
     if (hasAction()) {
-        std::shared_ptr<RS_ActionInterface> current = currentActions.last();
+        const auto actions = currentActions;
+        const auto& current = actions.last();
         LC_LOG<< "call action "<< current->getName();
 
         current->mouseReleaseEvent(e);
@@ -186,8 +189,11 @@ void RS_EventHandler::mouseReleaseEvent(QMouseEvent* e) {
  */
 void RS_EventHandler::mouseMoveEvent(QMouseEvent* e)
 {
-    if(hasAction())
-        currentActions.last()->mouseMoveEvent(e);
+    if(hasAction()) {
+        const auto actions = currentActions;
+        actions.last()->mouseMoveEvent(e);
+        cleanUp();
+    }
 
     else if (defaultAction)
         defaultAction->mouseMoveEvent(e);
@@ -235,7 +241,9 @@ void RS_EventHandler::mouseEnterEvent() {
 void RS_EventHandler::keyPressEvent(QKeyEvent* e) {
 
     if(hasAction()){
-        currentActions.last()->keyPressEvent(e);
+        const auto actions = currentActions;
+        actions.last()->keyPressEvent(e);
+        cleanUp();
     } else {
         if (defaultAction) {
             defaultAction->keyPressEvent(e);
@@ -256,7 +264,9 @@ void RS_EventHandler::keyPressEvent(QKeyEvent* e) {
 void RS_EventHandler::keyReleaseEvent(QKeyEvent* e) {
 
     if(hasAction()){
-        currentActions.last()->keyReleaseEvent(e);
+        const auto actions = currentActions;
+        actions.last()->keyReleaseEvent(e);
+        cleanUp();
     } else {
         if (defaultAction) {
             defaultAction->keyReleaseEvent(e);
@@ -274,6 +284,10 @@ void RS_EventHandler::keyReleaseEvent(QKeyEvent* e) {
 void RS_EventHandler::commandEvent(RS_CommandEvent* e) {
     RS_DEBUG->print("RS_EventHandler::commandEvent");
     QString cmd = e->getCommand();
+    // Actions may replace themselves while handling a command. Keep the old
+    // stack alive until all nested callbacks have returned.
+    const auto actionGuards = currentActions;
+    Q_UNUSED(actionGuards)
 
     if (coordinateInputEnabled) {
         if (!e->isAccepted()) {
@@ -281,7 +295,8 @@ void RS_EventHandler::commandEvent(RS_CommandEvent* e) {
                 // send command event directly to current action:
                 if (hasAction()) {
                     LC_LOG<<"RS_EventHandler::commandEvent(RS_CommandEvent* e): sending cmd("<<qPrintable(e->getCommand()) <<") to action: "<<currentActions.last()->rtti();
-                    currentActions.last()->commandEvent(e);
+                    const auto current = currentActions.last();
+                    current->commandEvent(e);
                 }
 
             if(hasAction() && !e->isAccepted()){
@@ -296,7 +311,8 @@ void RS_EventHandler::commandEvent(RS_CommandEvent* e) {
                         case ',':
                         {
                             RS_CoordinateEvent ce(at);
-                            currentActions.last()->coordinateEvent(&ce);
+                            const auto current = currentActions.last();
+                            current->coordinateEvent(&ce);
                             e->accept();
                             break;
                         }
@@ -320,7 +336,8 @@ void RS_EventHandler::commandEvent(RS_CommandEvent* e) {
                         RS_DEBUG->print("RS_EventHandler::commandEvent: 005");
                         RS_CoordinateEvent ce(RS_Vector(x,y));
                         RS_DEBUG->print("RS_EventHandler::commandEvent: 006");
-						currentActions.last()->coordinateEvent(&ce);
+						const auto current = currentActions.last();
+						current->coordinateEvent(&ce);
 					} else
 						RS_DIALOGFACTORY->commandMessage(
 									"Expression Syntax Error");
@@ -338,7 +355,8 @@ void RS_EventHandler::commandEvent(RS_CommandEvent* e) {
                         if (ok1 && ok2) {
                             RS_CoordinateEvent ce(RS_Vector(x,y) + relative_zero);
 
-                            currentActions.last()->coordinateEvent(&ce);
+                            const auto current = currentActions.last();
+                            current->coordinateEvent(&ce);
                             //                            currentActions[actionIndex]->coordinateEvent(&ce);
 						} else
 							RS_DIALOGFACTORY->commandMessage(
@@ -359,7 +377,8 @@ void RS_EventHandler::commandEvent(RS_CommandEvent* e) {
 							RS_Vector pos{
 								RS_Vector::polar(r,RS_Math::deg2rad(a))};
                             RS_CoordinateEvent ce(pos);
-                            currentActions.last()->coordinateEvent(&ce);
+                            const auto current = currentActions.last();
+                            current->coordinateEvent(&ce);
 						} else
                                 RS_DIALOGFACTORY->commandMessage(
                                             "Expression Syntax Error");
@@ -375,10 +394,11 @@ void RS_EventHandler::commandEvent(RS_CommandEvent* e) {
                         double r = RS_Math::eval(updateForFraction(cmd.mid(1, commaPos-1)), &ok1);
                         double a = RS_Math::eval(cmd.mid(commaPos+1), &ok2);
 
-                        if (ok1 && ok2) {
+						if (ok1 && ok2) {
 							RS_Vector pos = RS_Vector::polar(r,RS_Math::deg2rad(a));
                             RS_CoordinateEvent ce(pos + relative_zero);
-                            currentActions.last()->coordinateEvent(&ce);
+                            const auto current = currentActions.last();
+                            current->coordinateEvent(&ce);
 						} else
                                 RS_DIALOGFACTORY->commandMessage(
                                             "Expression Syntax Error");
@@ -394,6 +414,8 @@ void RS_EventHandler::commandEvent(RS_CommandEvent* e) {
             }
         }
     }
+
+    cleanUp();
 
     RS_DEBUG->print("RS_EventHandler::commandEvent: OK");
 }
@@ -482,7 +504,8 @@ void RS_EventHandler::setCurrentAction(RS_ActionInterface* action) {
     }
 
     // Predecessor of the new action or NULL:
-    auto& predecessor = hasAction() ? currentActions.last() : defaultAction;
+    const std::shared_ptr<RS_ActionInterface> predecessor =
+            hasAction() ? currentActions.last() : defaultAction;
     // Suspend current action:
     predecessor->suspend();
     predecessor->hideOptions();
@@ -504,7 +527,8 @@ void RS_EventHandler::setCurrentAction(RS_ActionInterface* action) {
     //    }
 
     // Set current action:
-    currentActions.push_back(std::shared_ptr<RS_ActionInterface>(action));
+    const auto currentAction = std::shared_ptr<RS_ActionInterface>(action);
+    currentActions.push_back(currentAction);
     if (m_pendingQAction != nullptr) {
         m_toQAction[action] = m_pendingQAction;
         m_pendingQAction = nullptr;
@@ -515,13 +539,13 @@ void RS_EventHandler::setCurrentAction(RS_ActionInterface* action) {
 
     // Initialisation of our new action:
     RS_DEBUG->print("RS_EventHandler::setCurrentAction: init current action");
-    action->init();
+    currentAction->init();
     // ## new:
-    if (!action->isFinished()) {
+    if (!currentAction->isFinished()) {
         RS_DEBUG->print("RS_EventHandler::setCurrentAction: show options");
-        action->showOptions();
+        currentAction->showOptions();
         RS_DEBUG->print("RS_EventHandler::setCurrentAction: set predecessor");
-        action->setPredecessor(predecessor.get());
+        currentAction->setPredecessor(predecessor.get());
     }
 
     RS_DEBUG->print("RS_EventHandler::setCurrentAction: cleaning up..");
@@ -578,11 +602,15 @@ void RS_EventHandler::killAllActions()
 		}
 	}
     currentActions.clear();
-    for (const auto& [action, qAction] : m_toQAction)
-        qAction->setChecked(false);
+    if (m_qActionStateActive) {
+        for (const auto& link : m_toQAction)
+            link.second->setChecked(false);
+        if (m_pendingQAction != nullptr)
+            m_pendingQAction->setChecked(false);
+    }
 
     m_toQAction.clear();
-    setQAction(nullptr);
+    m_pendingQAction = nullptr;
 
     if (!defaultAction->isFinished())
     {
@@ -693,7 +721,7 @@ void RS_EventHandler::setQAction(QAction* action)
     // so the link is established by setCurrentAction()
     QAction* dropped = m_pendingQAction;
     m_pendingQAction = action;
-    if (dropped != nullptr && dropped != action) {
+    if (m_qActionStateActive && dropped != nullptr && dropped != action) {
         // no action was started for it: Qt toggled it when it was triggered,
         // give it and the QAction of the current action the state of the invariant back
         dropped->setChecked(dropped == currentQAction());
@@ -718,10 +746,32 @@ QAction* RS_EventHandler::currentQAction() const
 
 void RS_EventHandler::updateQActions()
 {
-    QAction* current = currentQAction();
-    for (const auto& [action, qAction] : m_toQAction) {
-        qAction->setChecked(qAction == current);
+    if (!m_qActionStateActive) {
+        return;
     }
+
+    QAction* current = currentQAction();
+    if (current != nullptr) {
+        current->setChecked(true);
+    }
+    for (const auto& link : m_toQAction) {
+        link.second->setChecked(link.second == current);
+    }
+}
+
+void RS_EventHandler::setQActionStateActive(bool active)
+{
+    if (!active && m_qActionStateActive) {
+        for (const auto& link : m_toQAction) {
+            link.second->setChecked(false);
+        }
+        if (m_pendingQAction != nullptr) {
+            m_pendingQAction->setChecked(false);
+        }
+    }
+
+    m_qActionStateActive = active;
+    updateQActions();
 }
 
 void RS_EventHandler::unlinkQAction(const RS_ActionInterface* action)
@@ -736,9 +786,10 @@ void RS_EventHandler::unlinkQAction(const RS_ActionInterface* action)
     // triggered it again and it is about to be linked to the action started next
     const bool stillLinked = std::any_of(m_toQAction.begin(), m_toQAction.end(),
                                          [qAction](const auto& link) { return link.second == qAction; });
-    if (!stillLinked && qAction != m_pendingQAction) {
+    if (m_qActionStateActive && !stillLinked && qAction != m_pendingQAction) {
         qAction->setChecked(false);
     }
+    updateQActions();
 }
 
 void RS_EventHandler::setRelativeZero(const RS_Vector& point)

--- a/librecad/src/lib/gui/rs_eventhandler.cpp
+++ b/librecad/src/lib/gui/rs_eventhandler.cpp
@@ -655,11 +655,16 @@ bool RS_EventHandler::hasAction()
 void RS_EventHandler::cleanUp() {
     RS_DEBUG->print("RS_EventHandler::cleanUp");
 
-    if(hasAction()){
-        currentActions.last()->resume();
-        currentActions.last()->showOptions();
-    } else {
-		if (defaultAction) {
+    const std::shared_ptr<RS_ActionInterface> previous = currentActions.empty()
+            ? nullptr : currentActions.last();
+    RS_ActionInterface* current = hasAction()
+            ? currentActions.last().get() : nullptr;
+
+    if (current != previous.get()) {
+        if (current != nullptr) {
+            current->resume();
+            current->showOptions();
+        } else if (defaultAction) {
             defaultAction->resume();
             defaultAction->showOptions();
         }

--- a/librecad/src/lib/gui/rs_eventhandler.h
+++ b/librecad/src/lib/gui/rs_eventhandler.h
@@ -117,6 +117,8 @@ private:
     void updateQActions();
     //! unlink the QAction of an action which is removed from the stack; uncheck it unless another action or the pending link still holds it
     void unlinkQAction(const RS_ActionInterface* action);
+    //! uncheck every linked QAction and the pending one, if this is the active handler
+    void uncheckLinkedQActions();
 
     //! QAction triggered by the user, waiting for its action to be started by setCurrentAction()
     QAction* m_pendingQAction{nullptr};

--- a/librecad/src/lib/gui/rs_eventhandler.h
+++ b/librecad/src/lib/gui/rs_eventhandler.h
@@ -39,7 +39,6 @@ class RS_ActionInterface;
 class QAction;
 class QMouseEvent;
 class QKeyEvent;
-class QString;
 
 class RS_CommandEvent;
 class RS_Vector;
@@ -59,6 +58,19 @@ public:
     RS_EventHandler(QObject* parent = nullptr);
     ~RS_EventHandler();
 
+    /**
+     * Remember the QAction (toolbar button or menu entry) triggered by the user.
+     * The QAction is linked to the action started next by setCurrentAction().
+     *
+     * Only one QAction is checked (per graphic view, the QActions are shared by
+     * all drawing windows): the one of the topmost action on the stack which
+     * was started from a QAction. Helper actions started by an action (e.g.
+     * RS_ActionSelectSingle) and actions started from the command line run on
+     * top of it without changing it. RS_ActionSelect, which finishes and starts
+     * the modify action once the selection is done, passes its QAction on.
+     * The QAction is released when its action is removed from the stack, and
+     * a QAction for which no action is started gets its state back.
+     */
     void setQAction(QAction* action);
 
     void back();
@@ -97,11 +109,19 @@ public:
     bool inSelectionMode();
 
 private:
+    //! the pending QAction if one is set, else the QAction of the topmost action on the stack which has one, or nullptr
+    QAction* currentQAction() const;
+    //! check the current QAction, uncheck all others
+    void updateQActions();
+    //! unlink the QAction of an action which is removed from the stack; uncheck it unless another action or the pending link still holds it
+    void unlinkQAction(const RS_ActionInterface* action);
 
-	QAction* q_action{nullptr};
+    //! QAction triggered by the user, waiting for its action to be started by setCurrentAction()
+    QAction* m_pendingQAction{nullptr};
     std::shared_ptr<RS_ActionInterface> defaultAction{nullptr};
     QList<std::shared_ptr<RS_ActionInterface>> currentActions;
-    std::map<QString, QAction*> m_toQAction;
+    //! actions started by the user from a QAction, and their QAction
+    std::map<const RS_ActionInterface*, QAction*> m_toQAction;
 	bool coordinateInputEnabled{true};
     RS_Vector relative_zero;
 

--- a/librecad/src/lib/gui/rs_eventhandler.h
+++ b/librecad/src/lib/gui/rs_eventhandler.h
@@ -62,9 +62,9 @@ public:
      * Remember the QAction (toolbar button or menu entry) triggered by the user.
      * The QAction is linked to the action started next by setCurrentAction().
      *
-     * Only one QAction is checked (per graphic view, the QActions are shared by
-     * all drawing windows): the one of the topmost action on the stack which
-     * was started from a QAction. Helper actions started by an action (e.g.
+     * Only the active graphic view updates the shared QActions. Its checked
+     * QAction belongs to the topmost action which was started from one.
+     * Helper actions started by an action (e.g.
      * RS_ActionSelectSingle) and actions started from the command line run on
      * top of it without changing it. RS_ActionSelect, which finishes and starts
      * the modify action once the selection is done, passes its QAction on.
@@ -72,6 +72,8 @@ public:
      * a QAction for which no action is started gets its state back.
      */
     void setQAction(QAction* action);
+    //! Enable shared QAction updates while this is the active drawing handler.
+    void setQActionStateActive(bool active);
 
     void back();
     void enter();
@@ -118,6 +120,8 @@ private:
 
     //! QAction triggered by the user, waiting for its action to be started by setCurrentAction()
     QAction* m_pendingQAction{nullptr};
+    //! Only the active drawing may update application-wide QActions.
+    bool m_qActionStateActive{false};
     std::shared_ptr<RS_ActionInterface> defaultAction{nullptr};
     QList<std::shared_ptr<RS_ActionInterface>> currentActions;
     //! actions started by the user from a QAction, and their QAction

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -3265,7 +3265,14 @@ void QC_ApplicationWindow::relayAction(QAction* q_action)
         return;
     }
 
-    view->setCurrentQAction(q_action);
+    // QActions which are used in the middle of other actions (e.g. "Set relative zero")
+    // or don't start an action at all ("Lock relative zero") must not be handled as
+    // the current action of the view, otherwise the action in progress would lose
+    // its button, or the toggle would be released with the action, see issue #2012
+    const QVariant setAsCurrentAction = q_action->property("_SetAsCurrentActionInView");
+    if (!setAsCurrentAction.isValid() || setAsCurrentAction.toBool()) {
+        view->setCurrentQAction(q_action);
+    }
 
     const QString commands(q_action->data().toString());
     if (!commands.isEmpty())

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -1153,7 +1153,9 @@ void QC_ApplicationWindow::slotWindowActivated(QMdiSubWindow* w, bool forced)
     }
     if (m && m->getGraphicView()) {
         QG_GraphicView* view = m->getGraphicView();
-        view->getEventHandler()->setQActionStateActive(!view->isPrintPreview());
+        // The active window owns the shared QActions, a print preview included:
+        // its handler releases the zoom buttons it links like any other window.
+        view->getEventHandler()->setQActionStateActive(true);
         if (view->getCurrentAction()) {
             view->getCurrentAction()->showOptions();
         }
@@ -3290,7 +3292,7 @@ void QC_ApplicationWindow::relayAction(QAction* q_action)
     view->addRecentAction(q_action);
     const QVariant setAsCurrentAction = q_action->property("_SetAsCurrentActionInView");
     if (!setAsCurrentAction.isValid() || setAsCurrentAction.toBool()) {
-        view->setCurrentQAction(q_action);
+        view->getEventHandler()->setQAction(q_action);
     }
 
     const QString commands(q_action->data().toString());

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -66,6 +66,7 @@
 #include "rs_debug.h"
 #include "rs_dialogfactory.h"
 #include "rs_document.h"
+#include "rs_eventhandler.h"
 #include "rs_painterqt.h"
 #include "rs_pen.h"
 #include "rs_settings.h"
@@ -1054,6 +1055,11 @@ void QC_ApplicationWindow::slotWindowActivated(QMdiSubWindow* w, bool forced)
     RS_DEBUG->print("QC_ApplicationWindow::slotWindowActivated begin");
 
     if(w==nullptr) {
+        foreach (QMdiSubWindow* subWindow, mdiAreaCAD->subWindowList()) {
+            if (auto* mdiWindow = qobject_cast<QC_MDIWindow*>(subWindow)) {
+                mdiWindow->getEventHandler()->setQActionStateActive(false);
+            }
+        }
         emit windowsChanged(false);
         activedMdiSubWindow=w;
         return;
@@ -1138,17 +1144,24 @@ void QC_ApplicationWindow::slotWindowActivated(QMdiSubWindow* w, bool forced)
     // show action options for active window only
     foreach (QMdiSubWindow* sw, mdiAreaCAD->subWindowList()) {
         QC_MDIWindow* sm = qobject_cast<QC_MDIWindow*>(sw);
+        sm->getEventHandler()->setQActionStateActive(false);
         RS_ActionInterface* ai = sm->getGraphicView()->getCurrentAction();
         if (ai) {
             ai->hideOptions();
         }
     }
-    if (m && m->getGraphicView()->getCurrentAction()) {
-        m->getGraphicView()->getCurrentAction()->showOptions();
+    if (m && m->getGraphicView()) {
+        QG_GraphicView* view = m->getGraphicView();
+        view->getEventHandler()->setQActionStateActive(!view->isPrintPreview());
+        if (view->getCurrentAction()) {
+            view->getCurrentAction()->showOptions();
+        }
     }
 
     // Disable/Enable menu and toolbar items
     emit windowsChanged(m && m->getDocument());
+    ag_manager->toggleTools(m && m->getGraphicView()
+                            && m->getGraphicView()->isPrintPreview());
 
     RS_DEBUG->print("RVT_PORT emit windowsChanged(true);");
 
@@ -3257,11 +3270,15 @@ void QC_ApplicationWindow::relayAction(QAction* q_action)
 {
     // author: ravas
 
-    auto view = getMDIWindow()->getGraphicView();
-    if (!view)
+    auto window = getMDIWindow();
+    auto view = window ? window->getGraphicView() : nullptr;
+    if (!view || !q_action)
     {   // when switching back to LibreCAD from another program
         // occasionally no drawings are activated
-        qWarning("relayAction: graphicView is nullptr");
+        if (q_action != nullptr) {
+            q_action->setChecked(false);
+        }
+        qWarning("relayAction: graphicView or QAction is nullptr");
         return;
     }
 
@@ -3269,6 +3286,7 @@ void QC_ApplicationWindow::relayAction(QAction* q_action)
     // or don't start an action at all ("Lock relative zero") must not be handled as
     // the current action of the view, otherwise the action in progress would lose
     // its button, or the toggle would be released with the action, see issue #2012
+    view->addRecentAction(q_action);
     const QVariant setAsCurrentAction = q_action->property("_SetAsCurrentActionInView");
     if (!setAsCurrentAction.isValid() || setAsCurrentAction.toBool()) {
         view->setCurrentQAction(q_action);

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -1135,6 +1135,7 @@ void QC_ApplicationWindow::slotWindowActivated(QMdiSubWindow* w, bool forced)
         }
 
         if(snapToolBar){
+            snapToolBar->setLockedRelativeZero(view && view->isRelativeZeroLocked());
             actionHandler->slotSetSnaps(snapToolBar->getSnaps());
         }else {
             RS_DEBUG->print(RS_Debug::D_ERROR,"snapToolBar is nullptr\n");

--- a/librecad/src/ui/forms/qg_snaptoolbar.cpp
+++ b/librecad/src/ui/forms/qg_snaptoolbar.cpp
@@ -130,12 +130,16 @@ QG_SnapToolBar::QG_SnapToolBar(QWidget* parent, QG_ActionHandler* ah, LC_ActionG
     bRelZero = new QAction(QIcon(":/icons/set_rel_zero.svg"), tr("Set relative zero position"), agm->other);
     bRelZero->setObjectName("SetRelativeZero");
     bRelZero->setCheckable(false);
+    // used in the middle of other actions: keep the action in progress as the current one
+    bRelZero->setProperty("_SetAsCurrentActionInView", false);
     connect(bRelZero, SIGNAL(triggered()), actionHandler, SLOT(slotSetRelativeZero()));
     //connect(bRelZero, SIGNAL(triggered()), this, SLOT(slotSetRelativeZero()));
     this->addAction(bRelZero);
     bLockRelZero = new QAction(QIcon(":/icons/lock_rel_zero.svg"), tr("Lock relative zero position"), agm->other);
     bLockRelZero->setObjectName("LockRelativeZero");
     bLockRelZero->setCheckable(true);
+    // a toggle, not an action: its checked state must not depend on the current action (issue #2012)
+    bLockRelZero->setProperty("_SetAsCurrentActionInView", false);
     connect(bLockRelZero, SIGNAL(triggered(bool)),actionHandler, SLOT(slotLockRelativeZero(bool)));
     this->addAction(bLockRelZero);
     //restore snapMode from saved preferences

--- a/librecad/src/ui/lc_actionfactory.cpp
+++ b/librecad/src/ui/lc_actionfactory.cpp
@@ -53,6 +53,7 @@ void LC_ActionFactory::fillActionContainer(QMap<QString, QAction*>& a_map, LC_Ac
 
     action = new QAction(tr("Zoom &Panning"), agm->other);
     action->setIcon(QIcon(":/icons/zoom_pan.svg"));
+    action->setProperty("_EnabledInPrintPreview", true);
     connect(action, SIGNAL(triggered()),
     action_handler, SLOT(slotZoomPan()));
     action->setObjectName("ZoomPan");
@@ -1527,6 +1528,7 @@ void LC_ActionFactory::commonActions(QMap<QString, QAction*>& a_map, LC_ActionGr
 
     action = new QAction(tr("&Window Zoom"), agm->other);
     action->setCheckable(true);
+    action->setProperty("_EnabledInPrintPreview", true);
     if (using_theme)
         action->setIcon(QIcon::fromTheme("zoom-select", QIcon(":/icons/zoom_window.svg")));
     else

--- a/librecad/src/ui/lc_actiongroupmanager.cpp
+++ b/librecad/src/ui/lc_actiongroupmanager.cpp
@@ -171,7 +171,9 @@ void LC_ActionGroupManager::toggleTools(bool state)
     {
         foreach(auto action, group->actions())
         {
-            action->setDisabled(state);
+            const bool enabledInPrintPreview =
+                    action->property("_EnabledInPrintPreview").toBool();
+            action->setDisabled(state && !enabledInPrintPreview);
         }
     }
 }

--- a/librecad/src/ui/lc_actiongroupmanager.cpp
+++ b/librecad/src/ui/lc_actiongroupmanager.cpp
@@ -92,6 +92,13 @@ LC_ActionGroupManager::LC_ActionGroupManager(QC_ApplicationWindow *parent)
     }
 
 
+    // relayAction() hands the triggered QAction to the graphic view's event handler,
+    // which links it to the action started next by the QAction's own slot in
+    // QG_ActionHandler. This requires the group's triggered() to be delivered
+    // first: it is, because every tool QAction is created with its group as parent
+    // (QActionGroup connects to the QAction in its constructor, before
+    // LC_ActionFactory connects the slot). Do not add QActions to these groups
+    // with QActionGroup::addAction() after their slot has been connected.
     foreach (auto const& ag, toolGroups()) {
         connect( ag, &QActionGroup::triggered, parent, &QC_ApplicationWindow::relayAction);
     }

--- a/librecad/src/ui/qg_actionhandler.cpp
+++ b/librecad/src/ui/qg_actionhandler.cpp
@@ -254,23 +254,11 @@ RS_ActionInterface* QG_ActionHandler::setCurrentAction(RS2::ActionType id) {
         RS_DEBUG->print(RS_Debug::D_WARNING,
                 "QG_ActionHandler::setCurrentAction: graphic view or "
                 "document is nullptr");
-        return nullptr;
-    }
-
-    if (view->isPrintPreview()) {
-        switch (id) {
-        case RS2::ActionZoomIn:
-        case RS2::ActionZoomOut:
-        case RS2::ActionZoomAuto:
-        case RS2::ActionZoomWindow:
-        case RS2::ActionZoomPan:
-        case RS2::ActionZoomPrevious:
-        case RS2::ActionZoomRedraw:
-            break;
-        default:
+        if (view != nullptr) {
+            // no action is started: release the QAction the user triggered
             view->getEventHandler()->setQAction(nullptr);
-            return nullptr;
         }
+        return nullptr;
     }
 
     auto a_layer = (document->getLayerList() != nullptr) ? document->getLayerList()->getActive() : nullptr;

--- a/librecad/src/ui/qg_actionhandler.cpp
+++ b/librecad/src/ui/qg_actionhandler.cpp
@@ -257,6 +257,22 @@ RS_ActionInterface* QG_ActionHandler::setCurrentAction(RS2::ActionType id) {
         return nullptr;
     }
 
+    if (view->isPrintPreview()) {
+        switch (id) {
+        case RS2::ActionZoomIn:
+        case RS2::ActionZoomOut:
+        case RS2::ActionZoomAuto:
+        case RS2::ActionZoomWindow:
+        case RS2::ActionZoomPan:
+        case RS2::ActionZoomPrevious:
+        case RS2::ActionZoomRedraw:
+            break;
+        default:
+            view->getEventHandler()->setQAction(nullptr);
+            return nullptr;
+        }
+    }
+
     auto a_layer = (document->getLayerList() != nullptr) ? document->getLayerList()->getActive() : nullptr;
 
     switch (id) {
@@ -2229,4 +2245,3 @@ void QG_ActionHandler::slotDrawLinePoints(){
     setCurrentAction(RS2::ActionDrawLinePoints);
 }
 // EOF
-

--- a/librecad/src/ui/qg_actionhandler.cpp
+++ b/librecad/src/ui/qg_actionhandler.cpp
@@ -176,6 +176,7 @@
 #include "qg_snaptoolbar.h"
 #include "rs_debug.h"
 #include "rs_graphicview.h"
+#include "rs_eventhandler.h"
 #include "rs_layer.h"
 #include "rs_settings.h"
 #include "lc_actionpenpick.h"
@@ -1074,6 +1075,10 @@ RS_ActionInterface* QG_ActionHandler::setCurrentAction(RS2::ActionType id) {
 
 	if (a) {
         view->setCurrentAction(a);
+    } else {
+        // no action started (e.g. the tool is the current one already): the QAction
+        // the user triggered must not be linked to another action
+        view->getEventHandler()->setQAction(nullptr);
     }
 
     RS_DEBUG->print("QG_ActionHandler::setCurrentAction(): OK");

--- a/librecad/src/ui/qg_graphicview.cpp
+++ b/librecad/src/ui/qg_graphicview.cpp
@@ -1270,11 +1270,6 @@ void QG_GraphicView::setCursorHiding(bool state)
     cursor_hiding = state;
 }
 
-void QG_GraphicView::setCurrentQAction(QAction* q_action)
-{
-    eventHandler->setQAction(q_action);
-}
-
 void QG_GraphicView::addRecentAction(QAction* q_action)
 {
     if (recent_actions.contains(q_action))

--- a/librecad/src/ui/qg_graphicview.cpp
+++ b/librecad/src/ui/qg_graphicview.cpp
@@ -1272,7 +1272,7 @@ void QG_GraphicView::setCursorHiding(bool state)
 
 void QG_GraphicView::setCurrentQAction(QAction* q_action)
 {
-    //eventHandler->setQAction(q_action);
+    eventHandler->setQAction(q_action);
 
     if (recent_actions.contains(q_action))
     {

--- a/librecad/src/ui/qg_graphicview.cpp
+++ b/librecad/src/ui/qg_graphicview.cpp
@@ -1273,7 +1273,10 @@ void QG_GraphicView::setCursorHiding(bool state)
 void QG_GraphicView::setCurrentQAction(QAction* q_action)
 {
     eventHandler->setQAction(q_action);
+}
 
+void QG_GraphicView::addRecentAction(QAction* q_action)
+{
     if (recent_actions.contains(q_action))
     {
         recent_actions.removeOne(q_action);

--- a/librecad/src/ui/qg_graphicview.h
+++ b/librecad/src/ui/qg_graphicview.h
@@ -96,7 +96,6 @@ public:
     void addScrollbars();
     bool hasScrollbars();
 
-    void setCurrentQAction(QAction* q_action);
     void addRecentAction(QAction* q_action);
 
     QString device;

--- a/librecad/src/ui/qg_graphicview.h
+++ b/librecad/src/ui/qg_graphicview.h
@@ -97,6 +97,7 @@ public:
     bool hasScrollbars();
 
     void setCurrentQAction(QAction* q_action);
+    void addRecentAction(QAction* q_action);
 
     QString device;
 


### PR DESCRIPTION
### The bug

Since 2.2.1.1, checkable drawing-tool buttons and menu entries can remain highlighted after another tool is chosen or the action finishes. This becomes especially misleading after nested selection actions, when switching drawings, or when moving through print preview.

### Root cause

Commit `e0f5dd6b` disabled the link from a tool `QAction` to the `RS_ActionInterface` it starts. Restoring that link also requires respecting Qt signal order: `QActionGroup::triggered(QAction*)` reaches `relayAction()` before the individual action slot creates the LibreCAD action.

The QActions are application-wide, while action stacks and relative-zero lock state belong to individual graphic views. Cleanup can also run inside nested callbacks, so callback lifetimes and action-stack transitions must be handled explicitly.

### The fix

- Keep a triggered `QAction` pending until `setCurrentAction()` creates the corresponding action, and map by action instance rather than action name.
- Check only the topmost mapped action for the active drawing. Switching drawings clears the previous shared presentation and restores the active drawing tool without canceling either drawing action stack.
- Preserve tool ownership through helper actions. A selection-to-modify hand-off transfers the original QAction; helper, command-line, and relative-zero actions do not steal it.
- Keep the action stack alive while mouse, keyboard, and command callbacks run, and clean finished actions after keyboard, coordinate, and pointer input.
- Resume an underlying action only when cleanup actually removes the stack top, avoiding redundant preview redraws on ordinary mouse moves.
- Use the full `finish()` path when the Text or Image dialog is canceled.
- Disable the drawing-tool buttons in print preview while keeping Zoom Pan and Window Zoom available. The preview window tracks the QActions it starts like any other active window, so the zoom buttons are released when their action ends; the layer, edit and drawing-preferences actions keep working in the preview.
- Synchronize the relative-zero lock button from the active view so each drawing retains its own lock state.
- Safely handle a missing active window. Relative-zero actions remain available in recent actions without taking ownership of the current tool button.

### Verification

- Full CMake build passed on macOS arm64 with Qt 5, DWG support, and `RelWithDebInfo`.
- All changed translation units compile through qmake5 with C++17.
- The built application launched successfully.
- Live two-drawing checks confirmed that independent Line/Circle actions and relative-zero lock states follow their owning drawings across repeated activation.
- Live print-preview checks confirmed that drawing actions are disabled, Zoom Pan and Window Zoom remain enabled, and the parent drawing action state is restored after leaving preview.
- Source checks found no remaining Text/Image caller of the incomplete `setFinished()` path.
- The original branch evidence exercises 51 checks across 16 single-window tool, helper-action, selection, zoom, and relative-zero scenarios.
- Review follow-up: the action-handler gate that rejected every non-zoom action in print preview was removed after a code review found it also blocked Current Drawing Preferences, layer operations, undo/redo and the block-widget buttons while their controls stayed enabled; the preview handler now releases its zoom buttons; the QAction state update was moved off the per-event `hasAction()` path. Full CMake Qt 5 build passed after the change.

Detailed harness output and screenshots are on the contributor [test-evidence branch](https://github.com/ROMPEFUEGOS/LibreCAD/tree/pr-assets-tool-buttons/test-results).

![Line tool state before and after the fix](https://raw.githubusercontent.com/ROMPEFUEGOS/LibreCAD/pr-assets-tool-buttons/S1_baseline_vs_fix.png)
