### PR TITLE
Fix DXF import without $ACADVER and export of spline-bordered hatches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2530,6 +2530,7 @@ if (BUILD_TESTS)
         librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
         librecad/src/lib/filters/tests/dxf_layer0_declared_tests.cpp
         librecad/src/lib/filters/tests/dxf_unknown_version_tests.cpp
+        librecad/src/lib/filters/tests/byte_identity_harness.cpp
         librecad/src/lib/filters/tests/dxf_corpus_tests.cpp
         librecad/src/lib/filters/tests/i18n_codec_tests.cpp
         librecad/src/lib/filters/tests/i18n_caret_nfc_tests.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2529,6 +2529,7 @@ if (BUILD_TESTS)
         librecad/src/lib/filters/tests/mleader_dxf_context_tests.cpp
         librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
         librecad/src/lib/filters/tests/dxf_layer0_declared_tests.cpp
+        librecad/src/lib/filters/tests/dxf_unknown_version_tests.cpp
         librecad/src/lib/filters/tests/dxf_corpus_tests.cpp
         librecad/src/lib/filters/tests/i18n_codec_tests.cpp
         librecad/src/lib/filters/tests/i18n_caret_nfc_tests.cpp

--- a/libraries/libdxfrw/src/intern/drw_textcodec.h
+++ b/libraries/libdxfrw/src/intern/drw_textcodec.h
@@ -33,7 +33,14 @@ private:
 
 private:
     DRW::Version version{DRW::UNKNOWNV};
-    DRW::Version sourceVersion{DRW::AC1021};
+    // Until $ACADVER is read the source version is genuinely unknown.  Every
+    // consumer of getSourceVersion() already treats UNKNOWNV as "do not apply
+    // post-R12 strictness" (see requiresDxfSelfHandle() and
+    // dxfTableEntryComplete() in libdxfrw.cpp), so defaulting to a concrete
+    // modern version made those guards unreachable and rejected any DXF that
+    // omits $ACADVER - including hand-written files and R12 output, whose
+    // table records legitimately carry no handle.
+    DRW::Version sourceVersion{DRW::UNKNOWNV};
     bool m_sourceVersionSet { false };
     std::string cp;
     std::unique_ptr< DRW_Converter> conv;

--- a/libraries/libdxfrw/src/intern/dxfreader.cpp
+++ b/libraries/libdxfrw/src/intern/dxfreader.cpp
@@ -67,6 +67,91 @@ bool isUnambiguousDxfHandleCode(int code) {
            (code >= 480 && code <= 481);
 }
 
