### PR TITLE
Fix command language selection (2.2.1)

### DIFF
--- a/librecad/src/cmd/rs_commands.cpp
+++ b/librecad/src/cmd/rs_commands.cpp
@@ -38,11 +38,38 @@
 #include "rs_system.h"
 
 namespace {
+struct LC_CommandText {
+    constexpr LC_CommandText(const char* source)
+        : source(source) {
+    }
+
+    constexpr LC_CommandText(const char* source, bool translatable)
+        : source(source)
+        , translatable(translatable) {
+    }
+
+    constexpr LC_CommandText(const char* source, const char* disambiguation)
+        : source(source)
+        , disambiguation(disambiguation)
+        , translatable(true) {
+    }
+
+    const char* source{nullptr};
+    const char* disambiguation{nullptr};
+    bool translatable{false};
+};
+
 struct LC_CommandItem {
-    std::vector<std::pair<QString, QString>> const fullCmdList;
-    std::vector<std::pair<QString, QString>> const shortCmdList;
+    std::vector<std::pair<LC_CommandText, LC_CommandText>> const fullCmdList;
+    std::vector<std::pair<LC_CommandText, LC_CommandText>> const shortCmdList;
     RS2::ActionType actionType;
 };
+
+QString resolveCommandText(const LC_CommandText& text) {
+    return text.translatable
+               ? RS_SYSTEM->translateCommand(text.source, text.disambiguation)
+               : QString::fromUtf8(text.source);
+}
 
 // Prefixes for function-, Meta- and Alt- keys.
 const char* g_FnPrefix = "Fn";
@@ -138,11 +165,11 @@ RS_Commands::RS_Commands() {
         //      draw entity command template
         /*        {
 //          mainCommand / long form - full command, appears in alias file (librecad.alias)
-            {{"mainCommand", QObject::tr("mainCommand", "translationText")},
-             {"alt-mainCommand", QObject::tr("alt-mainCommand", "translationText")}},
+            {{"mainCommand", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "mainCommand", "translationText")},
+             {"alt-mainCommand", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "alt-mainCommand", "translationText")}},
 //          Short form(s) - keycode, legacy and single character commands
             {{"keycode", QObject::tr("altcmd, "translationText")},
-             {"(alt-)shortCommand", QObject::tr("(alt-)shortCommand", "translationText")}}
+             {"(alt-)shortCommand", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "(alt-)shortCommand", "translationText")}}
             RS2::ActionCommand
         },
 */
@@ -150,457 +177,457 @@ RS_Commands::RS_Commands() {
         /* LINE COMMANDS */
         // draw line
         {
-            {{"line2p", QObject::tr("line2p", "draw line")}},
-            {{"li", QObject::tr("li", "draw line")},
-                {"line", QObject::tr("line", "draw line")},
-                {"l", QObject::tr("l", "draw line")}},
+            {{"line2p", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "line2p", "draw line")}},
+            {{"li", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "li", "draw line")},
+                {"line", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "line", "draw line")},
+                {"l", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "l", "draw line")}},
             RS2::ActionDrawLine
         },
         // draw Snake line
         {
-            {{"sline", QObject::tr("sline", "draw snake line")}},
-            {{"sli", QObject::tr("sli", "draw snake line")},
-              {"sl", QObject::tr("sl", "draw snake line")}},
+            {{"sline", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "sline", "draw snake line")}},
+            {{"sli", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "sli", "draw snake line")},
+              {"sl", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "sl", "draw snake line")}},
             RS2::ActionDrawSnakeLine
         },
         // draw Snake-X line
         {
-            {{"slinex", QObject::tr("slinex", "draw snake line (X)")}},
-            {{"slix", QObject::tr("slix", "draw snake line (X)")},
-                {"slx", QObject::tr("rlx", "draw snake line (X)")}},
+            {{"slinex", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "slinex", "draw snake line (X)")}},
+            {{"slix", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "slix", "draw snake line (X)")},
+                {"slx", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rlx", "draw snake line (X)")}},
             RS2::ActionDrawSnakeLineX
         },
         // draw Snake-Y line
         {
-            {{"sliney", QObject::tr("sliney", "draw snake line (Y)")}},
-            {{"sliy", QObject::tr("sliy", "draw snake line (Y)")},
-                {"sly", QObject::tr("rly", "draw snake line (Y)")}},
+            {{"sliney", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "sliney", "draw snake line (Y)")}},
+            {{"sliy", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "sliy", "draw snake line (Y)")},
+                {"sly", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rly", "draw snake line (Y)")}},
             RS2::ActionDrawSnakeLineY
         },
         // draw line at angle - v2.2.0r2
         {
-            {{"lineang", QObject::tr("lineang", "angled line")}},
-            {{"la", QObject::tr("la", "angled line")}},
+            {{"lineang", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "lineang", "angled line")}},
+            {{"la", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "la", "angled line")}},
             RS2::ActionDrawLineAngle
         },
         // draw horizontal line
         {
-            {{"linehor", QObject::tr("linehor", "horizontal line")}},   // - v2.2.0r2
-            {{"lh", QObject::tr("lh", "horizontal line")}},
+            {{"linehor", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "linehor", "horizontal line")}},   // - v2.2.0r2
+            {{"lh", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "lh", "horizontal line")}},
             RS2::ActionDrawLineHorizontal
         },
         // draw vertical line
         {
-            {{"linever", QObject::tr("linever", "vertical line")}},   // - v2.2.0r2
-            {{"lv", QObject::tr("lv", "vertical line")}},
+            {{"linever", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "linever", "vertical line")}},   // - v2.2.0r2
+            {{"lv", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "lv", "vertical line")}},
             RS2::ActionDrawLineVertical
         },
         // draw rectangle - v2.2.0r2
         {
-            {{"linerec", QObject::tr("linerec", "draw rectangle")}},
-            {{"re", QObject::tr("re", "draw rectangle")},
-                {"rect", QObject::tr("rect", "draw rectangle")}},
+            {{"linerec", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "linerec", "draw rectangle")}},
+            {{"re", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "re", "draw rectangle")},
+                {"rect", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rect", "draw rectangle")}},
             RS2::ActionDrawLineRectangle
         },
         // draw  rectangle 1 Point
         {
-            {{"rect1", QObject::tr("rect1", "draw rectangle (1 Point)")}},
-            {{"re1", QObject::tr("re1", "draw rectangle (1 Point)")}},
+            {{"rect1", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rect1", "draw rectangle (1 Point)")}},
+            {{"re1", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "re1", "draw rectangle (1 Point)")}},
             RS2::ActionDrawRectangle1Point
         },
         // draw  rectangle 2 Points
         {
-            {{"rect2", QObject::tr("rect2", "draw rectangle (2 Points)")}},
-            {{"re2", QObject::tr("re2", "draw rectangle (2 Points)")}},
+            {{"rect2", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rect2", "draw rectangle (2 Points)")}},
+            {{"re2", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "re2", "draw rectangle (2 Points)")}},
             RS2::ActionDrawRectangle2Points
         },
         // draw rectangle 3 Points
         {
-            {{"rect3", QObject::tr("rect3", "draw rectangle (3 Points)")}},
-            {{"re3", QObject::tr("re3", "draw rectangle (3 Points)")}},
+            {{"rect3", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rect3", "draw rectangle (3 Points)")}},
+            {{"re3", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "re3", "draw rectangle (3 Points)")}},
             RS2::ActionDrawRectangle3Points
         },
         // slice/divide line
         {
-            {{"slicel", QObject::tr("slicel", "slice/divide line")}},
-            {{"sll", QObject::tr("sll", "slice/divide line")}},
+            {{"slicel", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "slicel", "slice/divide line")}},
+            {{"sll", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "sll", "slice/divide line")}},
             RS2::ActionDrawSliceDivideLine
         },
         // slice/divide circle/arc
         {
-            {{"slicec", QObject::tr("slicec", "slice/divide circle/arc")}},
-            {{"slc", QObject::tr("slc", "slice/divide circle/arc")}},
+            {{"slicec", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "slicec", "slice/divide circle/arc")}},
+            {{"slc", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "slc", "slice/divide circle/arc")}},
             RS2::ActionDrawSliceDivideCircle
         },
         // draw star
         {
-            {{"star", QObject::tr("star", "draw star")}},
-            {{"st", QObject::tr("st", "draw star")}},
+            {{"star", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "star", "draw star")}},
+            {{"st", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "st", "draw star")}},
             RS2::ActionDrawStar
         },
         // draw cross
         {
-            {{"cross", QObject::tr("cross", "draw cross for circle")}},
-            {{"cx", QObject::tr("cx", "draw cross for circle")}},
+            {{"cross", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "cross", "draw cross for circle")}},
+            {{"cx", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "cx", "draw cross for circle")}},
             RS2::ActionDrawCross
         },
         // draw line of points
         {
-            {{"linepoints", QObject::tr("linepoints", "draw line of points")}},
-            {{"lpoints", QObject::tr("lpoints", "draw line of points")}},
+            {{"linepoints", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "linepoints", "draw line of points")}},
+            {{"lpoints", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "lpoints", "draw line of points")}},
             RS2::ActionDrawLinePoints
         },
         // draw circle by arc
         {
-            {{"circlebyarc", QObject::tr("criclebyarc", "draw circle by arc")}},
-            {{"cba", QObject::tr("cba", "draw circle by arc")}},
+            {{"circlebyarc", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "criclebyarc", "draw circle by arc")}},
+            {{"cba", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "cba", "draw circle by arc")}},
             RS2::ActionDrawCircleByArc
         },
         // draw circle by arc
         {
-            {{"duplicate", QObject::tr("duplicate", "duplicate entity")}},
-            {{"dup", QObject::tr("dup", "duplicate entity")}},
+            {{"duplicate", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "duplicate", "duplicate entity")}},
+            {{"dup", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dup", "duplicate entity")}},
             RS2::ActionModifyDuplicate
         },
         // line join
         {
-            {{"linejoin", QObject::tr("linejoin", "lines join")}},
-            {{"lj", QObject::tr("lj", "lines join")}},
+            {{"linejoin", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "linejoin", "lines join")}},
+            {{"lj", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "lj", "lines join")}},
             RS2::ActionModifyLineJoin
         },
         // break/divide
         {
-            {{"breakdivide", QObject::tr("breakdivide", "break or divide entity")}},
-            {{"bd", QObject::tr("bd", "break or divide entity")}},
+            {{"breakdivide", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "breakdivide", "break or divide entity")}},
+            {{"bd", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "bd", "break or divide entity")}},
             RS2::ActionModifyBreakDivide
         },
         // Line Gap
         {
-            {{"gapline", QObject::tr("gapline", "line gap")}},
-            {{"gl", QObject::tr("gl", "line gap")}},
+            {{"gapline", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "gapline", "line gap")}},
+            {{"gl", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "gl", "line gap")}},
             RS2::ActionModifyBreakDivide
         },
         // draw parallel line
         {
-            {{"linepar", QObject::tr("linepar", "create parallel")},
-                {"lineoff", QObject::tr("lineoff", "create parallel")}},
-            {{"pa", QObject::tr("pa", "create parallel")},
-                {"ll", QObject::tr("ll", "create parallel")}},
+            {{"linepar", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "linepar", "create parallel")},
+                {"lineoff", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "lineoff", "create parallel")}},
+            {{"pa", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "pa", "create parallel")},
+                {"ll", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ll", "create parallel")}},
             RS2::ActionDrawLineParallel
         },
         // draw parallel line through point
         {
-            {{"lineparthro", QObject::tr("lineparthro", "parallel through point")}},   // - v2.2.0r2
-            {{"lp", QObject::tr("lp", "parallel through point")},
-                {"ptp", QObject::tr("ptp", "parallel through point")}},
+            {{"lineparthro", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "lineparthro", "parallel through point")}},   // - v2.2.0r2
+            {{"lp", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "lp", "parallel through point")},
+                {"ptp", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ptp", "parallel through point")}},
             RS2::ActionDrawLineParallelThrough
         },
         // draw angle bisector
         {
-            {{"linebisect", QObject::tr("linebisect", "angle bisector")}},
-            {{"bi", QObject::tr("bi", "angle bisector")},
-                {"bisect", QObject::tr("bisect", "angle bisector")}},
+            {{"linebisect", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "linebisect", "angle bisector")}},
+            {{"bi", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "bi", "angle bisector")},
+                {"bisect", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "bisect", "angle bisector")}},
             RS2::ActionDrawLineBisector
         },
         // draw line tangent to circle from point
         {
-            {{"linetancp", QObject::tr("linetancp", "tangent point and circle")}},
-            {{"lt", QObject::tr("lt", "tangent point and circle")},   // - v2.2.0r2
-                {"tanpc", QObject::tr("tanpc", "tangent point and circle")}},
+            {{"linetancp", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "linetancp", "tangent point and circle")}},
+            {{"lt", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "lt", "tangent point and circle")},   // - v2.2.0r2
+                {"tanpc", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "tanpc", "tangent point and circle")}},
             RS2::ActionDrawLineTangent1
         },
         // draw line tangent to two existing circles - v2.2.0r2
         {
-            {{"linetan2c", QObject::tr("linetan2c", "tangent two circles")}},
-            {{"lc", QObject::tr("lc", "tangent two circles")}},
+            {{"linetan2c", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "linetan2c", "tangent two circles")}},
+            {{"lc", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "lc", "tangent two circles")}},
             RS2::ActionDrawLineTangent2
         },
         // draw line tangent to an existing circle perpendicular to an existing line - v2.2.0r2
         {
-            {{"linetancper", QObject::tr("linetancper", "tangent line and circle")}},
-            {{"or", QObject::tr("or", "tangent line and circle")}},
+            {{"linetancper", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "linetancper", "tangent line and circle")}},
+            {{"or", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "or", "tangent line and circle")}},
             RS2::ActionDrawLineOrthTan
         },
         // draw perpendicular line
         {
-            {{"lineperp", QObject::tr("lineperp", "perpendicular line")}},
-            {{"lo", QObject::tr("lo", "perpendicular line")},
-                {"ortho", QObject::tr("ortho", "perpendicular line")}},
+            {{"lineperp", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "lineperp", "perpendicular line")}},
+            {{"lo", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "lo", "perpendicular line")},
+                {"ortho", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ortho", "perpendicular line")}},
             RS2::ActionDrawLineOrthogonal
         },
         // draw line with relative angle - v2.2.0r2
         {
-            {{"linerelang", QObject::tr("linerelang", "relative line")}},
-            {{"lr", QObject::tr("lr", "relative line")}},
+            {{"linerelang", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "linerelang", "relative line")}},
+            {{"lr", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "lr", "relative line")}},
             RS2::ActionDrawLineRelAngle
         },
         // draw polygon by centre and point - v2.2.0r2
         {
-            {{"polygoncencor", QObject::tr("polygoncencor", "polygon centre point")}},
-            {{"pp", QObject::tr("pp", "polygon centre point")},   // - v2.2.0r2
-                {"polycp", QObject::tr("polycp", "polygon centre point")},
-                {"pcp", QObject::tr("pcp", "polygon centre point")}},
+            {{"polygoncencor", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "polygoncencor", "polygon centre point")}},
+            {{"pp", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "pp", "polygon centre point")},   // - v2.2.0r2
+                {"polycp", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "polycp", "polygon centre point")},
+                {"pcp", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "pcp", "polygon centre point")}},
             RS2::ActionDrawLinePolygonCenCor
         },
         // draw polygon by centre and vertex - v2.2.0r2
         {
-            {{"polygoncentan", QObject::tr("polygoncentan", "polygon centre vertex")}},
-            {{"pv", QObject::tr("pv", "polygon centre vertex")},   // - v2.2.0r2
-                {"polyct", QObject::tr("polyct", "polygon centre vertex")}},
+            {{"polygoncentan", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "polygoncentan", "polygon centre vertex")}},
+            {{"pv", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "pv", "polygon centre vertex")},   // - v2.2.0r2
+                {"polyct", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "polyct", "polygon centre vertex")}},
             RS2::ActionDrawLinePolygonCenTan
         },
         // draw polygon by 2 vertices
         {
-            {{"polygon2v", QObject::tr("polygon2v", "polygon by 2 vertices")}},
-            {{"p2", QObject::tr("p2", "polygon by 2 vertices")},   // - v2.2.0r2
-                {"poly2", QObject::tr("poly2", "polygon by 2 vertices")}},
+            {{"polygon2v", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "polygon2v", "polygon by 2 vertices")}},
+            {{"p2", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "p2", "polygon by 2 vertices")},   // - v2.2.0r2
+                {"poly2", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "poly2", "polygon by 2 vertices")}},
             RS2::ActionDrawLinePolygonCorCor
         },
 
         /* CIRCLE COMMANDS */
         // draw circle
         {
-            {{"circle", QObject::tr("circle", "draw circle")}},
-            {{"ci", QObject::tr("ci", "draw circle")},
-                {"c", QObject::tr("c", "draw circle")}},   // - v2.2.0r2
+            {{"circle", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "circle", "draw circle")}},
+            {{"ci", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ci", "draw circle")},
+                {"c", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "c", "draw circle")}},   // - v2.2.0r2
             RS2::ActionDrawCircle
         },
         // draw 2 point circle
         {
-            {{"circle2p", QObject::tr("circle2p", "circle 2 points")}},
-            {{"c2", QObject::tr("c2", "circle 2 points")},
-                {"c2p", QObject::tr("c2p", "circle 2 points")}},
+            {{"circle2p", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "circle2p", "circle 2 points")}},
+            {{"c2", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "c2", "circle 2 points")},
+                {"c2p", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "c2p", "circle 2 points")}},
             RS2::ActionDrawCircle2P
         },
         // draw circle 2 points and radius - v2.2.0r2
         {
-            {{"circle2pr", QObject::tr("circle2pr", "circle 2 points radius")}},
-            {{"cc", QObject::tr("cc", "circle 2 points radius")}},
+            {{"circle2pr", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "circle2pr", "circle 2 points radius")}},
+            {{"cc", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "cc", "circle 2 points radius")}},
             RS2::ActionDrawCircle2PR
         },
         // draw 3 point circle
         {
-            {{"circle3p", QObject::tr("circle3p", "circle 3 points")}},
-            {{"c3", QObject::tr("c3", "circle 3 points")},
-                {"c3p", QObject::tr("c3p", "circle 3 points")}},
+            {{"circle3p", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "circle3p", "circle 3 points")}},
+            {{"c3", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "c3", "circle 3 points")},
+                {"c3p", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "c3p", "circle 3 points")}},
             RS2::ActionDrawCircle3P
         },
         // draw circle with centre point and radius - v2.2.0r2
         {
-            {{"circlecr", QObject::tr("circlecr", "circle point radius")}},
-            {{"cr", QObject::tr("cr", "circle point radius")},
-                {"ccr", QObject::tr("ccr", "circle point radius")}},
+            {{"circlecr", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "circlecr", "circle point radius")}},
+            {{"cr", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "cr", "circle point radius")},
+                {"ccr", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ccr", "circle point radius")}},
             RS2::ActionDrawCircleCR
         },
 
         // draw circle tangential to 2 circles and 1 point - v2.2.0r2
         {
-            {{"circletan2cp", QObject::tr("circletan2cp", "circle 2 tangent point")}},
-            {{"tr", QObject::tr("tr", "circle 2 tangent point")}},
+            {{"circletan2cp", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "circletan2cp", "circle 2 tangent point")}},
+            {{"tr", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "tr", "circle 2 tangent point")}},
             RS2::ActionDrawCircleTan2_1P
         },
         // draw circle Tangential to 2 Points - v2.2.0r2
         {
-            {{"circletan2p", QObject::tr("circletan2p", "circle tangent 2 points")}},
-            {{"td", QObject::tr("td", "circle tangent 2 points")}},
+            {{"circletan2p", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "circletan2p", "circle tangent 2 points")}},
+            {{"td", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "td", "circle tangent 2 points")}},
             RS2::ActionDrawCircleTan1_2P
         },
         //draw circle tangential to 2 circles with specified radius - v2.2.0r2
         {
-            {{"circletan2cr", QObject::tr("circletan2cr", "circle 2 tangent radius")}},
-            {{"tc", QObject::tr("tc", "circle 2 tangent radius")}},
+            {{"circletan2cr", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "circletan2cr", "circle 2 tangent radius")}},
+            {{"tc", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "tc", "circle 2 tangent radius")}},
             RS2::ActionDrawCircleTan2
         },
 
         // draw circle tangent to 3 objects
         {
-            {{"circletan3", QObject::tr("circletan3", "circle tangent to 3")}},
-            {{"t3", QObject::tr("t3", "circle tangent to 3")},   // - v2.2.0r2
-                {"ct3", QObject::tr("ct3", "circle tangent to 3")},
-                {"tan3", QObject::tr("tan3", "circle tangent to 3")}},
+            {{"circletan3", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "circletan3", "circle tangent to 3")}},
+            {{"t3", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "t3", "circle tangent to 3")},   // - v2.2.0r2
+                {"ct3", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ct3", "circle tangent to 3")},
+                {"tan3", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "tan3", "circle tangent to 3")}},
             RS2::ActionDrawCircleTan3
         },
 
         /* CURVE (ARC) COMMANDS */
         // draw arc by centre point and radius - v2.2.0r2 (Change to previous version)
         {
-            {{"arc", QObject::tr("arc", "arc point radius")}},
-            {{"ar", QObject::tr("ar", "arc point radius")},
-                {"a", QObject::tr("a", "arc point radius")}},
+            {{"arc", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "arc", "arc point radius")}},
+            {{"ar", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ar", "arc point radius")},
+                {"a", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "a", "arc point radius")}},
             RS2::ActionDrawArc
         },
         // draw 3 points arc - v2.2.0r2 (Change to previous version)
         {
-            {{"arc3p", QObject::tr("arc3p", "draw 3pt arc")}},
-            {{"a3", QObject::tr("a3", "draw 3pt arc")}},
+            {{"arc3p", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "arc3p", "draw 3pt arc")}},
+            {{"a3", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "a3", "draw 3pt arc")}},
             RS2::ActionDrawArc3P
         },
         // draw arc tangential - v2.2.0r2
         {
-            {{"arctan", QObject::tr("arctan", "arc tangent")}},
-            {{"at", QObject::tr("at", "arc tangent")}},
+            {{"arctan", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "arctan", "arc tangent")}},
+            {{"at", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "at", "arc tangent")}},
             RS2::ActionDrawArcTangential
         },
         // draw spline with degrees freedom
         {
-            {{"spline", QObject::tr("spline", "draw spline")}},
-            {{"sf", QObject::tr("sf", "draw spline")},   // - v2.2.0r2
-                {"spl", QObject::tr("spl", "draw spline")}},
+            {{"spline", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "spline", "draw spline")}},
+            {{"sf", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "sf", "draw spline")},   // - v2.2.0r2
+                {"spl", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "spl", "draw spline")}},
             RS2::ActionDrawSpline
         },
         //draw spline through points
         {
-            {{"spline2", QObject::tr("spline2", "spline through points")}},
-            {{"sp", QObject::tr("sp", "spline through points")},   // - v2.2.0r2
-                {"stp", QObject::tr("stp", "spline through points")}},
+            {{"spline2", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "spline2", "spline through points")}},
+            {{"sp", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "sp", "spline through points")},   // - v2.2.0r2
+                {"stp", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "stp", "spline through points")}},
             RS2::ActionDrawSplinePoints
         },
         // draw ellipse arc by axis - v2.2.0r2
         {
-            {{"arcellc2ax", QObject::tr("arcellc2ax", "arc ellipse")}},
-            {{"ae", QObject::tr("ae", "arc ellipse")}},
+            {{"arcellc2ax", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "arcellc2ax", "arc ellipse")}},
+            {{"ae", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ae", "arc ellipse")}},
             RS2::ActionDrawEllipseArcAxis
         },
         // draw parabola by 4 points - v2.2.1
         {
-            {{"parabola4p", QObject::tr("parabola4p", "Parabola 4 points")}},
-            {{"pl4", QObject::tr("pl4", "Parabola 4 points")}},
+            {{"parabola4p", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "parabola4p", "Parabola 4 points")}},
+            {{"pl4", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "pl4", "Parabola 4 points")}},
             RS2::ActionDrawParabola4Points
         },
         // draw parabola by focus directrix - v2.2.1
         {
-            {{"parabolafd", QObject::tr("parabolafd", "Parabola focus directrix")}},
-            {{"plfd", QObject::tr("plfd", "Parabola focus directrix")}},
+            {{"parabolafd", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "parabolafd", "Parabola focus directrix")}},
+            {{"plfd", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "plfd", "Parabola focus directrix")}},
             RS2::ActionDrawParabolaFD
         },
         //draw freehand line
         {
-            {{"free", QObject::tr("free", "draw freehand line")}},
-            {{"fh", QObject::tr("fh", "draw freehand line")},   // - v2.2.0r2
-                {"fhl", QObject::tr("fhl", "draw freehand line")}},
+            {{"free", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "free", "draw freehand line")}},
+            {{"fh", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "fh", "draw freehand line")},   // - v2.2.0r2
+                {"fhl", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "fhl", "draw freehand line")}},
             RS2::ActionDrawLineFree
         },
 
         /* ELLIPSE COMMANDS */
         // draw ellipse by axis - v2.2.0r2
         {
-            {{"ellipsec2p", QObject::tr("ellipsec2p", "ellipse axis")}},
-            {{"ea", QObject::tr("ea", "ellipse axis")}},
+            {{"ellipsec2p", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ellipsec2p", "ellipse axis")}},
+            {{"ea", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ea", "ellipse axis")}},
             RS2::ActionDrawEllipseAxis
         },
         // draw ellipse by foci point - v2.2.0r2
         {
-            {{"ellipse3p", QObject::tr("ellipse3p", "ellipse foci")}},
-            {{"ef", QObject::tr("ef", "ellipse foci")}},
+            {{"ellipse3p", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ellipse3p", "ellipse foci")}},
+            {{"ef", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ef", "ellipse foci")}},
             RS2::ActionDrawEllipseFociPoint
         },
         // draw 4 points ellipse - v2.2.0r2
         {
-            {{"ellipse4p", QObject::tr("ellipse4p", "ellipse 4 point")}},
-            {{"e4", QObject::tr("e4", "ellipse 4 point")}},
+            {{"ellipse4p", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ellipse4p", "ellipse 4 point")}},
+            {{"e4", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "e4", "ellipse 4 point")}},
             RS2::ActionDrawEllipse4Points
         },
         // draw ellipse by center and 3 points - v2.2.0r2
         {
-            {{"ellipsec3p", QObject::tr("ellipsec3p", "ellipse center 3 point")}},
-            {{"e3", QObject::tr("e3", "ellipse center 3 point")}},
+            {{"ellipsec3p", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ellipsec3p", "ellipse center 3 point")}},
+            {{"e3", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "e3", "ellipse center 3 point")}},
             RS2::ActionDrawEllipseCenter3Points
         },
         // draw inscribed ellipse
         {
-            {{"ellipseinscribed", QObject::tr("ellipseinscribed", "inscribed ellipse")}},
-            {{"ei", QObject::tr("ei", "inscribed ellipse")},
-                {"ie", QObject::tr("ie", "inscribed ellipse")}},
+            {{"ellipseinscribed", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ellipseinscribed", "inscribed ellipse")}},
+            {{"ei", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ei", "inscribed ellipse")},
+                {"ie", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ie", "inscribed ellipse")}},
             RS2::ActionDrawEllipseInscribe
         },
 
         /* POLYLINE COMMANDS */
         // draw polyline
         {
-            {{"polyline", QObject::tr("polyline", "draw polyline")}},
-            {{"pl", QObject::tr("pl", "draw polyline")}},
+            {{"polyline", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "polyline", "draw polyline")}},
+            {{"pl", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "pl", "draw polyline")}},
             RS2::ActionDrawPolyline
         },
         // draw angle line from line
         {
-            {{"angleline", QObject::tr("angleline", "draw angle from line")}},
-            {{"aline", QObject::tr("angleline", "draw angle from line")}},
+            {{"angleline", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "angleline", "draw angle from line")}},
+            {{"aline", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "angleline", "draw angle from line")}},
             RS2::ActionDrawLineAngleRel
         },
         // draw orthogonal line from line
         {
-            {{"ortline", QObject::tr("rortoline", "draw orthogonal")}},
-            {{"oline", QObject::tr("rort", "draw orthogonal")}},
+            {{"ortline", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rortoline", "draw orthogonal")}},
+            {{"oline", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rort", "draw orthogonal")}},
             RS2::ActionDrawLineOrthogonalRel
         },
         // draw line from point to line
         {
-            {{"point2line", QObject::tr("point2line", "draw line from point to line")}},
-            {{"p2l", QObject::tr("p2l", "draw line from point to line")}},
+            {{"point2line", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "point2line", "draw line from point to line")}},
+            {{"p2l", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "p2l", "draw line from point to line")}},
             RS2::ActionDrawLineFromPointToLine
         },
 
         // polyline add node - v2.2.0r2
         {
-            {{"plineadd", QObject::tr("plineadd", "pl add node")}},
-            {{"pi", QObject::tr("pi", "pl add node")}},   // - v2.2.0r2
+            {{"plineadd", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "plineadd", "pl add node")}},
+            {{"pi", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "pi", "pl add node")}},   // - v2.2.0r2
             RS2::ActionPolylineAdd
         },
         // polyline append node - v2.2.0r2
         {
-            {{"plineapp", QObject::tr("plineapp", "pl append node")}},
-            {{"pn", QObject::tr("pn", "pl append node")}},
+            {{"plineapp", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "plineapp", "pl append node")}},
+            {{"pn", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "pn", "pl append node")}},
             RS2::ActionPolylineAppend
         },
         // polyline delete node - v2.2.0r2
         {
-            {{"plinedel", QObject::tr("plinedel", "pl delete node")}},
-            {{"pd", QObject::tr("pd", "pl delete node")}},
+            {{"plinedel", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "plinedel", "pl delete node")}},
+            {{"pd", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "pd", "pl delete node")}},
             RS2::ActionPolylineDel
         },
         // polyline delete between two nodes - v2.2.0r2
         {
-            {{"plinedeltwn", QObject::tr("plinedeltwn", "pl del between nodes")}},
-            {{"pr", QObject::tr("pr", "pl del between nodes")}},
+            {{"plinedeltwn", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "plinedeltwn", "pl del between nodes")}},
+            {{"pr", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "pr", "pl del between nodes")}},
             RS2::ActionPolylineDelBetween
         },
         // polyline trim segments - v2.2.0r2
         {
-            {{"plinetrm", QObject::tr("plinetrm", "pl trim segments")}},
-            {{"pt", QObject::tr("pt", "pl trim segments")}},
+            {{"plinetrm", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "plinetrm", "pl trim segments")}},
+            {{"pt", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "pt", "pl trim segments")}},
             RS2::ActionPolylineTrim
         },
         // equidistant polyline - v2.2.0r2
         {
-            {{"plinepar", QObject::tr("plinepar", "pl equidistant")}},
-            {{"pe", QObject::tr("pe", "pl equidistant")}},
+            {{"plinepar", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "plinepar", "pl equidistant")}},
+            {{"pe", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "pe", "pl equidistant")}},
             RS2::ActionPolylineEquidistant
         },
         // polyline from existing segments - v2.2.0r2
         {
-            {{"plinejoin", QObject::tr("plinejoin", "pl join")}},
-            {{"pj", QObject::tr("pj", "pl join")}},
+            {{"plinejoin", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "plinejoin", "pl join")}},
+            {{"pj", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "pj", "pl join")}},
             RS2::ActionPolylineSegment
         },
 
         /* SELECT COMMANDS */
         // Select all entities
         {
-            {{"selectall", QObject::tr("selectall", "Select all entities")}},
-            {{"sa", QObject::tr("sa", "Select all entities")}},
+            {{"selectall", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "selectall", "Select all entities")}},
+            {{"sa", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "sa", "Select all entities")}},
             RS2::ActionSelectAll
         },
         // DeSelect all entities
         {
-            {{"deselectall", QObject::tr("deselectall", "deselect all entities")}},
-            {{"sx", QObject::tr("sx", "deselect all entities")},
-                {"tn", QObject::tr("tn", "deselect all entities")}},   // - v2.2.0r2
+            {{"deselectall", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "deselectall", "deselect all entities")}},
+            {{"sx", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "sx", "deselect all entities")},
+                {"tn", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "tn", "deselect all entities")}},   // - v2.2.0r2
             RS2::ActionDeselectAll
         },
         // Invert selection - v2.2.0r2
         {
-            {{"invertselect", QObject::tr("invertselect", "invert select")}},
-            {{"is", QObject::tr("is", "invert select")}},
+            {{"invertselect", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "invertselect", "invert select")}},
+            {{"is", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "is", "invert select")}},
             RS2::ActionSelectInvert
         },
         /* Remaining select tools require the mouse - no point in adding commands. */
