### PR TITLE
Start polyline commands in line mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2474,6 +2474,7 @@ if (BUILD_TESTS)
         librecad/src/lib/modification/tests/rs_modification_trim_tests.cpp
         librecad/src/lib/filters/tests/dwg_buffer_round_trip_tests.cpp
         librecad/src/lib/creation/tests/lc_action_draw_line_parallel_tests.cpp
+        librecad/src/lib/creation/tests/lc_action_draw_polyline_tests.cpp
         librecad/src/lib/engine/undo/tests/rs_undo_tests.cpp
         librecad/src/lib/filters/tests/dwg_entity_encode_round_trip_tests.cpp
         librecad/src/lib/filters/tests/dwg_header_encode_round_trip_tests.cpp
@@ -2794,6 +2795,9 @@ if (BUILD_TESTS)
     add_librecad_filter_micro_test(
         librecad_acis_wireframe_tests
         librecad/src/lib/filters/tests/acis_wireframe_tests.cpp)
+    add_librecad_filter_micro_test(
+        librecad_polyline_command_tests
+        librecad/src/lib/creation/tests/lc_action_draw_polyline_tests.cpp)
     add_executable(librecad_console_command_utils_tests
         EXCLUDE_FROM_ALL
         librecad/src/main/lc_release_label.cpp

--- a/librecad/src/actions/drawing/draw/polyline/lc_action_draw_polyline.cpp
+++ b/librecad/src/actions/drawing/draw/polyline/lc_action_draw_polyline.cpp
@@ -41,8 +41,9 @@
 #include "emu_c99.h"
 #endif
 
-LC_ActionDrawPolyline::LC_ActionDrawPolyline(LC_ActionContext *actionContext)
+LC_ActionDrawPolyline::LC_ActionDrawPolyline(LC_ActionContext *actionContext, const bool startInLineMode)
         :LC_UndoableDocumentModificationAction("ActionDrawPolyline",actionContext, RS2::ActionDrawPolyline)
+        , m_startInLineMode(startInLineMode)
         , m_actionData(std::make_unique<Points>()){
     reset();
 }
@@ -56,7 +57,9 @@ LC_ActionDrawPolyline::LC_ActionDrawPolyline(const QString& name, LC_ActionConte
 LC_ActionDrawPolyline::~LC_ActionDrawPolyline() = default;
 
 void LC_ActionDrawPolyline::doSaveOptions() {
-    save("Mode", m_mode);
+    if (!m_startInLineMode || m_modeWasExplicitlySet) {
+        save("Mode", m_mode);
+    }
     save("Radius", m_radius);
     save("Angle", m_angleDegrees);
     save("Reversed", m_reversed);
@@ -64,7 +67,7 @@ void LC_ActionDrawPolyline::doSaveOptions() {
 
 void LC_ActionDrawPolyline::doLoadOptions() {
     int mode = loadInt("Mode", SegmentMode::Line);
-    m_mode = static_cast<SegmentMode>(mode);
+    m_mode = m_startInLineMode ? Line : static_cast<SegmentMode>(mode);
     m_radius = loadDouble("Radius", 10.0);
     m_angleDegrees = loadDouble("Angle", 90.0);
     m_reversed = loadBool("Reversed", false);
@@ -450,6 +453,7 @@ void LC_ActionDrawPolyline::onCoordinateEvent(const int status, [[maybe_unused]]
 
 void LC_ActionDrawPolyline::setMode(const SegmentMode m){
     m_mode = m;
+    m_modeWasExplicitlySet = true;
     updateActionPrompt();
 }
 
@@ -506,27 +510,27 @@ bool LC_ActionDrawPolyline::doProcessCommand(const int status, const QString &co
     bool accept = false;
     // fixme - sand - register in commands
     if (checkCommand("li", command)){
-        m_mode = Line;
+        setMode(Line);
         updateOptions();
         accept = true;
     }
     else if (checkCommand("tan",command)){
-        m_mode = Tangential;
+        setMode(Tangential);
         updateOptions();
         accept = true;
     }
     else if (checkCommand("tar", command)){
-        m_mode = TangentalArcFixedRadius;
+        setMode(TangentalArcFixedRadius);
         updateOptions();
         accept = true;
     }
     else if (checkCommand("taa", command)){
-        m_mode = TangentalArcFixedRadius;
+        setMode(TangentalArcFixedAngle);
         updateOptions();
         accept = true;
     }
     else if (checkCommand("aa", command)){
-        m_mode = ArcFixedAngle;
+        setMode(ArcFixedAngle);
         updateOptions();
         accept = true;
     }

--- a/librecad/src/actions/drawing/draw/polyline/lc_action_draw_polyline.h
+++ b/librecad/src/actions/drawing/draw/polyline/lc_action_draw_polyline.h
@@ -62,7 +62,7 @@ public:
         // RadAngCenp
     };
 
-    explicit LC_ActionDrawPolyline(LC_ActionContext *actionContext);
+    explicit LC_ActionDrawPolyline(LC_ActionContext *actionContext, bool startInLineMode = false);
     ~LC_ActionDrawPolyline() override;
     void reset() const;
     void init(int status) override;
@@ -133,6 +133,8 @@ protected:
     double m_radius = 0.;
     double m_angleDegrees = 0.;
     SegmentMode m_mode{};
+    bool m_startInLineMode = false;
+    bool m_modeWasExplicitlySet = false;
     bool m_alternateArc = false;
     int m_reversed = 1;
     bool m_calculatedSegment = false;

--- a/librecad/src/lib/creation/tests/lc_action_draw_polyline_tests.cpp
+++ b/librecad/src/lib/creation/tests/lc_action_draw_polyline_tests.cpp
@@ -1,0 +1,198 @@
+/****************************************************************************
+**
+** This file is part of the LibreCAD project, a 2D CAD program
+**
+** Copyright (C) 2026 LibreCAD.org
+** Copyright (C) 2026 Dongxu Li (github.com/dxli)
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+**********************************************************************/
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+
+#include <QApplication>
+#include <QSettings>
+
+#include "lc_action_draw_polyline.h"
+#include "lc_actioncontext.h"
+#include "lc_actionhandlerfactory.h"
+#include "lc_defaultactioncontext.h"
+#include "lc_snapmanager.h"
+#include "qg_actionhandler.h"
+#include "rs_commands.h"
+#include "rs_graphic.h"
+#include "rs_graphicview.h"
+#include "rs_settings.h"
+
+namespace {
+
+QApplication* application() {
+    static int argc = 1;
+    static char name[] = "librecad_tests";
+    static char* argv[] = {name, nullptr};
+    static QApplication* app = [] {
+        auto* existing = qobject_cast<QApplication*>(QCoreApplication::instance());
+        return existing != nullptr ? existing : new QApplication(argc, argv);
+    }();
+    static bool settingsReady = [] {
+        QCoreApplication::setOrganizationName("LibreCAD");
+        QCoreApplication::setApplicationName("LibreCAD-tests");
+        RS_Settings::init("LibreCAD", "LibreCAD-tests");
+        return true;
+    }();
+    (void)settingsReady;
+    return app;
+}
+
+class SettingGuard {
+public:
+    SettingGuard(RS_Settings* settings, QString group, QString key)
+        : m_settings(settings), m_group(std::move(group)), m_key(std::move(key)),
+          m_fullKey(QString("/%1/%2").arg(m_group, m_key)),
+          m_existed(settings->getSettings()->contains(m_fullKey)),
+          m_value(settings->getSettings()->value(m_fullKey)) {}
+
+    ~SettingGuard() {
+        const auto groupGuard = m_settings->beginGroupGuard(m_group);
+        if (m_existed) {
+            m_settings->write(m_key, m_value);
+        }
+        else {
+            m_settings->remove(m_key);
+        }
+    }
+
+    void set(const int value) const { m_settings->writeSingle(m_group, m_key, value); }
+
+private:
+    RS_Settings* m_settings;
+    QString m_group;
+    QString m_key;
+    QString m_fullKey;
+    bool m_existed;
+    QVariant m_value;
+};
+
+class PolylineActionTestView final : public RS_GraphicView {
+public:
+    PolylineActionTestView() : RS_GraphicView(nullptr) {}
+
+    int getWidth() const override { return 640; }
+    int getHeight() const override { return 480; }
+    void redraw([[maybe_unused]] RS2::RedrawMethod method = RS2::RedrawAll,
+                [[maybe_unused]] bool immediately = false) override {}
+    void adjustOffsetControls() override {}
+    void adjustZoomControls() override {}
+    void setMouseCursor([[maybe_unused]] RS2::CursorType cursor) override {}
+    void updateGridStatusWidget([[maybe_unused]] QString status) override {}
+};
+
+class CommandCapturingActionHandler final : public QG_ActionHandler {
+public:
+    CommandCapturingActionHandler() : QG_ActionHandler(nullptr) {}
+
+    mutable RS2::ActionType actionType = RS2::ActionNone;
+    mutable bool startInLineMode = false;
+
+    std::shared_ptr<RS_ActionInterface> createActionInstance(const RS2::ActionType type,
+                                                              void* data) const override {
+        actionType = type;
+        startInLineMode = data != nullptr && *static_cast<const bool*>(data);
+        return {};
+    }
+};
+
+struct PolylineActionFixture {
+    const bool m_qtReady{application() != nullptr};
+    RS_Graphic m_graphic;
+    PolylineActionTestView m_view;
+    LC_ActionContext m_context;
+
+    PolylineActionFixture() {
+        m_graphic.initForNewDocument();
+        m_view.setDocument(&m_graphic);
+        m_context.setDocumentAndView(&m_graphic, &m_view);
+    }
+};
+
+struct CommandDispatchFixture {
+    const bool m_qtReady{application() != nullptr};
+    RS_Graphic m_graphic;
+    CommandCapturingActionHandler m_actionHandler;
+    LC_DefaultActionContext m_context{&m_actionHandler};
+    LC_SnapManager m_snapManager{nullptr};
+    PolylineActionTestView m_view;
+
+    CommandDispatchFixture() {
+        m_graphic.initForNewDocument();
+        m_view.setDocument(&m_graphic);
+        m_actionHandler.setActionContext(&m_context);
+        m_actionHandler.setDocumentAndView(&m_graphic, &m_view);
+        m_actionHandler.setSnapManager(&m_snapManager);
+    }
+};
+
+} // namespace
+
+TEST_CASE("polyline command always starts in line mode without resetting the tool preference",
+          "[polyline][issue1134]") {
+    PolylineActionFixture fixture;
+    CommandDispatchFixture dispatchFixture;
+    SettingGuard modeGuard{RS_SETTINGS, "ActionDrawPolyline", "Mode"};
+    modeGuard.set(LC_ActionDrawPolyline::TangentalArcFixedAngle);
+
+    CHECK(RS_COMMANDS->cmdToAction("polyline") == RS2::ActionDrawPolyline);
+    CHECK(RS_COMMANDS->cmdToAction("pl") == RS2::ActionDrawPolyline);
+    REQUIRE(dispatchFixture.m_actionHandler.command("pl"));
+    CHECK(dispatchFixture.m_actionHandler.actionType == RS2::ActionDrawPolyline);
+    CHECK(dispatchFixture.m_actionHandler.startInLineMode);
+
+    bool startInLineMode = true;
+    const auto commandAction = LC_ActionsHandlerFactory::createActionInstance(
+        RS2::ActionDrawPolyline, &fixture.m_context, &startInLineMode);
+    const auto* commandPolyline = dynamic_cast<const LC_ActionDrawPolyline*>(commandAction.get());
+    REQUIRE(commandPolyline != nullptr);
+    CHECK(commandPolyline->rtti() == RS2::ActionDrawPolyline);
+    CHECK(commandPolyline->getMode() == LC_ActionDrawPolyline::Line);
+
+    commandAction->saveOptions();
+    const auto toolAction = LC_ActionsHandlerFactory::createActionInstance(
+        RS2::ActionDrawPolyline, &fixture.m_context);
+    const auto* toolPolyline = dynamic_cast<const LC_ActionDrawPolyline*>(toolAction.get());
+    REQUIRE(toolPolyline != nullptr);
+    CHECK(toolPolyline->getMode() == LC_ActionDrawPolyline::TangentalArcFixedAngle);
+}
+
+TEST_CASE("explicit polyline mode changes update the tool preference", "[polyline][issue1134]") {
+    PolylineActionFixture fixture;
+    SettingGuard modeGuard{RS_SETTINGS, "ActionDrawPolyline", "Mode"};
+    modeGuard.set(LC_ActionDrawPolyline::Line);
+
+    bool startInLineMode = true;
+    const auto commandAction = LC_ActionsHandlerFactory::createActionInstance(
+        RS2::ActionDrawPolyline, &fixture.m_context, &startInLineMode);
+    auto* commandPolyline = dynamic_cast<LC_ActionDrawPolyline*>(commandAction.get());
+    REQUIRE(commandPolyline != nullptr);
+    commandPolyline->setMode(LC_ActionDrawPolyline::TangentalArcFixedAngle);
+    commandAction->saveOptions();
+
+    const auto toolAction = LC_ActionsHandlerFactory::createActionInstance(
+        RS2::ActionDrawPolyline, &fixture.m_context);
+    const auto* toolPolyline = dynamic_cast<const LC_ActionDrawPolyline*>(toolAction.get());
+    REQUIRE(toolPolyline != nullptr);
+    CHECK(toolPolyline->getMode() == LC_ActionDrawPolyline::TangentalArcFixedAngle);
+}

--- a/librecad/src/ui/lc_actionhandlerfactory.cpp
+++ b/librecad/src/ui/lc_actionhandlerfactory.cpp
@@ -453,7 +453,8 @@ namespace InnerFactory{
                 return new LC_ActionDrawLineRelAngle(ctx, M_PI_2, false);
             }
             case RS2::ActionDrawPolyline: {
-                return new LC_ActionDrawPolyline(ctx);
+                const auto* startInLineMode = static_cast<const bool*>(data);
+                return new LC_ActionDrawPolyline(ctx, startInLineMode != nullptr && *startInLineMode);
             }
             case RS2::ActionDrawLineOrthogonalRel: {
                 return new LC_ActionDrawLineAngleRel(ctx, 90.0, true);

--- a/librecad/src/ui/qg_actionhandler.cpp
+++ b/librecad/src/ui/qg_actionhandler.cpp
@@ -220,7 +220,8 @@ bool QG_ActionHandler::command(const QString& cmd) const {
             //special handling, currently needed for snap actions
             if (!m_snapManager->tryToProcessSnapActions(type)) {
                 //not handled yet
-                setCurrentAction(type);
+                bool startInLineMode = type == RS2::ActionDrawPolyline;
+                setCurrentAction(type, startInLineMode ? &startInLineMode : nullptr);
             }
             RS_DEBUG->print("QG_ActionHandler::command: current action set");
             return true;

--- a/librecad/src/ui/qg_actionhandler.h
+++ b/librecad/src/ui/qg_actionhandler.h
@@ -62,7 +62,7 @@ public:
     void setDocumentAndView(RS_Document* doc, RS_GraphicView* graphicView);
     void setActionContext(LC_DefaultActionContext* actionContext) {m_actionContext = actionContext;}
     void setSnapManager(LC_SnapManager* snapManager);
-    std::shared_ptr<RS_ActionInterface> createActionInstance(RS2::ActionType id, void* data) const;
+    virtual std::shared_ptr<RS_ActionInterface> createActionInstance(RS2::ActionType id, void* data) const;
 public slots:
     void setSnaps(const RS_SnapMode&s) const;
     void slotSnapMiddleManual() const;


### PR DESCRIPTION
## Summary
- Start `polyline` and `pl` command-line invocations in Line mode.
- Preserve the segment mode selected for the toolbar and menu polyline tool.
- Correct `taa` to select tangent-arc fixed-angle mode.
- Add focused regression coverage for command dispatch and explicit mode persistence.

Fixes #1134.

## Verification
- `cmake --build build/x64-debug --target librecad --parallel 8`
- `QT_QPA_PLATFORM=offscreen ./build/x64-debug/librecad_polyline_command_tests "[polyline][issue1134]" --reporter compact`