+
+// Group-code value types.
+//
+// This used to be a long if/else chain whose ranges overlapped by accident:
+// codes 260-269 fell through to the boolean branch written for 290-299, and
+// codes 482-998 fell through to the 1010-1059 double branch. Stating each
+// range once makes the assignments, and the unassigned spans, visible.
+//
+// This table reproduces the previous dispatch exactly; it is a restatement,
+// not a behaviour change. Order matters: the first matching row wins, so 1004
+// (binary chunk) precedes the 999-1008 string range, and that range precedes
+// the unassigned 482-998 span.
+//
+// Two things here are known to be unfinished, and both need a decision rather
+// than a quiet edit:
+//
+//  * 482-998 is unassigned, so decoding it as a double is a guess. Because
+//    every code in the span matches a row, the explicit unknown-code fallback
+//    at the end of readRec() is unreachable for it.
+//  * classifyDxfCode() in libdxfrw.cpp is a second copy of this map - its own
+//    comment describes it as mirroring this dispatch - and the two have
+//    already drifted: it classifies 260-269 as Int16 where this table says
+//    boolean. The two agree today only because captureRawGroup() funnels
+//    Int16, Int32 and Bool to the same getter. They are NOT interchangeable
+//    elsewhere: the raw re-emit path writes a Bool through writeBool(), which
+//    would turn a code-260 value other than 0 or 1 into a boolean, and
+//    isValidRawDxfNumericString() validates Int16 against the int16 range but
+//    Bool against the int32 range. Unifying the two maps therefore has to pick
+//    a kind for 260-269 deliberately.
+enum class DxfValueKind { Str, Dbl, I16, I32, I64, Bln, Bin, Unknown };
+
+struct DxfCodeRange {
+    int lo;
+    int hi;
+    DxfValueKind kind;
+};
+
+constexpr DxfCodeRange kDxfCodeRanges[] = {
+    {   0,    9, DxfValueKind::Str},
+    {  10,   59, DxfValueKind::Dbl},
+    {  60,   79, DxfValueKind::I16},
+    {  80,   89, DxfValueKind::Str},   // reserved
+    {  90,   99, DxfValueKind::I32},
+    { 100,  109, DxfValueKind::Str},   // subclass/control/embedded markers
+    { 110,  149, DxfValueKind::Dbl},
+    { 150,  159, DxfValueKind::Str},   // reserved
+    { 160,  169, DxfValueKind::I64},
+    { 170,  179, DxfValueKind::I16},
+    { 180,  209, DxfValueKind::Str},   // reserved
+    { 210,  259, DxfValueKind::Dbl},   // 3D point coordinates, incl. 240/242
+    { 260,  269, DxfValueKind::Bln},   // not in the published table, but the
+                                       // reader has always decoded these as a
+                                       // boolean/integer and dxf_object_tests
+                                       // pins code 260 as an INTEGER variant
+    { 270,  289, DxfValueKind::I16},
+    { 290,  299, DxfValueKind::Bln},
+    { 300,  309, DxfValueKind::Str},
+    { 310,  319, DxfValueKind::Bin},
+    { 320,  369, DxfValueKind::Str},   // handles
+    { 370,  389, DxfValueKind::I16},
+    { 390,  399, DxfValueKind::Str},   // handles
+    { 400,  409, DxfValueKind::I16},
+    { 410,  419, DxfValueKind::Str},
+    { 420,  429, DxfValueKind::I32},
+    { 430,  439, DxfValueKind::Str},
+    { 440,  449, DxfValueKind::I32},
+    { 450,  459, DxfValueKind::I32},
+    { 460,  469, DxfValueKind::Dbl},
+    { 470,  481, DxfValueKind::Str},
+    {1004, 1004, DxfValueKind::Bin},   // must precede the 999-1008 range
+    { 999, 1008, DxfValueKind::Str},
+    { 482,  998, DxfValueKind::Dbl},   // unassigned; see the note above
+    {1009, 1059, DxfValueKind::Dbl},
+    {1060, 1070, DxfValueKind::I16},
+    {1071, 1071, DxfValueKind::I32},
+};
+
+DxfValueKind dxfValueKindForCode(int code) {
+    for (const DxfCodeRange& range : kDxfCodeRanges) {
+        if (code >= range.lo && code <= range.hi)
+            return range.kind;
+    }
+    return DxfValueKind::Unknown;
+}
+
 }  // namespace
 
 bool dxfReader::readRec(int *codeData) {
@@ -104,74 +189,20 @@ bool dxfReader::readRec(int *codeData) {
     *codeData = code;
 
     bool valueOk = true;
-    if (code < 10)
-        valueOk = readString();
-    else if (code < 60)
-        valueOk = readDouble();
-    else if (code < 80)
-        valueOk = readInt16();
-    else if (code < 90)
-        valueOk = readString(); // reserved 80-89 range
-    else if (code > 89 && code < 100) //TODO this is an int 32b
-        valueOk = readInt32();
-    else if (code >= 100 && code < 110)
-        valueOk = readString(); // subclass/control/embedded and reserved strings
-    else if (code > 109 && code < 150) //skip not used at the v2012
-        valueOk = readDouble();
-    else if (code < 160)
-        valueOk = readString(); // reserved 150-159 range
-    else if (code > 159 && code < 170) //skip not used at the v2012
-        valueOk = readInt64();
-    else if (code < 180)
-        valueOk = readInt16();
-    else if (code < 210)
-        valueOk = readString(); // reserved 180-209 range
-    else if (code > 209 && code < 260) //3D point coordinates, including 240/242
-        valueOk = readDouble();
-    else if (code > 269 && code < 290) //skip not used at the v2012
-        valueOk = readInt16();
-    else if (code < 300) //TODO this is a boolean indicator, int in Binary?
-        valueOk = readBool();
-    else if (code < 310)
-        valueOk = readString();
-    else if (code < 320)
-        valueOk = readBinary();
-    else if (code < 370)
-        valueOk = readString();
-    else if (code < 390)
-        valueOk = readInt16();
-    else if (code < 400)
-        valueOk = readString();
-    else if (code < 410)
-        valueOk = readInt16();
-    else if (code < 420)
-        valueOk = readString();
-    else if (code < 430) //TODO this is an int 32b
-        valueOk = readInt32();
-    else if (code < 440)
-        valueOk = readString();
-    else if (code < 450) //TODO this is an int 32b
-        valueOk = readInt32();
-    else if (code < 460) //TODO this is long??
-        valueOk = readInt32();
-    else if (code < 470) //TODO this is a floating point double precision??
-        valueOk = readDouble();
-    else if (code <= 481)
-        valueOk = readString();
-    else if (code == 1004)
-        valueOk = readBinary();
-    else if (code > 998 && code < 1009) //skip not used at the v2012
-        valueOk = readString();
-    else if (code < 1060) //TODO this is a floating point double precision??
-        valueOk = readDouble();
-    else if (code < 1071)
-        valueOk = readInt16();
-    else if (code == 1071) //TODO this is an int 32b
-        valueOk = readInt32();
-    else if (skip)
-        //skip safely this dxf entry ( ok for ascii dxf)
-        valueOk = readString();
-    else {
+    switch (dxfValueKindForCode(code)) {
+    case DxfValueKind::Str:    valueOk = readString(); break;
+    case DxfValueKind::Dbl:    valueOk = readDouble(); break;
+    case DxfValueKind::I16:    valueOk = readInt16();  break;
+    case DxfValueKind::I32:    valueOk = readInt32();  break;
+    case DxfValueKind::I64:    valueOk = readInt64();  break;
+    case DxfValueKind::Bln:    valueOk = readBool();   break;
+    case DxfValueKind::Bin:    valueOk = readBinary(); break;
+    case DxfValueKind::Unknown:
+        if (skip) {
+            //skip safely this dxf entry ( ok for ascii dxf)
+            valueOk = readString();
+            break;
+        }
         //break in binary files because the conduct is unpredictable
         invalidateRecord();
         return false;

--- a/librecad/src/lib/filters/rs_filterdxfrw.cpp
+++ b/librecad/src/lib/filters/rs_filterdxfrw.cpp
@@ -30185,11 +30185,37 @@ void RS_FilterDXFRW::writeLeader(const RS_Leader *l) {
 
 namespace {
 
+// Fill the clamped uniform knot vector a control-point spline must carry.
+//
+// A DXF SPLINE always stores its knots (group 40), and libdxfrw's payload
+// validation requires knots == controls + degree + 1
+// (isValidControlSplineLayout in drw_entities.cpp). Emitting none produced a
+// boundary edge that dxfRW::validateHatchPayload() rejects, and because a
+// rejected entity fails the whole write, a drawing containing a
+// spline-bordered hatch could not be exported to DXF at all.
+//
+// The vector generated here is the one the reader used to re-derive for an
+// empty knot list, so consumers see the same curve as before.
+void fillClampedUniformKnots(DRW_Spline &drw) {
+  const std::int32_t degree = drw.degree;
+  const std::int32_t controls = static_cast<std::int32_t>(drw.controllist.size());
+  if (degree < 1 || controls < degree + 1)
+    return;
+  const std::int32_t spans = controls - degree;
+  drw.knotslist.clear();
+  drw.knotslist.reserve(static_cast<std::size_t>(controls + degree + 1));
+  for (std::int32_t i = 0; i <= degree; ++i)
+    drw.knotslist.push_back(0.0);
+  for (std::int32_t i = 1; i < spans; ++i)
+    drw.knotslist.push_back(static_cast<double>(i));
+  for (std::int32_t i = 0; i <= degree; ++i)
+    drw.knotslist.push_back(static_cast<double>(spans));
+  drw.nknots = static_cast<std::int32_t>(drw.knotslist.size());
+}
+
 // Emit an LC_SplinePoints boundary edge as a degree-2 DRW_Spline. Either
 // the control net or the fit points are populated depending on the
-// LC_SplinePointsData mode. Knotslist is left empty; the libdxfrw reader
-// re-derives a clamped uniform knot vector when consuming this struct
-// (see drw_entities.cpp parseDwg). See plan §B.1.
+// LC_SplinePointsData mode. See plan §B.1.
 std::shared_ptr<DRW_Spline>
 makeDrwSplineFromSplinePoints(const LC_SplinePoints *sp) {
   auto drw = std::make_shared<DRW_Spline>();
@@ -30204,6 +30230,7 @@ makeDrwSplineFromSplinePoints(const LC_SplinePoints *sp) {
     for (const auto &v : d.controlPoints)
       drw->controllist.push_back(std::make_shared<DRW_Coord>(v.x, v.y, 0.0));
     drw->ncontrol = static_cast<std::int32_t>(d.controlPoints.size());
+    fillClampedUniformKnots(*drw);
   } else {
     for (const auto &v : d.splinePoints)
       drw->fitlist.push_back(std::make_shared<DRW_Coord>(v.x, v.y, 0.0));
@@ -30243,6 +30270,8 @@ std::shared_ptr<DRW_Spline> makeDrwSplineFromRSSpline(const RS_Spline *sp) {
   }
   drw->knotslist = sd.knotslist;
   drw->nknots = static_cast<std::int32_t>(sd.knotslist.size());
+  if (drw->knotslist.empty())
+    fillClampedUniformKnots(*drw);
   return drw;
 }
 

--- a/librecad/src/lib/filters/tests/acad_table_tests.cpp
+++ b/librecad/src/lib/filters/tests/acad_table_tests.cpp
@@ -443,7 +443,12 @@ TEST_CASE("dwgRW reads R2000 ACAD_TABLE grid + resolves *T block (TS1.dwg)",
   // RS_FilterDXFRW::addTable inserts this block => the table draws.
   CHECK(table.blockRecH.ref == 567u);
   REQUIRE(table.name.rfind("*T", 0) == 0);  // starts with "*T"
-  CHECK(table.name == "*T8");
+  // The anonymous block in this file is named "*T", with no numeric suffix.
+  // Cross-checked against LibreDWG: `dwgread -O JSON` reports the same
+  // BLOCK_HEADER name for handle 567 (and "*D" for the other anonymous
+  // blocks), so the reader matches the file rather than the suffix AutoCAD
+  // shows in its UI.
+  CHECK(table.name == "*T");
 
   // Grid geometry — dwgread JSON oracle (cross-tool match with libdxfrw).
   CHECK(table.basePoint.x == Catch::Approx(24.02389827721959));

--- a/librecad/src/lib/filters/tests/byte_identity_harness.cpp
+++ b/librecad/src/lib/filters/tests/byte_identity_harness.cpp
@@ -1,0 +1,171 @@
+/****************************************************************************
+** Byte-identity harness (scaffolding, not part of the shipped suite).
+**
+** Section 1 of the DWG/DXF improvement plan: a behaviour-preserving refactor
+** of the encoders cannot be validated by the unit tests alone, because most of
+** the encoder surface is only reachable through a full write. This harness
+** exports one fixed document to every writable format and prints a SHA-256 per
+** output. Run it before a refactor, save the output, run it after, and diff.
+**
+**   ./librecad_tests "[byteid]" 2>/dev/null | grep BYTEID | sort > before.txt
+**   ...refactor...
+**   ./librecad_tests "[byteid]" 2>/dev/null | grep BYTEID | sort > after.txt
+**   diff before.txt after.txt
+**
+** Any difference must be explained or the change reverted.
+**********************************************************************/
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdio>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QCryptographicHash>
+#include <QFile>
+
+#include "lc_splinepoints.h"
+#include "rs_arc.h"
+#include "rs_block.h"
+#include "rs_circle.h"
+#include "rs_ellipse.h"
+#include "rs_filterdxfrw.h"
+#include "rs_graphic.h"
+#include "rs_hatch.h"
+#include "rs_insert.h"
+#include "rs_layer.h"
+#include "rs_line.h"
+#include "rs_mtext.h"
+#include "rs_polyline.h"
+#include "rs_settings.h"
+#include "rs_text.h"
+
+namespace {
+
+void ensureSettings() {
+    static int argc = 1;
+    static char arg0[] = "librecad_tests";
+    static char* argv[] = {arg0, nullptr};
+    static QCoreApplication* app = QCoreApplication::instance()
+                                        ? QCoreApplication::instance()
+                                        : new QCoreApplication(argc, argv);
+    static bool ready = [] {
+        QCoreApplication::setOrganizationName("LibreCAD");
+        QCoreApplication::setApplicationName("LibreCAD-tests");
+        RS_Settings::init("LibreCAD", "LibreCAD-tests");
+        return true;
+    }();
+    (void)app;
+    (void)ready;
+}
+
+// Populate a graphic with a spread of entity kinds so the export touches as
+// much of the writer surface as one document reasonably can.
+void buildFixture(RS_Graphic& g) {
+    g.initForNewDocument();
+
+    auto* extra = new RS_Layer("HARNESS");
+    extra->setPen(RS_Pen(RS_Color(255, 0, 0), RS2::Width05, RS2::DashLine));
+    g.addLayer(extra);
+
+    g.addEntity(new RS_Line(&g, {{0.0, 0.0}, {100.0, 50.0}}));
+    g.addEntity(new RS_Line(&g, {{100.0, 50.0}, {0.0, 50.0}}));
+    g.addEntity(new RS_Circle(&g, RS_CircleData(RS_Vector(20.0, 20.0), 7.5)));
+    g.addEntity(new RS_Arc(
+        &g, RS_ArcData(RS_Vector(40.0, 20.0), 5.0, 0.0, 1.57, false)));
+    g.addEntity(new RS_Ellipse(
+        &g, {RS_Vector(60.0, 20.0), RS_Vector(10.0, 0.0), 0.5, 0.0, 0.0, false}));
+
+    auto* poly = new RS_Polyline(&g);
+    poly->addVertex(RS_Vector(0.0, 0.0));
+    poly->addVertex(RS_Vector(10.0, 5.0));
+    poly->addVertex(RS_Vector(20.0, 0.0), 0.25);
+    poly->endPolyline();
+    g.addEntity(poly);
+
+    g.addEntity(new RS_Text(
+        &g, RS_TextData(RS_Vector(5.0, 40.0), RS_Vector(5.0, 40.0), 2.5, 1.0,
+                        RS_TextData::VABaseline, RS_TextData::HALeft,
+                        RS_TextData::None, "harness", "standard", 0.0)));
+
+    // Spline-bordered hatch: exercises the boundary-edge encoder.
+    auto* hatch = new RS_Hatch(&g, RS_HatchData(true, 1.0, 0.0, "SOLID"));
+    auto* loop = new RS_EntityContainer(hatch);
+    hatch->addEntity(loop);
+    LC_SplinePointsData sd(/*closed*/ true, /*cut*/ false);
+    sd.useControlPoints = true;
+    sd.controlPoints = {RS_Vector(70.0, 40.0), RS_Vector(65.0, 45.0),
+                        RS_Vector(70.0, 50.0), RS_Vector(75.0, 45.0)};
+    loop->addEntity(new LC_SplinePoints(loop, std::move(sd)));
+    g.addEntity(hatch);
+    hatch->update();
+
+    // A block plus an insert of it.
+    auto* block = new RS_Block(&g, RS_BlockData("HARNESS_BLOCK",
+                                                RS_Vector(0.0, 0.0), false));
+    block->addEntity(new RS_Line(block, {{0.0, 0.0}, {5.0, 0.0}}));
+    block->addEntity(new RS_Line(block, {{5.0, 0.0}, {5.0, 5.0}}));
+    g.addBlock(block);
+    g.addEntity(new RS_Insert(
+        &g, RS_InsertData("HARNESS_BLOCK", RS_Vector(80.0, 5.0),
+                          RS_Vector(1.0, 1.0), 0.0, 1, 1,
+                          RS_Vector(0.0, 0.0))));
+}
+
+std::string sha256Of(const std::string& path) {
+    QFile f(QString::fromStdString(path));
+    if (!f.open(QIODevice::ReadOnly))
+        return "<unreadable>";
+    QCryptographicHash h(QCryptographicHash::Sha256);
+    h.addData(&f);
+    return h.result().toHex().toStdString();
+}
+
+struct Target {
+    const char* label;
+    RS2::FormatType format;
+    const char* suffix;
+};
+
+} // namespace
+
+TEST_CASE("byte-identity harness: export a fixed document to every format",
+          "[.][byteid]") {
+    ensureSettings();
+
+    const std::vector<Target> targets{
+        {"DXFRW  ", RS2::FormatDXFRW, "dxf"},
+        {"DWG_R15", RS2::FormatDWG, "dwg"},
+        {"DWG2004", RS2::FormatDWG2004, "dwg"},
+        {"DWG2007", RS2::FormatDWG2007, "dwg"},
+        {"DWG2010", RS2::FormatDWG2010, "dwg"},
+        {"DWG2013", RS2::FormatDWG2013, "dwg"},
+        {"DWG2018", RS2::FormatDWG2018, "dwg"},
+    };
+
+    const auto dir = std::filesystem::temp_directory_path() / "lc_byteid";
+    std::filesystem::create_directories(dir);
+
+    for (const Target& t : targets) {
+        RS_Graphic g;
+        buildFixture(g);
+
+        const std::string out =
+            (dir / (std::string("harness_") + t.label + "." + t.suffix)).string();
+        std::filesystem::remove(out);
+
+        RS_FilterDXFRW filter;
+        const bool ok =
+            filter.fileExport(g, QString::fromStdString(out), t.format);
+        const std::string digest = ok ? sha256Of(out) : std::string("<write-failed>");
+        const std::uintmax_t size =
+            ok && std::filesystem::exists(out) ? std::filesystem::file_size(out) : 0;
+        std::fprintf(stderr, "BYTEID %s %-12s %10ju  %s\n", t.label,
+                     ok ? "ok" : "FAILED", static_cast<std::uintmax_t>(size),
+                     digest.c_str());
+    }
+    SUCCEED("harness output is on stderr");
+}

--- a/librecad/src/lib/filters/tests/dxf_object_tests.cpp
+++ b/librecad/src/lib/filters/tests/dxf_object_tests.cpp
@@ -7798,6 +7798,82 @@ TEST_CASE("DXF raw capture matches reader types in the reserved 240 range",
   CHECK(object.groups[2].i_val() == 1);
 }
 
+TEST_CASE("DXF group-code value types are stated once per range",
+          "[dxf][rawobject][rawcapture][types]") {
+  // Pins the group-code -> value-type map used by dxfReader::readRec(). The
+  // map used to be an if/else chain whose ranges overlapped by accident; this
+  // walks one representative code from each assigned range plus both edges of
+  // the unassigned span so a future edit that shifts a boundary is visible.
+  SECTION("assigned ranges keep their published types") {
+    RawObjectCapture cap;
+    const char *dxf =
+        "0\nSECTION\n2\nOBJECTS\n"
+        "0\nACDBWFDIAG\n5\n3B\n"
+        "40\n1.5\n"     // 10-59   double
+        "70\n7\n"       // 60-79   int16
+        "90\n9\n"       // 90-99   int32
+        "140\n2.5\n"    // 110-149 double
+        "170\n3\n"      // 170-179 int16
+        "210\n4.5\n"    // 210-259 double
+        "270\n5\n"      // 270-289 int16
+        "290\n1\n"      // 290-299 boolean
+        "300\ntext\n"   // 300-309 string
+        "370\n6\n"      // 370-389 int16
+        "420\n77\n"     // 420-429 int32
+        "460\n8.5\n"    // 460-469 double
+        "0\nENDSEC\n0\nEOF\n";
+    readDxf(dxf, cap, "lc_codemap_assigned.dxf");
+
+    REQUIRE(cap.m_objects.size() == 1);
+    const DRW_RawDxfObject &o = cap.m_objects.front();
+    const auto typeOf = [&o](int code) {
+      for (const auto &g : o.groups)
+        if (g.code() == code)
+          return static_cast<int>(g.type());
+      return -1;
+    };
+    CHECK(typeOf(40) == DRW_Variant::DOUBLE);
+    CHECK(typeOf(70) == DRW_Variant::INTEGER);
+    CHECK(typeOf(90) == DRW_Variant::INTEGER);
+    CHECK(typeOf(140) == DRW_Variant::DOUBLE);
+    CHECK(typeOf(170) == DRW_Variant::INTEGER);
+    CHECK(typeOf(210) == DRW_Variant::DOUBLE);
+    CHECK(typeOf(270) == DRW_Variant::INTEGER);
+    CHECK(typeOf(290) == DRW_Variant::INTEGER);
+    CHECK(typeOf(300) == DRW_Variant::STRING);
+    CHECK(typeOf(370) == DRW_Variant::INTEGER);
+    CHECK(typeOf(420) == DRW_Variant::INTEGER);
+    CHECK(typeOf(460) == DRW_Variant::DOUBLE);
+  }
+
+  SECTION("the unassigned 482-998 span keeps its current decoding") {
+    // 482-998 has no published type. Both the reader's map and
+    // classifyDxfCode() in libdxfrw.cpp decode it as a double, which also
+    // makes the reader's explicit unknown-code fallback unreachable for the
+    // span. Pinned here so that changing it becomes a deliberate act - the two
+    // maps have to move together, since the raw re-emit path picks its writer
+    // from classifyDxfCode().
+    RawObjectCapture cap;
+    const char *dxf =
+        "0\nSECTION\n2\nOBJECTS\n"
+        "0\nACDBWFDIAG\n5\n3B\n500\n2.5\n"
+        "0\nENDSEC\n0\nEOF\n";
+    readDxf(dxf, cap, "lc_codemap_unassigned.dxf");
+
+    REQUIRE(cap.m_objects.size() == 1);
+    const DRW_RawDxfObject &o = cap.m_objects.front();
+    bool seen = false;
+    for (const auto &g : o.groups) {
+      if (g.code() != 500)
+        continue;
+      seen = true;
+      CHECK(g.type() == DRW_Variant::DOUBLE);
+      CHECK(g.d_val() == 2.5);
+    }
+    CHECK(seen);
+  }
+}
+
 TEST_CASE("DXF raw capture preserves reserved string ranges",
           "[dxf][rawobject][rawcapture][types]") {
   RawObjectCapture cap;

--- a/librecad/src/lib/filters/tests/dxf_unknown_version_tests.cpp
+++ b/librecad/src/lib/filters/tests/dxf_unknown_version_tests.cpp
@@ -1,0 +1,146 @@
+/****************************************************************************
+**
+** This file is part of the LibreCAD project, a 2D CAD program
+**
+** Copyright (C) 2026 LibreCAD (librecad.org)
+** Copyright (C) 2026 Dongxu Li (github.com/dxli)
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+**********************************************************************/
+
+// Regression tests for the source-version default used while reading DXF.
+//
+// DRW_TextCodec::sourceVersion is the version of the file being read. Until
+// $ACADVER is parsed it is genuinely unknown, and the reader's strictness
+// checks are written to reflect that: requiresDxfSelfHandle() and
+// dxfTableEntryComplete() (libdxfrw.cpp) both special-case DRW::UNKNOWNV and
+// only demand a per-record handle for post-R12 sources.
+//
+// The member used to default to DRW::AC1021 instead, so those UNKNOWNV
+// branches were unreachable: a DXF carrying no $ACADVER was treated as R2007
+// and every table record without a group-5 handle was rejected, failing the
+// whole import with DRW::BAD_CODE_PARSED. Hand-written DXF files and R12-era
+// output legitimately omit both $ACADVER and table-record handles, so they
+// could not be opened at all.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <QCoreApplication>
+
+#include "rs_filterdxfrw.h"
+#include "rs_graphic.h"
+#include "rs_layer.h"
+#include "rs_settings.h"
+
+namespace {
+
+void ensureSettings() {
+    static int argc = 1;
+    static char arg0[] = "librecad_tests";
+    static char* argv[] = {arg0, nullptr};
+    static QCoreApplication* app = QCoreApplication::instance()
+                                        ? QCoreApplication::instance()
+                                        : new QCoreApplication(argc, argv);
+    static bool ready = [] {
+        QCoreApplication::setOrganizationName("LibreCAD");
+        QCoreApplication::setApplicationName("LibreCAD-tests");
+        RS_Settings::init("LibreCAD", "LibreCAD-tests");
+        return true;
+    }();
+    (void)app;
+    (void)ready;
+}
+
+std::string writeTemp(const char* suffix, const std::string& content) {
+    const std::string path =
+        (std::filesystem::temp_directory_path() /
+         (std::string("dxf_unknown_version_") + suffix + ".dxf"))
+            .string();
+    std::ofstream out(path);
+    out << content;
+    return path;
+}
+
+// One LINE on layer "0"; no HEADER section, so no $ACADVER.
+const std::string kEntities =
+    "0\nSECTION\n2\nENTITIES\n"
+    "0\nLINE\n8\n0\n10\n0.0\n20\n0.0\n30\n0.0\n11\n10.0\n21\n10.0\n31\n0.0\n"
+    "0\nENDSEC\n0\nEOF\n";
+
+} // namespace
+
+TEST_CASE("DXF without $ACADVER imports when table records carry no handle",
+          "[dxf][filter][version][regression]") {
+    ensureSettings();
+
+    // A LAYER table record with a name but no group-5 handle, which is what
+    // R12-era and hand-written DXF files contain.
+    const std::string dxf =
+        "0\nSECTION\n2\nTABLES\n"
+        "0\nTABLE\n2\nLAYER\n"
+        "0\nLAYER\n2\n0\n70\n0\n62\n3\n6\nCONTINUOUS\n"
+        "0\nENDTAB\n"
+        "0\nENDSEC\n" +
+        kEntities;
+    const std::string src = writeTemp("no_acadver", dxf);
+
+    RS_Graphic graphic;
+    graphic.initForNewDocument();
+
+    RS_FilterDXFRW filter;
+    REQUIRE(filter.fileImport(graphic, QString::fromStdString(src),
+                              RS2::FormatDXFRW));
+
+    // The layer table entry and the entity both survive the import.
+    RS_Layer* layer0 = graphic.findLayer("0");
+    REQUIRE(layer0 != nullptr);
+
+    int entityCount = 0;
+    for (auto it = graphic.begin(); it != graphic.end(); ++it)
+        ++entityCount;
+    CHECK(entityCount == 1);
+
+    std::filesystem::remove(src);
+}
+
+TEST_CASE("DXF declaring a modern $ACADVER still requires table-record handles",
+          "[dxf][filter][version][regression]") {
+    ensureSettings();
+
+    // Same table record, but the file now claims to be AC1021. A post-R12
+    // source must still be held to the handle requirement, so the lenient
+    // unknown-version path must not weaken files that state their version.
+    const std::string dxf =
+        "0\nSECTION\n2\nHEADER\n"
+        "9\n$ACADVER\n1\nAC1021\n"
+        "0\nENDSEC\n"
+        "0\nSECTION\n2\nTABLES\n"
+        "0\nTABLE\n2\nLAYER\n"
+        "0\nLAYER\n2\n0\n70\n0\n62\n3\n6\nCONTINUOUS\n"
+        "0\nENDTAB\n"
+        "0\nENDSEC\n" +
+        kEntities;
+    const std::string src = writeTemp("acadver_ac1021", dxf);
+
+    RS_Graphic graphic;
+    graphic.initForNewDocument();
+
+    RS_FilterDXFRW filter;
+    CHECK_FALSE(filter.fileImport(graphic, QString::fromStdString(src),
+                                  RS2::FormatDXFRW));
+
+    std::filesystem::remove(src);
+}

--- a/librecad/src/lib/filters/tests/underlay_tests.cpp
+++ b/librecad/src/lib/filters/tests/underlay_tests.cpp
@@ -206,7 +206,10 @@ TEST_CASE("DXF round-trip: UNDERLAY entity preserves fields",
   {
     dxfRW w(path.string().c_str());
     emitter.m_rw = &w;
-    REQUIRE(w.write(&emitter, DRW::AC1021, false));
+    // DRW_Underlay::inverseClipBoundary is an R2010+ field (see its
+    // declaration in drw_entities.h); dxfRW::writeUnderlay() refuses to
+    // emit it for AC1021 and older, so round-trip it at AC1024.
+    REQUIRE(w.write(&emitter, DRW::AC1024, false));
   }
 
   UnderlayCapture capture;
@@ -385,8 +388,14 @@ TEST_CASE("UNDERLAY rejects oversized clip storage before writing",
   std::filesystem::remove(path);
   dxfRW writer(path.string().c_str());
   emitter.m_rw = &writer;
-  REQUIRE(writer.write(&emitter, DRW::AC1021, false));
+  // Writing an entity the encoder cannot represent is atomic: every
+  // rejecting writer sets m_writeError (dxfRW::rejectUnsupportedDxfWrite()
+  // and the per-entity validation branches), and dxfRW::write() turns that
+  // into a failed write rather than silently dropping the entity.
+  CHECK_FALSE(writer.write(&emitter, DRW::AC1021, false));
   CHECK_FALSE(emitter.m_writeResult);
+  // The output transaction is aborted, so no partial file is left behind.
+  CHECK_FALSE(std::filesystem::exists(path));
   std::filesystem::remove(path);
 }
 
@@ -401,7 +410,9 @@ TEST_CASE("DXF UNDERLAY rejects an oversized inverse clip count",
   {
     dxfRW writer(path.string().c_str());
     emitter.m_rw = &writer;
-    REQUIRE(writer.write(&emitter, DRW::AC1021, false));
+    // The inverse clip count (group 170) this test corrupts is only
+    // emitted for R2010+, so the seed file must be written at AC1024.
+    REQUIRE(writer.write(&emitter, DRW::AC1024, false));
   }
 
   std::ifstream in(path);


### PR DESCRIPTION
Section 0 and part of section 3 of the DWG/DXF improvement plan: make the suite trustworthy, and fix what it was hiding. On `origin/master` `librecad_tests` reports **32 failing assertions**; this branch takes that to **26**, and two of the six are user-facing bugs.

### Fix DXF import of files that do not declare `$ACADVER`

`DRW_TextCodec::sourceVersion` holds the version of the file being read. Until `$ACADVER` is parsed that version is unknown, and the reader's strictness checks are written for exactly that case: `requiresDxfSelfHandle()` and `dxfTableEntryComplete()` both special-case `DRW::UNKNOWNV` and require a per-record handle only for post-R12 sources.

The member defaulted to `DRW::AC1021`, so those branches were unreachable. A header-less DXF was treated as R2007, every table record without a group-5 handle was rejected, and the import failed with `BAD_CODE_PARSED`. Hand-written DXF files and R12-era output omit both, so they could not be opened at all.

### Fix DXF export of drawings containing a spline-bordered hatch

`makeDrwSplineFromSplinePoints()` emitted a hatch boundary spline with an empty knot vector, relying on the reader to re-derive one. A DXF `SPLINE` always stores its knots, and libdxfrw's own validation requires `knots == controls + degree + 1`, so `validateHatchPayload()` rejected the edge. Because a rejected entity fails the whole write, exporting any drawing with a spline-bordered hatch produced no file at all.

The byte-identity harness below shows this independently: on `origin/master` the DXF export of its fixture fails outright, and it succeeds here.

### State each DXF group-code range once

`dxfReader::readRec()` picked its value reader from a 30-branch `if/else` chain whose ranges overlapped by accident: 260-269 matched no branch until the boolean test written for 290-299, and 482-998 fell into the 1010-1059 double branch. Replaced with an ordered table, as a restatement rather than a behaviour change, with a test pinning one code per assigned range.

Two loose ends are documented at the table instead of quietly changed, because both need a decision:

- 482-998 is unassigned, so decoding it as a double is a guess, and no code in that span can reach the reader's explicit unknown-code fallback.
- `classifyDxfCode()` in `libdxfrw.cpp` is a second copy of this map, and the two have already drifted: it reads 260-269 as `Int16` where the reader says boolean. They agree in practice only because `captureRawGroup()` funnels `Int16`, `Int32` and `Bool` to one getter. The raw re-emit path does not, and would push a code-260 value through `writeBool()`.

### Byte-identity harness

Refactoring these encoders cannot be validated by unit tests alone, since most of the encoder surface is only reachable through a full write. The harness exports a fixed document to all seven writable formats and prints a SHA-256 each; run it before and after a change and diff. It is tagged `[.]` so it never runs by default, and its output is deterministic across runs. #2799 uses it.

### Two test corrections

Both assertion-only, and both fix expectations that never matched the code:

- **UNDERLAY.** Two tests wrote an inverse clip boundary at AC1021; that field is documented as R2010+ where it is declared, and the writer refuses to emit it before AC1024. A third expected a rejected entity to leave the file write successful, but rejection is atomic throughout the DXF writer. The tests and the code they exercise both arrived in abd1f4a8e and have never agreed.
- **ACAD_TABLE.** The R2000 test expected the anonymous block name `*T8`. The name in the file is `*T`: LibreDWG's `dwgread` reports the same `BLOCK_HEADER` name for handle 567, and the R2010 test in the same file already expects `*T`.

### Still failing (26)

`dwg_write_smoke_tests.cpp` (24) and `acad_table_tests.cpp` (2). Of 21 sampled failing assertions in the first file, 20 were added by abd1f4a8e, so that feature's own tests have never passed. The two ACAD_TABLE failures need a decision about intended R2010 table semantics: `example_2004.dwg` fails to read where `dwgread` succeeds, and `example_2010.dwg` yields 0 columns where a pin expects 9.

### Verification

CMake with `-DBUILD_TESTS=ON`, Qt 6, macOS arm64. Full suite run before and after every commit.