@@ -608,348 +635,348 @@ RS_Commands::RS_Commands() {
         /* DIMENSION COMMANDS */
         // dimension aligned
         {
-            {{"dimaligned", QObject::tr("dimaligned", "dimension - aligned")}},
-            {{"ds", QObject::tr("ds", "dimension - aligned")}},   // - v2.2.0r2 (Change to previous version)
+            {{"dimaligned", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dimaligned", "dimension - aligned")}},
+            {{"ds", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ds", "dimension - aligned")}},   // - v2.2.0r2 (Change to previous version)
             RS2::ActionDimAligned
         },
         // dimension linear
         {
-            {{"dimlinear", QObject::tr("dimlinear", "dimension - linear")}},
-            {{"dl", QObject::tr("dl", "dimension - linear")}},
+            {{"dimlinear", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dimlinear", "dimension - linear")}},
+            {{"dl", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dl", "dimension - linear")}},
             RS2::ActionDimLinear
         },
         // dimension horizontal
         {
-            {{"dimhorizontal", QObject::tr("dimhorizontal", "dimension - horizontal")}},
-            {{"dh", QObject::tr("dh", "dimension - horizontal")}},
+            {{"dimhorizontal", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dimhorizontal", "dimension - horizontal")}},
+            {{"dh", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dh", "dimension - horizontal")}},
             RS2::ActionDimLinearHor
         },
         // dimension vertical
         {
-            {{"dimvertical", QObject::tr("dimvertical", "dimension - vertical")}},
-            {{"dv", QObject::tr("dv", "dimension - vertical")}},
+            {{"dimvertical", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dimvertical", "dimension - vertical")}},
+            {{"dv", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dv", "dimension - vertical")}},
             RS2::ActionDimLinearVer
         },
         // dimension radius
         {
-            {{"dimradius", QObject::tr("dimradius", "dimension - radial")},
-                {"dimradial", QObject::tr("dimradial", "dimension - radial")}},
-            {{"dr", QObject::tr("dr", "dimension - radial")}},
+            {{"dimradius", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dimradius", "dimension - radial")},
+                {"dimradial", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dimradial", "dimension - radial")}},
+            {{"dr", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dr", "dimension - radial")}},
             RS2::ActionDimRadial
         },
         // dimension diameter
         {
-            {{"dimdiameter", QObject::tr("dimdiameter", "dimension - diametric")}},
-            {{"dd", QObject::tr("dd", "dimension - diametric")},
-                {"dimdiametric", QObject::tr("dimdiametric", "dimension - diametric")}},
+            {{"dimdiameter", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dimdiameter", "dimension - diametric")}},
+            {{"dd", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dd", "dimension - diametric")},
+                {"dimdiametric", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dimdiametric", "dimension - diametric")}},
             RS2::ActionDimDiametric
         },
         // dimension angular
         {
-            {{"dimangular", QObject::tr("dimangular", "dimension - angular")}},
-            {{"da", QObject::tr("da", "dimension - angular")},
-                {"dan", QObject::tr("dan", "dimension - angular")}},
+            {{"dimangular", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dimangular", "dimension - angular")}},
+            {{"da", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "da", "dimension - angular")},
+                {"dan", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dan", "dimension - angular")}},
             RS2::ActionDimAngular
         },
         // dimension leader
         {
-            {{"dimleader", QObject::tr("dimleader", "dimension - leader")}},
-            {{"ld", QObject::tr("ld", "dimension - leader")}},
+            {{"dimleader", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dimleader", "dimension - leader")}},
+            {{"ld", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ld", "dimension - leader")}},
             RS2::ActionDimLeader
         },
         // dimension regenerate
         {
-            {{"dimregen", QObject::tr("dimregen", "dimension - regenerate")}},
-            {{"dg", QObject::tr("dg", "dimension - regenerate")}},
+            {{"dimregen", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dimregen", "dimension - regenerate")}},
+            {{"dg", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dg", "dimension - regenerate")}},
             RS2::ActionToolRegenerateDimensions
         },
 
         /* MODIFY COMMANDS */
         // move
         {
-            {{"modmove", QObject::tr("modmove", "modify - move (copy)")}},
-            {{"mv", QObject::tr("mv", "modify - move (copy)")}},
+            {{"modmove", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "modmove", "modify - move (copy)")}},
+            {{"mv", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "mv", "modify - move (copy)")}},
             RS2::ActionModifyMove
         },
         // rotate
         {
-            {{"modrotate", QObject::tr("modrotate", "modify - rotate")}},
-            {{"ro", QObject::tr("ro", "modify - rotate")}},
+            {{"modrotate", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "modrotate", "modify - rotate")}},
+            {{"ro", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ro", "modify - rotate")}},
             RS2::ActionModifyRotate
         },
         // scale
         {
-            {{"modscale", QObject::tr("modscale", "modify - scale")}},
-            {{"sz", QObject::tr("sz", "modify - scale")}},
+            {{"modscale", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "modscale", "modify - scale")}},
+            {{"sz", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "sz", "modify - scale")}},
             RS2::ActionModifyScale
         },
         // mirror  (Removed extra space from translation sting.)
         {
-            {{"modmirror", QObject::tr("modmirror", "modify -  mirror")}},
-            {{"mi", QObject::tr("mi", "modify -  mirror")}},
+            {{"modmirror", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "modmirror", "modify -  mirror")}},
+            {{"mi", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "mi", "modify -  mirror")}},
             RS2::ActionModifyMirror
         },
         // move and rotate - v2.2.0r2
         {
-            {{"modmovrot", QObject::tr("modmovrot", "modify - move rotate")}},
-            {{"mr", QObject::tr("mr", "modify - move rotate")}},
+            {{"modmovrot", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "modmovrot", "modify - move rotate")}},
+            {{"mr", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "mr", "modify - move rotate")}},
             RS2::ActionModifyMoveRotate
         },
         // rotate two - v2.2.0r2
         {
-            {{"mod2rot", QObject::tr("mod2rot", "modify - rotate2")}},
-            {{"r2", QObject::tr("r2", "modify - rotate2")}},
+            {{"mod2rot", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "mod2rot", "modify - rotate2")}},
+            {{"r2", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "r2", "modify - rotate2")}},
             RS2::ActionModifyRotate2
         },
         // revert (Removed extra space from translation sting.)
         {
-            {{"modrevert", QObject::tr("modrevert", "modify -  revert direction")}},
-            {{"md", QObject::tr("md", "modify -  revert direction")},
-                {"rev", QObject::tr("rev", "modify -  revert direction")}},
+            {{"modrevert", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "modrevert", "modify -  revert direction")}},
+            {{"md", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "md", "modify -  revert direction")},
+                {"rev", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rev", "modify -  revert direction")}},
             RS2::ActionModifyRevertDirection
         },
         // trim
         {
-            {{"modtrim", QObject::tr("modtrim", "modify - trim (extend)")}},
-            {{"tm", QObject::tr("tm", "modify - trim (extend)")}},
+            {{"modtrim", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "modtrim", "modify - trim (extend)")}},
+            {{"tm", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "tm", "modify - trim (extend)")}},
             RS2::ActionModifyTrim
         },
         // trim2
         {
-            {{"modtrim2", QObject::tr("modtrim2", "modify - multi trim (extend)")}},
-            {{"t2", QObject::tr("t2", "modify - multi trim (extend)")},
-                {"tm2", QObject::tr("tm2", "modify - multi trim (extend)")}},
+            {{"modtrim2", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "modtrim2", "modify - multi trim (extend)")}},
+            {{"t2", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "t2", "modify - multi trim (extend)")},
+                {"tm2", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "tm2", "modify - multi trim (extend)")}},
             RS2::ActionModifyTrim2
         },
         // lengthen
         {
-            {{"modlengthen", QObject::tr("modlengthen", "modify - lengthen")}},
-            {{"le", QObject::tr("le", "modify - lengthen")}},
+            {{"modlengthen", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "modlengthen", "modify - lengthen")}},
+            {{"le", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "le", "modify - lengthen")}},
             RS2::ActionModifyTrimAmount
         },
         // offset
         {
-            {{"modoffset", QObject::tr("modoffset", "modify - offset")}},
-            {{"mo", QObject::tr("mo", "modify - offset")},   // - v2.2.0r2
-                {"moff", QObject::tr("moff", "modify - offset")}},
+            {{"modoffset", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "modoffset", "modify - offset")}},
+            {{"mo", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "mo", "modify - offset")},   // - v2.2.0r2
+                {"moff", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "moff", "modify - offset")}},
             RS2::ActionModifyOffset
         },
         // bevel
         {
-            {{"modbevel", QObject::tr("modbevel", "modify - bevel")}},
-            {{"bev", QObject::tr("bev", "modify - bevel")},
-                {"ch", QObject::tr("ch", "modify - bevel")}},
+            {{"modbevel", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "modbevel", "modify - bevel")}},
+            {{"bev", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "bev", "modify - bevel")},
+                {"ch", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ch", "modify - bevel")}},
             RS2::ActionModifyBevel
         },
         // fillet
         {
-            {{"modfillet", QObject::tr("modfillet", "modify - fillet")}},
-            {{"fi", QObject::tr("fi", "modify - fillet")}},
+            {{"modfillet", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "modfillet", "modify - fillet")}},
+            {{"fi", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "fi", "modify - fillet")}},
             RS2::ActionModifyRound
         },
         // divide
         {
-            {{"moddivide", QObject::tr("moddivide", "modify - divide (cut)")},
-                {"cut", QObject::tr("cut", "modify - divide (cut)")}},
-            {{"div", QObject::tr("div", "modify - divide (cut)")},
-                {"di", QObject::tr("di", "modify - divide (cut)")}},
+            {{"moddivide", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "moddivide", "modify - divide (cut)")},
+                {"cut", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "cut", "modify - divide (cut)")}},
+            {{"div", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "div", "modify - divide (cut)")},
+                {"di", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "di", "modify - divide (cut)")}},
             RS2::ActionModifyCut
         },
         // stretch
         {
-            {{"modstretch", QObject::tr("modstretch", "modify - stretch")}},
-            {{"ss", QObject::tr("ss", "modify - stretch")}},
+            {{"modstretch", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "modstretch", "modify - stretch")}},
+            {{"ss", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ss", "modify - stretch")}},
             RS2::ActionModifyStretch
         },
         // modify properties
         {
-            {{"modproperties", QObject::tr("modproperties", "modify properties")}},
-            {{"prop", QObject::tr("prop", "modify properties")},
-                {"mp", QObject::tr("mp", "modify properties")}},
+            {{"modproperties", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "modproperties", "modify properties")}},
+            {{"prop", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "prop", "modify properties")},
+                {"mp", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "mp", "modify properties")}},
             RS2::ActionModifyEntity
         },
         // modify attributes
         {
-            {{"modattr", QObject::tr("modattr", "modify attribute")}},
-            {{"attr", QObject::tr("attr", "modify attribute")},
-                {"ma", QObject::tr("ma", "modify attribute")}},
+            {{"modattr", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "modattr", "modify attribute")}},
+            {{"attr", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "attr", "modify attribute")},
+                {"ma", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ma", "modify attribute")}},
             RS2::ActionModifyAttributes
         },
         // explode text - v2.2.0r2
         {
-            {{"modexpltext", QObject::tr("modexpltext", "explode text strings")}},
-            {{"xt", QObject::tr("xt", "explode text strings")}},
+            {{"modexpltext", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "modexpltext", "explode text strings")}},
+            {{"xt", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "xt", "explode text strings")}},
             RS2::ActionModifyExplodeText
         },
         // explode
         {
-            {{"modexplode", QObject::tr("modexplode", "explode block/polyline into entities")}},
-            {{"xp", QObject::tr("xp", "explode block/polyline into entities")}},
+            {{"modexplode", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "modexplode", "explode block/polyline into entities")}},
+            {{"xp", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "xp", "explode block/polyline into entities")}},
             RS2::ActionBlocksExplode
         },
         // delete
         {
-            {{"moddelete", QObject::tr("moddelete", "modify - delete (erase)")}},
-            {{"er", QObject::tr("er", "modify - delete (erase)")},
-                {"del", QObject::tr("del", "modify - delete (erase)")}},
+            {{"moddelete", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "moddelete", "modify - delete (erase)")}},
+            {{"er", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "er", "modify - delete (erase)")},
+                {"del", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "del", "modify - delete (erase)")}},
             RS2::ActionModifyDelete
         },
 
         /* INFO COMMANDS */
         // Distance Point to Point
         {
-            {{"infodistance", QObject::tr("infodistance", "distance point to point")}},
-            {{"id", QObject::tr("id", "distance point to point")},   // - v2.2.0r2
-                {"dist", QObject::tr("dist", "distance point to point")},
-                {"dpp", QObject::tr("dpp", "distance point to point")}},
+            {{"infodistance", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "infodistance", "distance point to point")}},
+            {{"id", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "id", "distance point to point")},   // - v2.2.0r2
+                {"dist", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dist", "distance point to point")},
+                {"dpp", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dpp", "distance point to point")}},
             RS2::ActionInfoDist
         },
         // Distance Entity to Point
         {
-            {{"infodistep", QObject::tr("infodistep", "distance entity to point")}},
-            {{"ii", QObject::tr("ii", "distance entity to point")},   // - v2.2.0r2
-                {"dep", QObject::tr("dep", "distance entity to point")}},
+            {{"infodistep", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "infodistep", "distance entity to point")}},
+            {{"ii", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ii", "distance entity to point")},   // - v2.2.0r2
+                {"dep", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dep", "distance entity to point")}},
             RS2::ActionInfoDist2
         },
         // Measure angle
         {
-            {{"infoangle", QObject::tr("infoangle", "measure angle")}},
-            {{"ia", QObject::tr("ia", "measure angle")},   // - v2.2.0r2
-                {"ang", QObject::tr("ang", "measure angle")}},
+            {{"infoangle", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "infoangle", "measure angle")}},
+            {{"ia", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ia", "measure angle")},   // - v2.2.0r2
+                {"ang", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ang", "measure angle")}},
             RS2::ActionInfoAngle
         },
         // Measure area
         {
-            {{"infoarea", QObject::tr("infoarea", "measure area")}},
-            {{"aa", QObject::tr("aa", "measure area")}},   // - v2.2.0r2
+            {{"infoarea", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "infoarea", "measure area")}},
+            {{"aa", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "aa", "measure area")}},   // - v2.2.0r2
             RS2::ActionInfoArea
         },
 
         /* OTHER COMMANDS */
         // draw mtext
         {
-            {{"mtext", QObject::tr("mtext", "draw mtext")}},
-            {{"mt", QObject::tr("mt", "draw mtext")},   // - v2.2.0r2
-                {"mtxt", QObject::tr("mtxt", "draw mtext")}},
+            {{"mtext", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "mtext", "draw mtext")}},
+            {{"mt", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "mt", "draw mtext")},   // - v2.2.0r2
+                {"mtxt", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "mtxt", "draw mtext")}},
             RS2::ActionDrawMText
         },
         // draw text
         {
-            {{"text", QObject::tr("text", "draw text")}},
-            {{"tx", QObject::tr("tx", "draw text")},   // - v2.2.0r2
-                {"txt", QObject::tr("txt", "draw text")}},
+            {{"text", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "text", "draw text")}},
+            {{"tx", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "tx", "draw text")},   // - v2.2.0r2
+                {"txt", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "txt", "draw text")}},
             RS2::ActionDrawText
         },
         // draw hatch
         {
-            {{"hatch", QObject::tr("hatch", "draw hatch")}},
-            {{"ha", QObject::tr("ha", "draw hatch")}},
+            {{"hatch", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "hatch", "draw hatch")}},
+            {{"ha", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ha", "draw hatch")}},
             RS2::ActionDrawHatchNoSelect
         },
         // draw point
         {
-            {{"point", QObject::tr("point", "draw point")}},
-            {{"po", QObject::tr("po", "draw point")}},
+            {{"point", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "point", "draw point")}},
+            {{"po", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "po", "draw point")}},
             RS2::ActionDrawPoint
         },
 
         /* SNAP COMMANDS */
         /* snap exclusive - v2.2.0r2
         {
-            {{"snapexcl", QObject::tr("snapexcl", "snap - excl")}},
-            {{"sx", QObject::tr("sx", "snap - excl")},
-             {"ex", QObject::tr("ex", "snap - excl")}},
+            {{"snapexcl", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "snapexcl", "snap - excl")}},
+            {{"sx", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "sx", "snap - excl")},
+             {"ex", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ex", "snap - excl")}},
             RS2::ActionSnapExcl  // Not present
         }, */
         // snap free
         {
-            {{"snapfree", QObject::tr("snapfree", "snap - free")}},
-            {{"so", QObject::tr("so", "snap - free")},
-                {"os", QObject::tr("os", "snap - free")}},
+            {{"snapfree", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "snapfree", "snap - free")}},
+            {{"so", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "so", "snap - free")},
+                {"os", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "os", "snap - free")}},
             RS2::ActionSnapFree
         },
         // snap center
         {
-            {{"snapcenter", QObject::tr("snapcenter", "snap - center")}},
-            {{"sc", QObject::tr("sc", "snap - center")}},
+            {{"snapcenter", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "snapcenter", "snap - center")}},
+            {{"sc", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "sc", "snap - center")}},
             RS2::ActionSnapCenter
         },
         //snap dist
         {
-            {{"snapdist", QObject::tr("snapdist", "snap - distance to endpoints")}},
-            {{"sd", QObject::tr("sd", "snap - distance to endpoints")}},
+            {{"snapdist", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "snapdist", "snap - distance to endpoints")}},
+            {{"sd", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "sd", "snap - distance to endpoints")}},
             RS2::ActionSnapDist
         },
         // snap end
         {
-            {{"snapend", QObject::tr("snapend", "snap - end points")}},
-            {{"se", QObject::tr("se", "snap - end points")}},
+            {{"snapend", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "snapend", "snap - end points")}},
+            {{"se", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "se", "snap - end points")}},
             RS2::ActionSnapEndpoint
         },
         // snap grid
         {
-            {{"snapgrid", QObject::tr("snapgrid", "snap - grid")}},
-            {{"sg", QObject::tr("sg", "snap - grid")}},
+            {{"snapgrid", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "snapgrid", "snap - grid")}},
+            {{"sg", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "sg", "snap - grid")}},
             RS2::ActionSnapGrid
         },
         // snap intersection
         {
-            {{"snapintersection", QObject::tr("snapintersection", "snap - intersection")}},
-            {{"si", QObject::tr("si", "snap - intersection")}},
+            {{"snapintersection", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "snapintersection", "snap - intersection")}},
+            {{"si", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "si", "snap - intersection")}},
             RS2::ActionSnapIntersection
         },
         // snap middle
         {
-            {{"snapmiddle", QObject::tr("snapmiddle", "snap - middle points")}},
-            {{"sm", QObject::tr("sm", "snap - middle points")}},
+            {{"snapmiddle", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "snapmiddle", "snap - middle points")}},
+            {{"sm", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "sm", "snap - middle points")}},
             RS2::ActionSnapMiddle
         },
         // snap on entity
         {
-            {{"snaponentity", QObject::tr("snaponentity", "snap - on entity")}},
-            {{"sn", QObject::tr("sn", "snap - on entity")},
-                {"np", QObject::tr("np", "snap - on entity")}},
+            {{"snaponentity", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "snaponentity", "snap - on entity")}},
+            {{"sn", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "sn", "snap - on entity")},
+                {"np", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "np", "snap - on entity")}},
             RS2::ActionSnapOnEntity
         },
 
         /* Snap Middle Manual */
         {
             //list all <full command, translation> pairs
-            {{"snapmiddlemanual", QObject::tr("snapmiddlemanual", "snap middle manual")}}, 
-            {{"snapmanual", QObject::tr("snapmanual", "snap middle manual")}, 
-             {"smm", QObject::tr("smm", "snap middle manual")}}, 
+            {{"snapmiddlemanual", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "snapmiddlemanual", "snap middle manual")}},
+            {{"snapmanual", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "snapmanual", "snap middle manual")},
+             {"smm", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "smm", "snap middle manual")}},
 
             RS2::ActionSnapMiddleManual
         },
 
         // set relative zero
         {
-            {{"setrelativezero", QObject::tr("setrelativezero", "set relative zero position")}},
-            {{"rz", QObject::tr("rz", "set relative zero position")}},
+            {{"setrelativezero", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "setrelativezero", "set relative zero position")}},
+            {{"rz", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rz", "set relative zero position")}},
             RS2::ActionSetRelativeZero
         },
         // snap restrictions
         {
-            {{"restrictnothing", QObject::tr("restrictnothing", "restrict - nothing")}},
-            {{"rn", QObject::tr("rn", "restrict - nothing")}},
+            {{"restrictnothing", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "restrictnothing", "restrict - nothing")}},
+            {{"rn", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rn", "restrict - nothing")}},
             RS2::ActionRestrictNothing
         },
         // snap orthogonal
         {
-            {{"restrictorthogonal", QObject::tr("restrictorthogonal", "restrict - orthogonal")}},
-            {{"rr", QObject::tr("rr", "restrict - orthogonal")}},
+            {{"restrictorthogonal", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "restrictorthogonal", "restrict - orthogonal")}},
+            {{"rr", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rr", "restrict - orthogonal")}},
             RS2::ActionRestrictOrthogonal
         },
         // snap horizontal
         {
-            {{"restricthorizontal", QObject::tr("restricthorizontal", "restrict - horizontal")}},
-            {{"rh", QObject::tr("rh", "restrict - horizontal")}},
+            {{"restricthorizontal", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "restricthorizontal", "restrict - horizontal")}},
+            {{"rh", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rh", "restrict - horizontal")}},
             RS2::ActionRestrictHorizontal
         },
         // snap vertical
         {
-            {{"restrictvertical", QObject::tr("restrictvertical", "restrict - vertical")}},
-            {{"rv", QObject::tr("rv", "restrict - vertical")}},
+            {{"restrictvertical", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "restrictvertical", "restrict - vertical")}},
+            {{"rv", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rv", "restrict - vertical")}},
             RS2::ActionRestrictVertical
         },
 
@@ -957,65 +984,65 @@ RS_Commands::RS_Commands() {
         /* EDIT COMMANDS */
         // kill actions
         {
-            {{"kill", QObject::tr("kill", "kill all actions")}},
-            {{"ki", QObject::tr("ki", "kill all actions")},
-                {"k", QObject::tr("k", "kill all actions")}},
+            {{"kill", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "kill", "kill all actions")}},
+            {{"ki", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ki", "kill all actions")},
+                {"k", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "k", "kill all actions")}},
             RS2::ActionEditKillAllActions
         },
         // undo cycle
         {
-            {{"undo", QObject::tr("undo", "undo cycle")}},
-            {{"un", QObject::tr("un", "undo cycle")},
-                {"u", QObject::tr("u", "undo cycle")}},
+            {{"undo", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "undo", "undo cycle")}},
+            {{"un", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "un", "undo cycle")},
+                {"u", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "u", "undo cycle")}},
             RS2::ActionEditUndo
         },
         // redo cycle
         {
-            {{"redo", QObject::tr("redo", "redo cycle")}},
-            {{"rd", QObject::tr("rd", "redo cycle")},
-                {"r", QObject::tr("r", "redo cycle")}},
+            {{"redo", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "redo", "redo cycle")}},
+            {{"rd", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rd", "redo cycle")},
+                {"r", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "r", "redo cycle")}},
             RS2::ActionEditRedo
         },
 
         /* OPTIONS COMMANDS */
         // Drawing Prefs - v2.2.0r2
         {
-            {{"drawpref", QObject::tr("drawpref", "drawing preferences")}},
-            {{"dp", QObject::tr("dp", "drawing preferences")}},
+            {{"drawpref", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "drawpref", "drawing preferences")}},
+            {{"dp", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "dp", "drawing preferences")}},
             RS2::ActionOptionsDrawing
         },
 
         /* VIEW COMMANDS */
         // zoom redraw
         {
-            {{"regen", QObject::tr("regen", "zoom - redraw")},
-                {"redraw", QObject::tr("redraw", "zoom - redraw")}},
-            {{"rg", QObject::tr("rg", "zoom - redraw")},
-                {"zr", QObject::tr("zr", "zoom - redraw")}},
+            {{"regen", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "regen", "zoom - redraw")},
+                {"redraw", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "redraw", "zoom - redraw")}},
+            {{"rg", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rg", "zoom - redraw")},
+                {"zr", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "zr", "zoom - redraw")}},
             RS2::ActionZoomRedraw
         },
         // zoom auto
         {
-            {{"zoomauto", QObject::tr("zoomauto", "zoom - auto")}},
-            {{"za", QObject::tr("za", "zoom - auto")}},
+            {{"zoomauto", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "zoomauto", "zoom - auto")}},
+            {{"za", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "za", "zoom - auto")}},
             RS2::ActionZoomAuto
         },
         // zoom previous
         {
-            {{"zoomprevious", QObject::tr("zoomprevious", "zoom - previous")}},
-            {{"zv", QObject::tr("zv", "zoom - previous")}},
+            {{"zoomprevious", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "zoomprevious", "zoom - previous")}},
+            {{"zv", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "zv", "zoom - previous")}},
             RS2::ActionZoomPrevious
         },
         // zoom window
         {
-            {{"zoomwindow", QObject::tr("zoomwindow", "zoom - window")}},
-            {{"zw", QObject::tr("zw", "zoom - window")}},
+            {{"zoomwindow", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "zoomwindow", "zoom - window")}},
+            {{"zw", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "zw", "zoom - window")}},
             RS2::ActionZoomWindow
         },
         // zoom pan
         {
-            {{"zoompan", QObject::tr("zoompan", "zoom - pan")}},
-            {{"zp", QObject::tr("zp", "zoom - pan")}},
+            {{"zoompan", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "zoompan", "zoom - pan")}},
+            {{"zp", LC_CommandText QT_TRANSLATE_NOOP3("QObject", "zp", "zoom - pan")}},
             RS2::ActionZoomPan
         }
     };
@@ -1024,222 +1051,228 @@ RS_Commands::RS_Commands() {
         auto const act=c0.actionType;
         //add full commands
         for(auto const& p0: c0.fullCmdList){
-            if (isCollisionFree(m_cmdTranslation, p0.first, p0.second))
-                m_cmdTranslation[p0.first] = p0.second;
-            if (isCollisionFree(m_mainCommands, p0.second, act, m_actionToCommand.count(act) ? m_actionToCommand[act] : QString{})) {
-                m_mainCommands[p0.second] = act;
-                m_actionToCommand.emplace(act, p0.second);
+            const QString original = resolveCommandText(p0.first);
+            const QString translated = resolveCommandText(p0.second);
+            if (isCollisionFree(m_cmdTranslation, original, translated))
+                m_cmdTranslation[original] = translated;
+            if (isCollisionFree(m_mainCommands, translated, act, m_actionToCommand.count(act) ? m_actionToCommand[act] : QString{})) {
+                m_mainCommands[translated] = act;
+                m_actionToCommand.emplace(act, translated);
             }
         }
         for(auto const& p0: c0.fullCmdList){
-            if(isCollisionFree(m_mainCommands, p0.first, act, m_actionToCommand.count(act) ? m_actionToCommand[act] : QString{})) {
+            const QString original = resolveCommandText(p0.first);
+            if(isCollisionFree(m_mainCommands, original, act, m_actionToCommand.count(act) ? m_actionToCommand[act] : QString{})) {
                 // enable english commands, if no conflict is found
-                m_mainCommands[p0.first]=act;
-                m_actionToCommand.emplace(act, p0.first);
+                m_mainCommands[original]=act;
+                m_actionToCommand.emplace(act, original);
             }
         }
         //add short commands
         for(auto const& p1: c0.shortCmdList){
-            if(isCollisionFree(m_cmdTranslation, p1.first, p1.second))
-                m_cmdTranslation[p1.first]=p1.second;
-            if(isCollisionFree(m_shortCommands, p1.second, act, m_actionToCommand.count(act) ? m_actionToCommand[act] : QString{})) {
-                m_shortCommands[p1.second]=act;
+            const QString original = resolveCommandText(p1.first);
+            const QString translated = resolveCommandText(p1.second);
+            if(isCollisionFree(m_cmdTranslation, original, translated))
+                m_cmdTranslation[original]=translated;
+            if(isCollisionFree(m_shortCommands, translated, act, m_actionToCommand.count(act) ? m_actionToCommand[act] : QString{})) {
+                m_shortCommands[translated]=act;
                 if (m_actionToCommand.count(act) == 0)
-                    m_actionToCommand.emplace(act, p1.second);
+                    m_actionToCommand.emplace(act, translated);
             }
         }
         for(auto const& p1: c0.shortCmdList){
-            if(isCollisionFree(m_shortCommands, p1.first, act, m_actionToCommand.count(act) ? m_actionToCommand[act] : QString{})) {
+            const QString original = resolveCommandText(p1.first);
+            if(isCollisionFree(m_shortCommands, original, act, m_actionToCommand.count(act) ? m_actionToCommand[act] : QString{})) {
                 // enable english short commands, if no conflict is found
-                m_shortCommands[p1.first]=act;
+                m_shortCommands[original]=act;
                 if (m_actionToCommand.count(act) == 0)
-                    m_actionToCommand.emplace(act, p1.second);
+                    m_actionToCommand.emplace(act, original);
             }
         }
     }
 
     // translations
-    std::vector<std::pair<QString, QString>> transList={
-        {"angle",QObject::tr("angle")},
-        {"dpi",QObject::tr("dpi")},
-        {"close",QObject::tr("close")},
-        {"chord length",QObject::tr("chord length")},
-        {"columns",QObject::tr("columns")},
-        {"columnspacing",QObject::tr("columnspacing")},
-        {"equation",QObject::tr("equation")},
-        {"factor",QObject::tr("factor")},
-        {"length",QObject::tr("length")},
-        {"length1",QObject::tr("length1", "bevel/fillet length1")},
-        {"length2",QObject::tr("length2", "bevel/fillet length2")},
-        {"number",QObject::tr("number")},
-        {"radius",QObject::tr("radius")},
-        {"rows",QObject::tr("rows")},
-        {"rowspacing",QObject::tr("rowspacing")},
-        {"through",QObject::tr("through")},
-        {"trim",QObject::tr("trim")},
+    std::vector<std::pair<LC_CommandText, LC_CommandText>> transList={
+        {"angle",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "angle"), true)},
+        {"dpi",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "dpi"), true)},
+        {"close",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "close"), true)},
+        {"chord length",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "chord length"), true)},
+        {"columns",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "columns"), true)},
+        {"columnspacing",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "columnspacing"), true)},
+        {"equation",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "equation"), true)},
+        {"factor",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "factor"), true)},
+        {"length",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "length"), true)},
+        {"length1",LC_CommandText QT_TRANSLATE_NOOP3("QObject", "length1", "bevel/fillet length1")},
+        {"length2",LC_CommandText QT_TRANSLATE_NOOP3("QObject", "length2", "bevel/fillet length2")},
+        {"number",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "number"), true)},
+        {"radius",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "radius"), true)},
+        {"rows",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "rows"), true)},
+        {"rowspacing",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "rowspacing"), true)},
+        {"through",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "through"), true)},
+        {"trim",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "trim"), true)},
 
         // commands for relative line drawing actions
-        {"x",QObject::tr("x")},
-        {"y",QObject::tr("y")},
-        {"p",QObject::tr("p")},
-        {"anglerel",QObject::tr("anglerel")},
-        {"start",QObject::tr("start")},
+        {"x",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "x"), true)},
+        {"y",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "y"), true)},
+        {"p",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "p"), true)},
+        {"anglerel",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "anglerel"), true)},
+        {"start",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "start"), true)},
 
         // commands for line angle rel action
-        {"offset",QObject::tr("offset")},
-        {"linesnap",QObject::tr("linesnap")},
-        {"ticksnap",QObject::tr("ticksnap")},
+        {"offset",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "offset"), true)},
+        {"linesnap",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "linesnap"), true)},
+        {"ticksnap",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "ticksnap"), true)},
 
         // rectangle one point
-        {"width",QObject::tr("width")},
-        {"height",QObject::tr("height")},
-        {"pos",QObject::tr("pos")},
-        {"size",QObject::tr("size")},
-        {"bevels",QObject::tr("bevels")},
-        {"nopoly",QObject::tr("nopoly")},
-        {"usepoly",QObject::tr("usepoly")},
-        {"corners",QObject::tr("corners")},
-        {"str",QObject::tr("str")},
-        {"round",QObject::tr("round")},
-        {"bevels",QObject::tr("bevels")},
-        {"snap1",QObject::tr("snap1")},
-        {"topl",QObject::tr("topl")},
-        {"top",QObject::tr("top")},
-        {"topr",QObject::tr("topr")},
-        {"left",QObject::tr("left")},
-        {"middle",QObject::tr("middle")},
-        {"right",QObject::tr("right")},
-        {"bottoml",QObject::tr("bottoml")},
-        {"bottom",QObject::tr("bottom")},
-        {"bottomr",QObject::tr("bottomr")},
-        {"snapcorner",QObject::tr("snapcorner")},
-        {"snapshift",QObject::tr("snapshift")},
-        {"sizein",QObject::tr("sizein")},
-        {"sizeout",QObject::tr("sizeout")},
-        {"hor",QObject::tr("hor")},
-        {"vert",QObject::tr("vert")},
+        {"width",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "width"), true)},
+        {"height",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "height"), true)},
+        {"pos",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "pos"), true)},
+        {"size",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "size"), true)},
+        {"bevels",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "bevels"), true)},
+        {"nopoly",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "nopoly"), true)},
+        {"usepoly",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "usepoly"), true)},
+        {"corners",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "corners"), true)},
+        {"str",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "str"), true)},
+        {"round",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "round"), true)},
+        {"bevels",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "bevels"), true)},
+        {"snap1",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "snap1"), true)},
+        {"topl",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "topl"), true)},
+        {"top",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "top"), true)},
+        {"topr",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "topr"), true)},
+        {"left",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "left"), true)},
+        {"middle",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "middle"), true)},
+        {"right",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "right"), true)},
+        {"bottoml",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "bottoml"), true)},
+        {"bottom",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "bottom"), true)},
+        {"bottomr",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "bottomr"), true)},
+        {"snapcorner",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "snapcorner"), true)},
+        {"snapshift",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "snapshift"), true)},
+        {"sizein",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "sizein"), true)},
+        {"sizeout",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "sizeout"), true)},
+        {"hor",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "hor"), true)},
+        {"vert",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "vert"), true)},
 
         // rect 2 points
-        {"snap2",QObject::tr("snap2")},
-        {"corner",QObject::tr("corner")},
-        {"mid-vert",QObject::tr("mid-vert")},
-        {"mid-hor",QObject::tr("mid-hor")},
+        {"snap2",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "snap2"), true)},
+        {"corner",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "corner"), true)},
+        {"mid-vert",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "mid-vert"), true)},
+        {"mid-hor",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "mid-hor"), true)},
         // rect 3 points
-        {"quad",QObject::tr("quad")},
-        {"noquad",QObject::tr("noquad")},
-        {"angle_inner",QObject::tr("angle_inner")},
+        {"quad",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "quad"), true)},
+        {"noquad",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "noquad"), true)},
+        {"angle_inner",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "angle_inner"), true)},
 
         // line points
-        {"edges",QObject::tr("edges")},
-        {"edge-none",QObject::tr("edge-none")},
-        {"edge-both",QObject::tr("edge-both")},
-        {"edge-start",QObject::tr("edge-start")},
-        {"edge-end",QObject::tr("edge-end")},
-        {"end",QObject::tr("end")},
-        {"both",QObject::tr("both")},
-        {"none",QObject::tr("none")},
-        {"fit",QObject::tr("fit")},
-        {"nofit",QObject::tr("nofit")},
-        {"dist_fixed",QObject::tr("dist_fixed")},
-        {"dist_flex",QObject::tr("dist_flex")},
-        {"distance",QObject::tr("distance")},
+        {"edges",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "edges"), true)},
+        {"edge-none",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "edge-none"), true)},
+        {"edge-both",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "edge-both"), true)},
+        {"edge-start",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "edge-start"), true)},
+        {"edge-end",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "edge-end"), true)},
+        {"end",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "end"), true)},
+        {"both",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "both"), true)},
+        {"none",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "none"), true)},
+        {"fit",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "fit"), true)},
+        {"nofit",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "nofit"), true)},
+        {"dist_fixed",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "dist_fixed"), true)},
+        {"dist_flex",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "dist_flex"), true)},
+        {"distance",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "distance"), true)},
 
 
         // star
-        {"sym",QObject::tr("sym")},
-        {"nosym",QObject::tr("nosym")},
+        {"sym",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "sym"), true)},
+        {"nosym",LC_CommandText(QT_TRANSLATE_NOOP("QObject", "nosym"), true)},
         // commands
 
         /** following are reversed translation,i.e.,from translated to english **/
         //not used as command keywords
         // used in function,checkCommand()
-        {QObject::tr("angle"),"angle"},
-        {QObject::tr("ang", "angle"),"angle"},
-        {QObject::tr("an", "angle"),"angle"},
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "angle"), true),"angle"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ang", "angle"),"angle"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "an", "angle"),"angle"},
 
-        {QObject::tr("center"),"center"},
-        {QObject::tr("cen", "center"),"center"},
-        {QObject::tr("ce", "center"),"center"},
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "center"), true),"center"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "cen", "center"),"center"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ce", "center"),"center"},
 
-        {QObject::tr("chord length"),"chord length"},
-        //    {QObject::tr("length", "chord length"),"chord length"},
-        {QObject::tr("cl", "chord length"),"chord length"},
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "chord length"), true),"chord length"},
+        //    {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "length", "chord length"),"chord length"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "cl", "chord length"),"chord length"},
 
-        {QObject::tr("close"),"close"},
-        {QObject::tr("c", "close"),"close"},
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "close"), true),"close"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "c", "close"),"close"},
 
-        {QObject::tr("columns"),"columns"},
-        {QObject::tr("cols", "columns"),"columns"},
-        {QObject::tr("co", "columns"),"columns"},
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "columns"), true),"columns"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "cols", "columns"),"columns"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "co", "columns"),"columns"},
 
-        {QObject::tr("columnspacing", "columnspacing for inserts"),"columnspacing"},
-        {QObject::tr("colspacing", "columnspacing for inserts"),"columnspacing"},
-        {QObject::tr("cs", "columnspacing for inserts"),"columnspacing"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "columnspacing", "columnspacing for inserts"),"columnspacing"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "colspacing", "columnspacing for inserts"),"columnspacing"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "cs", "columnspacing for inserts"),"columnspacing"},
 
-        {QObject::tr("factor"),"factor"},
-        {QObject::tr("fact", "factor"),"factor"},
-        {QObject::tr("f", "factor"),"factor"},
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "factor"), true),"factor"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "fact", "factor"),"factor"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "f", "factor"),"factor"},
 
-        {QObject::tr("equation"),"equation"},
-        {QObject::tr("eqn", "equation"),"equation"},
-        {QObject::tr("eq", "equation"),"equation"},
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "equation"), true),"equation"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "eqn", "equation"),"equation"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "eq", "equation"),"equation"},
 
-        {QObject::tr("help"),"help"},
-        {QObject::tr("?", "help"),"help"},
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "help"), true),"help"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "?", "help"),"help"},
 
-        {QObject::tr("length","length"),"length"},
-        {QObject::tr("len","length"),"length"},
-        {QObject::tr("l","length"),"length"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "length", "length"),"length"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "len", "length"),"length"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "l", "length"),"length"},
 
-        {QObject::tr("length1","length1"),"length1"},
-        {QObject::tr("len1","length1"),"length1"},
-        {QObject::tr("l1","length1"),"length1"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "length1", "length1"),"length1"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "len1", "length1"),"length1"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "l1", "length1"),"length1"},
 
-        {QObject::tr("length2","length2"),"length2"},
-        {QObject::tr("len2","length2"),"length2"},
-        {QObject::tr("l2","length2"),"length2"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "length2", "length2"),"length2"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "len2", "length2"),"length2"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "l2", "length2"),"length2"},
 
-        {QObject::tr("number","number"),"number"},
-        {QObject::tr("num","number"),"number"},
-        {QObject::tr("n","number"),"number"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "number", "number"),"number"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "num", "number"),"number"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "n", "number"),"number"},
 
-        {QObject::tr("radius"),"radius"},
-        {QObject::tr("ra","radius"),"radius"},
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "radius"), true),"radius"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "ra", "radius"),"radius"},
 
-        {QObject::tr("reversed","reversed"),"reversed"},
-        {QObject::tr("rev","reversed"),"reversed"},
-        {QObject::tr("rev","reversed"),"reversed"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "reversed", "reversed"),"reversed"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rev", "reversed"),"reversed"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rev", "reversed"),"reversed"},
 
-        {QObject::tr("row", "row"),"row"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "row", "row"),"row"},
 
-        {QObject::tr("rowspacing", "rowspacing for inserts"),"rowspacing"},
-        {QObject::tr("rs","rowspacing for inserts"),"rowspacing"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rowspacing", "rowspacing for inserts"),"rowspacing"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "rs", "rowspacing for inserts"),"rowspacing"},
 
-        {QObject::tr("text"),"text"},
-        {QObject::tr("t","text"),"text"},
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "text"), true),"text"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "t", "text"),"text"},
 
-        {QObject::tr("through"),"through"},
-        {QObject::tr("t","through"),"through"},
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "through"), true),"through"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "t", "through"),"through"},
 
-        {QObject::tr("undo"),"undo"},
-        {QObject::tr("u","undo"),"undo"},
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "undo"), true),"undo"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "u", "undo"),"undo"},
 
-        {QObject::tr("redo"),"redo"},
-        {QObject::tr("r","redo"),"redo"},
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "redo"), true),"redo"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "r", "redo"),"redo"},
 
-        {QObject::tr("back"),"back"},
-        {QObject::tr("b","back"),"back"},
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "back"), true),"back"},
+        {LC_CommandText QT_TRANSLATE_NOOP3("QObject", "b", "back"),"back"},
         //printer preview
-        {QObject::tr("bw"), "blackwhite"},
-        {QObject::tr("blackwhite"), "blackwhite"},
-        {QObject::tr("color"), "color"},
-        {QObject::tr("paperoffset"),"paperoffset"},
-        {QObject::tr("graphoffset"),"graphoffset"}
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "bw"), true), "blackwhite"},
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "blackwhite"), true), "blackwhite"},
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "color"), true), "color"},
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "paperoffset"), true),"paperoffset"},
+        {LC_CommandText(QT_TRANSLATE_NOOP("QObject", "graphoffset"), true),"graphoffset"}
 
         // fixme - add reversive translation for added commands
     };
     for(auto const& p: transList){
-        m_cmdTranslation[p.first] = p.second;
+        m_cmdTranslation[resolveCommandText(p.first)] = resolveCommandText(p.second);
     }
 }
 
@@ -1421,6 +1454,17 @@ QString RS_Commands::command(const QString& cmd) {
     RS_DEBUG->print(RS_Debug::D_WARNING,
                     "RS_Commands::command: command '%s' unknown", cmd.toLatin1().data());
     return "";
+}
+
+QString RS_Commands::localizedCommand(const char* source, const char* disambiguation,
+                                      const char* context) {
+    return RS_SYSTEM->translateCommand(source, disambiguation, context);
+}
+
+bool RS_Commands::matchesLocalizedCommand(const QString& command, const char* source,
+                                          const char* disambiguation, const char* context) {
+    return command.compare(QLatin1String(source), Qt::CaseInsensitive) == 0
+           || command.compare(localizedCommand(source, disambiguation, context), Qt::CaseInsensitive) == 0;
 }
 
 

--- a/librecad/src/cmd/rs_commands.h
+++ b/librecad/src/cmd/rs_commands.h
@@ -58,6 +58,11 @@ public:
     RS2::ActionType keycodeToAction(const QString& code) const;
 
     static QString command(const QString& cmd);
+    static QString localizedCommand(const char* source, const char* disambiguation = nullptr,
+                                    const char* context = "QObject");
+    static bool matchesLocalizedCommand(const QString& command, const char* source,
+                                        const char* disambiguation = nullptr,
+                                        const char* context = "QObject");
 
     static bool checkCommand(const QString& cmd, const QString& str,
                              RS2::ActionType action=RS2::ActionNone);

--- a/librecad/src/lib/engine/rs_system.cpp
+++ b/librecad/src/lib/engine/rs_system.cpp
@@ -390,14 +390,9 @@ void RS_System::initAllLanguagesList() {
 
 
 /**
- * Loads a different translation for the application GUI.
- *
- *fixme, need to support command language
+ * Loads .qm translation files for the application GUI and command line.
  */
-/**
- * Loads .qm translation files matching the requested language (case-insensitive).
- */
-void RS_System::loadTranslation(const QString& lang, const QString& /*langCmd*/)
+void RS_System::loadTranslation(const QString& lang, const QString& langCmd)
 {
     if (lang.trimmed().isEmpty())
         return;
@@ -473,13 +468,48 @@ void RS_System::loadTranslation(const QString& lang, const QString& /*langCmd*/)
             }
 
             if (tr[0] && tr[1] && tr[2])
-                return;
+                break;
         }
+
+        if (tr[0] && tr[1] && tr[2])
+            break;
     }
 
     if (!loadedAny) {
         LC_ERR << "No matching .qm files for language: " << lang;
     }
+
+    delete m_commandTranslator;
+    m_commandTranslator = nullptr;
+
+    if (langCmd.trimmed().isEmpty())
+        return;
+
+    const QLocale commandLocale(langCmd.trimmed());
+    for (const QString& path : std::as_const(paths)) {
+        QDir dir(path);
+        for (const QString& file : dir.entryList({"librecad_*.qm"}, QDir::Files)) {
+            QString language = file.mid(9);
+            language.chop(3);
+            if (commandLocale != QLocale(language))
+                continue;
+
+            QTranslator* translator = new QTranslator(nullptr);
+            if (translator->load(dir.absoluteFilePath(file))) {
+                m_commandTranslator = translator;
+                return;
+            }
+            delete translator;
+        }
+    }
+}
+
+QString RS_System::translateCommand(const char* source, const char* disambiguation,
+                                    const char* context) const {
+    const QString translation = m_commandTranslator != nullptr
+                                    ? m_commandTranslator->translate(context, source, disambiguation)
+                                    : QString{};
+    return translation.isEmpty() ? QString::fromUtf8(source) : translation;
 }
 
 /**

--- a/librecad/src/lib/engine/rs_system.h
+++ b/librecad/src/lib/engine/rs_system.h
@@ -37,6 +37,8 @@
 
 #define RS_SYSTEM RS_System::instance()
 
+class QTranslator;
+
 /**
  * Class for some system methods such as file system operations.
  * Implemented as singleton. Use init to Initialize the class
@@ -176,6 +178,8 @@ public:
     static QString getEncoding(const QString& str);
 
     void loadTranslation(const QString& lang, const QString& langCmd);
+    QString translateCommand(const char* source, const char* disambiguation = nullptr,
+                             const char* context = "QObject") const;
 
     static bool test();
 
@@ -199,6 +203,7 @@ protected:
     bool initialized {false};
     bool externalAppDir {false};
     QList<QSharedPointer<RS_Locale> > allKnownLocales;
+    QTranslator* m_commandTranslator{nullptr};
 };
 
 #endif

--- a/librecad/src/ui/forms/qg_commandwidget.cpp
+++ b/librecad/src/ui/forms/qg_commandwidget.cpp
@@ -251,7 +251,8 @@ void QG_CommandWidget::tabPressed() {
 void QG_CommandWidget::escape() {
     //leCommand->clearFocus();
     if (actionHandler) {
-        actionHandler->command(QString(tr("escape", "escape, go back from action steps")));
+        actionHandler->command(RS_Commands::localizedCommand("escape", "escape, go back from action steps",
+                                                              "QG_ActionHandler"));
     }
 }
 

--- a/librecad/src/ui/forms/qg_dlginitial.cpp
+++ b/librecad/src/ui/forms/qg_dlginitial.cpp
@@ -91,7 +91,7 @@ void QG_DlgInitial::ok() {
     RS_SETTINGS->writeEntry("/Language",
                             cbLanguage->itemData(cbLanguage->currentIndex()));
     RS_SETTINGS->writeEntry("/LanguageCmd",
-                            cbLanguage->itemData(cbLanguage->currentIndex()));
+                            cbLanguageCmd->itemData(cbLanguageCmd->currentIndex()));
     RS_SETTINGS->endGroup();
 
     RS_SETTINGS->beginGroup("/Defaults");

--- a/librecad/src/ui/forms/qg_dlgoptionsgeneral.cpp
+++ b/librecad/src/ui/forms/qg_dlgoptionsgeneral.cpp
@@ -107,7 +107,7 @@ void QG_DlgOptionsGeneral::init()
 
     // set current language:
     setLanguageItem(cbLanguage, "/Language");
-    setLanguageItem(cbLanguageCmd, "/Language");
+    setLanguageItem(cbLanguageCmd, "/LanguageCmd");
 
     // graphic view:
 

--- a/librecad/src/ui/qg_actionhandler.cpp
+++ b/librecad/src/ui/qg_actionhandler.cpp
@@ -1279,7 +1279,8 @@ bool QG_ActionHandler::command(const QString& cmd)
     RS_DEBUG->print("QG_ActionHandler::command: %s", cmd.toLatin1().data());
     QString c = cmd.toLower();
 
-    if (c==tr("escape", "escape, go back from action steps"))
+    if (RS_Commands::matchesLocalizedCommand(c, "escape", "escape, go back from action steps",
+                                             "QG_ActionHandler"))
     {
         view->back();
         RS_DEBUG->print("QG_ActionHandler::command: back");

--- a/librecad/src/ui/qg_commandedit.cpp
+++ b/librecad/src/ui/qg_commandedit.cpp
@@ -38,6 +38,24 @@
 #include "rs_math.h"
 #include "rs_settings.h"
 
+namespace {
+int calculatorCommandLength(const QString& input, bool acceptColon = false) {
+    static constexpr const char* commandNames[] = {"cal", "calculate"};
+    for (const char* commandName : commandNames) {
+        const QString localized = RS_Commands::localizedCommand(commandName,
+                                                                 "command to trigger cli calculator");
+        for (const QString& candidate : {QString::fromLatin1(commandName), localized}) {
+            if (!input.startsWith(candidate, Qt::CaseInsensitive))
+                continue;
+            const int length = candidate.size();
+            if (input.size() == length || input.at(length).isSpace()
+                || (acceptColon && input.at(length) == QLatin1Char(':')))
+                return length;
+        }
+    }
+    return -1;
+}
+}
 
 /**
  * Default Constructor. You must call init manually if you choose
@@ -252,16 +270,12 @@ void QG_CommandEdit::processInput(QString input)
 QString QG_CommandEdit::filterCliCal(const QString& cmd)
 {
     QString str=cmd.trimmed();
-    const QRegularExpression calCmd(R"(^\s*(cal|calculate)\s?)", QRegularExpression::CaseInsensitiveOption);
-    QRegularExpressionMatch match = calCmd.match(str);
-    if(!(match.hasMatch()
-         || str.startsWith(QObject::tr("cal ","command to trigger cli calculator"), Qt::CaseInsensitive)
-         || str.startsWith(QObject::tr("calculate ","command to trigger cli calculator"), Qt::CaseInsensitive)
-                           )) {
+    const int commandLength = calculatorCommandLength(str);
+    if (commandLength < 0) {
         return cmd;
     }
-    int index = match.capturedEnd(0);
-    bool spaceFound=(index>=0);
+    int index = commandLength;
+    bool spaceFound = index < str.size() && str.at(index).isSpace();
     str=str.mid(index);
     index=str.indexOf(QRegularExpression(R"(\S)"));
     if(!(spaceFound && index>=0))
@@ -294,7 +308,7 @@ bool QG_CommandEdit::isForeignCommand(QString input)
     else if ((input = filterCliCal(input)).isEmpty()) {
         r_value = false;
     }
-    else if (input == QObject::tr("cal"))
+    else if (calculatorCommandLength(input.trimmed(), true) >= 0)
     {
         calculator_mode = !calculator_mode;
         if(calculator_mode)
@@ -391,5 +405,4 @@ void QG_CommandEdit::modifiedPaste()
     txt.replace("\n", ";");
     setText(txt);
 }
-
 


### PR DESCRIPTION
Fixes #976.

This maintenance-branch fix makes the command-language setting independent from the GUI language. It stores each command translation with its source text and disambiguation, loads the selected command catalog without installing it globally, and uses that catalog for command-line-only keywords.

It also fixes the two command-language preference widgets, which previously read or wrote the GUI language setting.

Validation:
- Compared lupdate output for `rs_commands.cpp` with `origin/2.2.1`: identical source/comment metadata (440 messages).
- Compiled a German catalog and verified the disambiguated direct lookup for `length1` returns `Länge 1`.
- qmake6 compiled the changed command-edit, action-handler, and initial-dialog units; the legacy branch cannot complete a Qt 6 build due to pre-existing Qt 5-only dependencies (`QTextCodec`, `QRegExp`, and a `QStringList` declaration conflict). Qt 5 is not installed on this host.