### PR TITLE
libdxfrw: de-duplicate the table-record emitters and typed class registrars

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2530,6 +2530,7 @@ if (BUILD_TESTS)
         librecad/src/lib/filters/tests/mleader_text_tests.cpp
         librecad/src/lib/filters/tests/mleader_dxf_context_tests.cpp
         librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
+        librecad/src/lib/filters/tests/dxf_line_width_mapping_tests.cpp
         librecad/src/lib/filters/tests/dxf_layer0_declared_tests.cpp
         librecad/src/lib/filters/tests/dxf_corpus_tests.cpp
         librecad/src/lib/filters/tests/i18n_codec_tests.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2488,6 +2488,7 @@ if (BUILD_TESTS)
         librecad/src/lib/filters/tests/libdxfrw_debug_tests.cpp
         librecad/src/lib/filters/tests/libdxfrw_qt_free_tests.cpp
         librecad/src/lib/filters/tests/dwg_object_encode_round_trip_tests.cpp
+        librecad/src/lib/filters/tests/dwg_class_table_tests.cpp
         librecad/src/lib/filters/tests/dwg_smoke_tests.cpp
         librecad/src/lib/filters/tests/dwg_write_smoke_tests.cpp
         librecad/src/lib/filters/tests/eed_tests.cpp

--- a/libraries/libdxfrw/src/drw_entities.cpp
+++ b/libraries/libdxfrw/src/drw_entities.cpp
@@ -20385,15 +20385,14 @@ bool DRW_MLeader::parseDxfContextCode(int code, const std::unique_ptr<dxfReader>
         case 46: context.blockRotation = reader->getDouble(); return true;
         case 93: context.blockColor = reader->getInt32(); return true;
         /* common tail */
-        case 110: context.basePoint.x = reader->getDouble(); return true;
-        case 120: context.basePoint.y = reader->getDouble(); return true;
-        case 130: context.basePoint.z = reader->getDouble(); return true;
-        case 111: context.baseDirection.x = reader->getDouble(); return true;
-        case 121: context.baseDirection.y = reader->getDouble(); return true;
-        case 131: context.baseDirection.z = reader->getDouble(); return true;
-        case 112: context.baseVertical.x = reader->getDouble(); return true;
-        case 122: context.baseVertical.y = reader->getDouble(); return true;
-        case 132: context.baseVertical.z = reader->getDouble(); return true;
+        case 110: case 120: case 130:
+        case 111: case 121: case 131:
+        case 112: case 122: case 132:
+            // The helper answers true for every code in this set, so this
+            // matches the nine `return true` arms it replaces.
+            return readCoordTripletCode(code, reader, context.basePoint,
+                                        context.baseDirection,
+                                        context.baseVertical);
         case 297: context.isNormalReversed = (reader->getInt32() != 0); return true;
         case 272: context.styleBottomAttach = reader->getInt32(); return true;
         case 273: context.styleTopAttach = reader->getInt32(); return true;
@@ -21288,7 +21287,7 @@ bool DRW_Viewport::parseCode(int code, const std::unique_ptr<dxfReader>& reader)
     case 110: case 120: case 130:
     case 111: case 121: case 131:
     case 112: case 122: case 132:
-        readUcsTripletCode(code, reader, ucsOrigin, ucsXAxis, ucsYAxis);
+        readCoordTripletCode(code, reader, ucsOrigin, ucsXAxis, ucsYAxis);
         break;
     case 146:
         ucsElevation = reader->getDouble();

--- a/libraries/libdxfrw/src/drw_entities.cpp
+++ b/libraries/libdxfrw/src/drw_entities.cpp
@@ -21285,32 +21285,10 @@ bool DRW_Viewport::parseCode(int code, const std::unique_ptr<dxfReader>& reader)
     case 74:
         ucsAtOrigin = reader->getInt32() != 0;
         break;
-    case 110:
-        ucsOrigin.x = reader->getDouble();
-        break;
-    case 120:
-        ucsOrigin.y = reader->getDouble();
-        break;
-    case 130:
-        ucsOrigin.z = reader->getDouble();
-        break;
-    case 111:
-        ucsXAxis.x = reader->getDouble();
-        break;
-    case 121:
-        ucsXAxis.y = reader->getDouble();
-        break;
-    case 131:
-        ucsXAxis.z = reader->getDouble();
-        break;
-    case 112:
-        ucsYAxis.x = reader->getDouble();
-        break;
-    case 122:
-        ucsYAxis.y = reader->getDouble();
-        break;
-    case 132:
-        ucsYAxis.z = reader->getDouble();
+    case 110: case 120: case 130:
+    case 111: case 121: case 131:
+    case 112: case 122: case 132:
+        readUcsTripletCode(code, reader, ucsOrigin, ucsXAxis, ucsYAxis);
         break;
     case 146:
         ucsElevation = reader->getDouble();

--- a/libraries/libdxfrw/src/drw_objects.cpp
+++ b/libraries/libdxfrw/src/drw_objects.cpp
@@ -4587,7 +4587,7 @@ bool DRW_Vport::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     case 110: case 120: case 130:
     case 111: case 121: case 131:
     case 112: case 122: case 132:
-        readUcsTripletCode(code, reader, ucsOrigin, ucsXAxis, ucsYAxis);
+        readCoordTripletCode(code, reader, ucsOrigin, ucsXAxis, ucsYAxis);
         break;
     case 141:
         brightness = reader->getDouble();
@@ -5951,7 +5951,7 @@ bool DRW_View::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     case 110: case 120: case 130:
     case 111: case 121: case 131:
     case 112: case 122: case 132:
-        readUcsTripletCode(code, reader, ucsOrigin, ucsXAxis, ucsYAxis);
+        readCoordTripletCode(code, reader, ucsOrigin, ucsXAxis, ucsYAxis);
         break;
     case 79:
         ucsOrthoType = reader->getInt32();

--- a/libraries/libdxfrw/src/drw_objects.cpp
+++ b/libraries/libdxfrw/src/drw_objects.cpp
@@ -86,6 +86,42 @@ bool objectBodyFitsSize(std::uint64_t bodyBitOffset,
 
 std::uint64_t currentObjectDwgBit(const dwgBuffer *buf);
 
+// Resolve the body/string split of an R2007+ object body.
+//
+// From R2007 a DWG object stores its strings in a separate stream whose bounds
+// are declared at the end of the object.  Every typed parser needs the same
+// three things from that: where the body data ends, where the string data
+// ends, and a check that the declared bounds are consistent with the object
+// size and with the buffer's current position.  Before R2007, and for a
+// zero-sized object, both ends are simply the object size.
+//
+// Returns false when the declared bounds are inconsistent; callers turn that
+// into their own fail() so the parser's error reporting is unchanged.
+bool resolveR2007StreamBounds(DRW::Version version, dwgBuffer& stringBuffer,
+                              std::uint32_t objSize, std::uint32_t& bodyEnd,
+                              std::uint32_t& stringEnd) {
+    bodyEnd = objSize;
+    stringEnd = objSize;
+    if (version <= DRW::AC1018 || objSize == 0)
+        return true;
+
+    std::uint64_t stringStartBit = 0;
+    std::uint64_t stringEndBit = 0;
+    if (!stringBuffer.getR2007StringStreamBounds(objSize, stringStartBit,
+                                                 stringEndBit)
+        || stringStartBit > objSize
+        || stringEndBit > objSize
+        || stringEndBit < stringStartBit
+        || stringStartBit > std::numeric_limits<std::uint32_t>::max()
+        || stringEndBit > std::numeric_limits<std::uint32_t>::max()
+        || currentObjectDwgBit(&stringBuffer) != stringStartBit)
+        return false;
+
+    bodyEnd = static_cast<std::uint32_t>(stringStartBit);
+    stringEnd = static_cast<std::uint32_t>(stringEndBit);
+    return true;
+}
+
 bool objectBodyIsEmpty(const dwgBuffer *buf, DRW::Version version,
                        std::uint32_t bodyEnd) {
     return buf != nullptr && buf->isGood() && version >= DRW::AC1012
@@ -2960,23 +2996,10 @@ bool DRW_Dimstyle::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_t 
     if (!parsed.DRW_TableEntry::parseDwg(version, buf, sBuf, bs))
         return fail();
     DRW_DBG("\n***************************** parsing dimension style **************************************\n");
-    std::uint32_t bodyEnd = parsed.objSize;
-    std::uint32_t stringEnd = parsed.objSize;
-    if (version > DRW::AC1018 && parsed.objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!sBuff.getR2007StringStreamBounds(
-                parsed.objSize, stringStartBit, stringEndBit)
-            || stringStartBit > parsed.objSize
-            || stringEndBit > parsed.objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&sBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, sBuff, parsed.objSize, bodyEnd, stringEnd))
+        return fail();
     const auto readText = [version, buf, sBuf, bodyEnd, stringEnd](UTF8STRING& value) {
         return readVariableTextWithinBounds(buf, sBuf, version, bodyEnd,
                                             stringEnd, value);
@@ -3491,23 +3514,10 @@ bool DRW_LType::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_t bs)
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuff : buf;
     dwgBuffer *bodySBuf = version > DRW::AC1018 ? &bodyStringBuff : sBuf;
 
-    std::uint32_t bodyEnd = parsed.objSize;
-    std::uint32_t stringEnd = parsed.objSize;
-    if (version > DRW::AC1018 && parsed.objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuff.getR2007StringStreamBounds(
-                parsed.objSize, stringStartBit, stringEndBit)
-            || stringStartBit > parsed.objSize
-            || stringEndBit > parsed.objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuff, parsed.objSize, bodyEnd, stringEnd))
+        return fail();
 
     const auto readText = [version, bodyBuf, bodySBuf,
                            bodyEnd, stringEnd](UTF8STRING& value) {
@@ -3735,22 +3745,10 @@ bool DRW_Layer::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_t bs)
     if (!ret)
         return fail();
 
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!sBuff.getR2007StringStreamBounds(
-            objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&sBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, sBuff, objSize, bodyEnd, stringEnd))
+        return fail();
 
     UTF8STRING parsedName;
     if (!readVariableTextWithinBounds(buf, sBuf, version, bodyEnd, stringEnd,
@@ -3943,23 +3941,10 @@ bool DRW_Block_Record::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint3
     dwgBuffer bodyStringBuff = *sBuf;
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuff : buf;
     dwgBuffer *bodySBuf = version > DRW::AC1018 ? &bodyStringBuff : sBuf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuff.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize
-            || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuff, objSize, bodyEnd, stringEnd))
+        return fail();
 
     const auto readText = [version, bodyBuf, bodySBuf, bodyEnd,
                            stringEnd](UTF8STRING& value) {
@@ -4344,22 +4329,10 @@ bool DRW_Textstyle::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_t
     if (!ret)
         return fail();
 
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!sBuff.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&sBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, sBuff, objSize, bodyEnd, stringEnd))
+        return fail();
 
     const auto readText = [version, buf, sBuf, bodyEnd, stringEnd](UTF8STRING& value) {
         return readVariableTextWithinBounds(buf, sBuf, version, bodyEnd,
@@ -4611,32 +4584,10 @@ bool DRW_Vport::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     case 79:
         ucsOrthoType = reader->getInt32();
         break;
-    case 110:
-        ucsOrigin.x = reader->getDouble();
-        break;
-    case 120:
-        ucsOrigin.y = reader->getDouble();
-        break;
-    case 130:
-        ucsOrigin.z = reader->getDouble();
-        break;
-    case 111:
-        ucsXAxis.x = reader->getDouble();
-        break;
-    case 121:
-        ucsXAxis.y = reader->getDouble();
-        break;
-    case 131:
-        ucsXAxis.z = reader->getDouble();
-        break;
-    case 112:
-        ucsYAxis.x = reader->getDouble();
-        break;
-    case 122:
-        ucsYAxis.y = reader->getDouble();
-        break;
-    case 132:
-        ucsYAxis.z = reader->getDouble();
+    case 110: case 120: case 130:
+    case 111: case 121: case 131:
+    case 112: case 122: case 132:
+        readUcsTripletCode(code, reader, ucsOrigin, ucsXAxis, ucsYAxis);
         break;
     case 141:
         brightness = reader->getDouble();
@@ -4773,23 +4724,10 @@ bool DRW_Vport::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_t bs)
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuff : buf;
     dwgBuffer *bodySBuf = version > DRW::AC1018 ? &bodyStringBuff : sBuf;
 
-    std::uint32_t bodyEnd = parsed.objSize;
-    std::uint32_t stringEnd = parsed.objSize;
-    if (version > DRW::AC1018 && parsed.objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuff.getR2007StringStreamBounds(
-                parsed.objSize, stringStartBit, stringEndBit)
-            || stringStartBit > parsed.objSize
-            || stringEndBit > parsed.objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuff, parsed.objSize, bodyEnd, stringEnd))
+        return fail();
 
     const auto readText = [version, bodyBuf, bodySBuf,
                            bodyEnd, stringEnd](UTF8STRING& value) {
@@ -5171,23 +5109,10 @@ bool DRW_ImageDef::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_t 
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuff : buf;
     dwgBuffer *bodySBuf = version > DRW::AC1018 ? &bodyStringBuff : sBuf;
 
-    std::uint32_t bodyEnd = parsed.objSize;
-    std::uint32_t stringEnd = parsed.objSize;
-    if (version > DRW::AC1018 && parsed.objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuff.getR2007StringStreamBounds(
-                parsed.objSize, stringStartBit, stringEndBit)
-            || stringStartBit > parsed.objSize
-            || stringEndBit > parsed.objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuff, parsed.objSize, bodyEnd, stringEnd))
+        return fail();
 
     std::int32_t parsedImageVersion = 0;
     if (!readBitLongWithinBody(bodyBuf, version, bodyEnd,
@@ -5433,23 +5358,10 @@ bool DRW_PlotSettings::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint3
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuff : buf;
     dwgBuffer *bodySBuf = version > DRW::AC1018 ? &bodyStringBuff : sBuf;
 
-    std::uint32_t bodyEnd = parsed.objSize;
-    std::uint32_t stringEnd = parsed.objSize;
-    if (version > DRW::AC1018 && parsed.objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuff.getR2007StringStreamBounds(
-                parsed.objSize, stringStartBit, stringEndBit)
-            || stringStartBit > parsed.objSize
-            || stringEndBit > parsed.objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuff, parsed.objSize, bodyEnd, stringEnd))
+        return fail();
 
     const auto readText = [version, bodyBuf, bodySBuf,
                            bodyEnd, stringEnd](UTF8STRING& value) {
@@ -5776,23 +5688,10 @@ bool DRW_UCS::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_t bs){
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuff : buf;
     dwgBuffer *bodySBuf = version > DRW::AC1018 ? &bodyStringBuff : sBuf;
 
-    std::uint32_t bodyEnd = parsed.objSize;
-    std::uint32_t stringEnd = parsed.objSize;
-    if (version > DRW::AC1018 && parsed.objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuff.getR2007StringStreamBounds(
-                parsed.objSize, stringStartBit, stringEndBit)
-            || stringStartBit > parsed.objSize
-            || stringEndBit > parsed.objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuff, parsed.objSize, bodyEnd, stringEnd))
+        return fail();
 
     const auto readText = [version, bodyBuf, bodySBuf,
                            bodyEnd, stringEnd](UTF8STRING& value) {
@@ -6049,32 +5948,10 @@ bool DRW_View::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     case 73:
         cameraPlottable = reader->getBool();
         break;
-    case 110:
-        ucsOrigin.x = reader->getDouble();
-        break;
-    case 120:
-        ucsOrigin.y = reader->getDouble();
-        break;
-    case 130:
-        ucsOrigin.z = reader->getDouble();
-        break;
-    case 111:
-        ucsXAxis.x = reader->getDouble();
-        break;
-    case 121:
-        ucsXAxis.y = reader->getDouble();
-        break;
-    case 131:
-        ucsXAxis.z = reader->getDouble();
-        break;
-    case 112:
-        ucsYAxis.x = reader->getDouble();
-        break;
-    case 122:
-        ucsYAxis.y = reader->getDouble();
-        break;
-    case 132:
-        ucsYAxis.z = reader->getDouble();
+    case 110: case 120: case 130:
+    case 111: case 121: case 131:
+    case 112: case 122: case 132:
+        readUcsTripletCode(code, reader, ucsOrigin, ucsXAxis, ucsYAxis);
         break;
     case 79:
         ucsOrthoType = reader->getInt32();
@@ -6164,23 +6041,10 @@ bool DRW_View::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_t bs){
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuff : buf;
     dwgBuffer *bodySBuf = version > DRW::AC1018 ? &bodyStringBuff : sBuf;
 
-    std::uint32_t bodyEnd = parsed.objSize;
-    std::uint32_t stringEnd = parsed.objSize;
-    if (version > DRW::AC1018 && parsed.objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuff.getR2007StringStreamBounds(
-                parsed.objSize, stringStartBit, stringEndBit)
-            || stringStartBit > parsed.objSize
-            || stringEndBit > parsed.objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuff, parsed.objSize, bodyEnd, stringEnd))
+        return fail();
 
     const auto readText = [version, bodyBuf, bodySBuf,
                            bodyEnd, stringEnd](UTF8STRING& value) {
@@ -6485,22 +6349,10 @@ bool DRW_AppId::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_t bs)
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
 
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
 
     UTF8STRING parsedName;
     if (!readVariableTextWithinBounds(bodyBuf, bodyStringBuf, version,
@@ -7193,22 +7045,10 @@ bool DRW_ViewportEntityHeader::parseDwg(DRW::Version version,
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
 
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
     UTF8STRING parsedName;
     if (!readVariableTextWithinBounds(bodyBuf, bodyStringBuf, version,
                                       bodyEnd, stringEnd, parsedName))
@@ -7649,22 +7489,10 @@ bool DRW_TvDeviceProperties::parseDwg(DRW::Version version,
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
 
     // dwgTs::parseTvDeviceProperties reads the first six fields in every
     // version. Optional fields are present only while the bounded R2007+
@@ -7816,22 +7644,10 @@ bool DRW_CsacDocumentOptions::parseDwg(DRW::Version version,
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
 
     const auto bodyBytesRemaining = [version, bodyBuf, bodyEnd]() {
         if (version <= DRW::AC1018 || bodyEnd == 0)
@@ -7906,22 +7722,10 @@ bool DRW_ContextDataManager::parseDwg(DRW::Version version,
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
 
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
 
     bool countReadOk = true;
     std::uint32_t remainingRecordBudget =
@@ -8424,22 +8228,10 @@ bool DRW_DictionaryVar::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint
         return fail();
     }
 
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!sBuff.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&sBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, sBuff, objSize, bodyEnd, stringEnd))
+        return fail();
 
     std::uint8_t parsedSchema = 0;
     if (!readRawCharWithinBody(buf, version, bodyEnd, parsedSchema))
@@ -9321,22 +9113,10 @@ bool DRW_FieldList::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_t
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
 
     std::int32_t parsedFieldCount = 0;
     bool parsedUnknown = false;
@@ -9617,22 +9397,10 @@ bool DRW_RasterVariables::parseDwg(DRW::Version version, dwgBuffer *buf, std::ui
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
     if (!readBitLongWithinBody(bodyBuf, version, bodyEnd, parsedClassVersion)
         || !readBitShortWithinBody(bodyBuf, version, bodyEnd, parsedImageFrame)
         || !readBitShortWithinBody(bodyBuf, version, bodyEnd, parsedImageQuality)
@@ -9703,22 +9471,10 @@ bool DRW_WipeoutVariables::parseDwg(DRW::Version version, dwgBuffer *buf, std::u
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
     std::int32_t parsedDisplayFrame = 0;
     if (!readBitShortWithinBody(bodyBuf, version, bodyEnd, parsedDisplayFrame)
         || !bodyBuf->isGood()
@@ -11337,22 +11093,10 @@ bool DRW_PointCloudDef::parseDwg(DRW::Version version, dwgBuffer *buf,
 
     dwgBuffer bodyBuffer = *buf;
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!stringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&stringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, stringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
     std::int32_t classVersion = 0;
     if (!readBitLongWithinBody(bodyBuf, version, bodyEnd, classVersion)
         || classVersion < 0 || classVersion > kMaxClassVersion)
@@ -11531,22 +11275,10 @@ bool DRW_NavisworksModelDef::parseDwg(DRW::Version version, dwgBuffer *buf,
 
     dwgBuffer bodyBuffer = *buf;
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!stringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&stringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, stringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
     std::int32_t parsedFlags = 0;
     UTF8STRING parsedPath;
     bool parsedStatus = false;
@@ -11743,22 +11475,10 @@ bool DRW_PointCloudColorMap::parseDwg(DRW::Version version, dwgBuffer *buf,
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
     std::int32_t classVersion = 0;
     if (!readBitShortWithinBody(bodyBuf, version, bodyEnd, classVersion)
         || classVersion < 0 || classVersion > kMaxClassVersion)
@@ -11999,22 +11719,10 @@ bool DRW_SunStudy::parseDwg(DRW::Version version, dwgBuffer *buf,
     if (!DRW_TableEntry::parseDwg(version, buf, textBuffer, bs))
         return fail();
 
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!stringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&stringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, stringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
 
     const auto readLong = [&](std::int32_t& value) {
         return readBitLongWithinBody(buf, version, bodyEnd, value);
@@ -12314,22 +12022,10 @@ bool DRW_MotionPath::parseDwg(DRW::Version version, dwgBuffer *buf,
     dwgBuffer bodyBuffer = *buf;
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
 
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!stringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&stringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, stringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
 
     std::int32_t classVersion = 0;
     dwgHandle cameraPath;
@@ -12458,22 +12154,10 @@ bool DRW_CurvePath::parseDwg(DRW::Version version, dwgBuffer *buf,
     dwgBuffer bodyBuffer = *buf;
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
 
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!stringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&stringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, stringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
 
     std::int32_t classVersion = 0;
     dwgHandle entity;
@@ -12585,22 +12269,10 @@ bool DRW_PointPath::parseDwg(DRW::Version version, dwgBuffer *buf,
     dwgBuffer bodyBuffer = *buf;
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
 
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!stringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&stringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, stringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
 
     std::int32_t classVersion = 0;
     DRW_Coord point;
@@ -13078,22 +12750,10 @@ bool DRW_Background::parseDwg(DRW::Version version, dwgBuffer *buf,
     if (!DRW_TableEntry::parseDwg(version, buf, strBuf, bs))
         return fail();
 
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!stringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&stringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, stringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
 
     std::int32_t classVersion = 0;
     std::int32_t solidColor = 0;
@@ -13518,22 +13178,10 @@ bool DRW_TableStyle::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuff : buf;
     dwgBuffer *bodySBuf = version > DRW::AC1018 ? &bodyStringBuff : sBuf;
 
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuff.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuff, objSize, bodyEnd, stringEnd))
+        return fail();
 
     // The body cursor reaches the inline handle stream for R2000/R2004;
     // R2007+ uses the separate absolute objSize boundary.
@@ -13850,22 +13498,10 @@ bool DRW_CellStyleMap::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint3
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuff : buf;
     dwgBuffer *bodySBuf = version > DRW::AC1018 ? &bodyStringBuff : sBuf;
 
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuff.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuff, objSize, bodyEnd, stringEnd))
+        return fail();
 
     // The body cursor reaches the inline handle stream for R2000/R2004;
     // R2007+ uses the separate absolute objSize boundary.
@@ -14080,22 +13716,10 @@ bool DRW_Layout::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_t bs
     dwgBuffer *bodySBuf = version > DRW::AC1018 ? &bodyStringBuff
                                                 : &bodyBuff;
 
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuff.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuff, objSize, bodyEnd, stringEnd))
+        return fail();
 
     const auto readShort = [&](std::int32_t& value) {
         return readBitShortWithinBody(bodyBuf, version, bodyEnd, value);
@@ -14439,23 +14063,10 @@ bool DRW_MLineStyle::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuff : buf;
     dwgBuffer *bodySBuf = version > DRW::AC1018 ? &bodyStringBuff : sBuf;
 
-    std::uint32_t bodyEnd = parsed.objSize;
-    std::uint32_t stringEnd = parsed.objSize;
-    if (version > DRW::AC1018 && parsed.objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuff.getR2007StringStreamBounds(
-                parsed.objSize, stringStartBit, stringEndBit)
-            || stringStartBit > parsed.objSize
-            || stringEndBit > parsed.objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuff, parsed.objSize, bodyEnd, stringEnd))
+        return fail();
 
     const auto readText = [version, bodyBuf, bodySBuf, bodyEnd,
                            stringEnd](UTF8STRING& value) {
@@ -14725,23 +14336,10 @@ bool DRW_MLeaderStyle::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint3
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuff : buf;
     dwgBuffer *bodySBuf = version > DRW::AC1018 ? &bodyStringBuff : sBuf;
 
-    std::uint32_t bodyEnd = parsed.objSize;
-    std::uint32_t stringEnd = parsed.objSize;
-    if (version > DRW::AC1018 && parsed.objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuff.getR2007StringStreamBounds(
-                parsed.objSize, stringStartBit, stringEndBit)
-            || stringStartBit > parsed.objSize
-            || stringEndBit > parsed.objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuff, parsed.objSize, bodyEnd, stringEnd))
+        return fail();
 
     const auto readText = [version, bodyBuf, bodySBuf, bodyEnd,
                            stringEnd](UTF8STRING& value) {
@@ -15032,22 +14630,10 @@ bool DRW_Index::parseDwg(DRW::Version version, dwgBuffer *buf,
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
 
     std::int32_t parsedDays = 0;
     std::int32_t parsedMilliseconds = 0;
@@ -15135,22 +14721,10 @@ bool DRW_IDBuffer::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_t 
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
 
     std::uint8_t parsedClassVersion = 0;
     std::int32_t parsedIdCount = 0;
@@ -15313,22 +14887,10 @@ bool DRW_LayerIndex::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
     std::int32_t parsedTimestamp1 = 0;
     std::int32_t parsedTimestamp2 = 0;
     std::int32_t parsedEntryCount = 0;
@@ -15436,22 +14998,10 @@ bool DRW_SpatialIndex::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint3
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
 
     std::int32_t parsedTimestamp1 = 0;
     std::int32_t parsedTimestamp2 = 0;
@@ -16642,22 +16192,10 @@ bool DRW_UnderlayDefinition::parseDwg(DRW::Version version, dwgBuffer *buf, std:
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
     const auto readText = [version, bodyBuf, bodyStringBuf, bodyEnd, stringEnd](
                                UTF8STRING& value) {
         return readVariableTextWithinBounds(bodyBuf, bodyStringBuf, version,
@@ -16792,22 +16330,10 @@ bool DRW_Scale::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_t bs)
 
     dwgBuffer bodyBuff = *buf;
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuff : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!sBuff.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&sBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, sBuff, objSize, bodyEnd, stringEnd))
+        return fail();
     std::int32_t parsedFlag = 0;
     double parsedPaperUnits = 1.0;
     double parsedDrawingUnits = 1.0;
@@ -17367,22 +16893,10 @@ bool DRW_Group::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_t bs)
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
 
     UTF8STRING parsedDescription;
     if (!readVariableTextWithinBounds(bodyBuf, bodyStringBuf, version,
@@ -17533,22 +17047,10 @@ bool DRW_LightList::parseDwg(DRW::Version version, dwgBuffer *buf,
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
     std::int32_t classVersion = 0;
     std::int32_t lightCount = 0;
     if (!readBitLongWithinBody(bodyBuf, version, bodyEnd, classVersion)
@@ -17688,22 +17190,10 @@ bool DRW_LayerFilter::parseDwg(DRW::Version version, dwgBuffer *buf,
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
     std::int32_t nameCount = 0;
     if (!readBitLongWithinBody(bodyBuf, version, bodyEnd, nameCount)
         || nameCount < 0
@@ -17873,22 +17363,10 @@ bool DRW_DataLink::parseDwg(DRW::Version version, dwgBuffer *buf,
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
     const auto readText = [&](UTF8STRING& value) {
         return readVariableTextWithinBounds(bodyBuf, bodyStringBuf, version,
                                             bodyEnd, stringEnd, value);
@@ -18082,22 +17560,10 @@ bool DRW_GeoMapImage::parseDwg(DRW::Version version, dwgBuffer *buf,
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
     std::int32_t classVersion = 0;
     DRW_Coord insertionPoint;
     DRW_Coord imageSize;
@@ -18562,22 +18028,10 @@ bool DRW_ImageDefinitionReactor::parseDwg(DRW::Version version, dwgBuffer *buf, 
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
     std::int32_t classVersion = 0;
     if (!readBitLongWithinBody(bodyBuf, version, bodyEnd, classVersion)
         || classVersion < 0 || classVersion > kMaxClassVersion
@@ -18741,22 +18195,10 @@ bool DRW_SpatialFilter::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuffer : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuffer : sBuf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
     std::int32_t pointCount = 0;
     if (!readBitShortWithinBody(bodyBuf, version, bodyEnd, pointCount)
         || pointCount < 0
@@ -19056,22 +18498,10 @@ bool DRW_GeoData::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_t b
     dwgBuffer *bodyBuf = &bodyBuffer;
     dwgBuffer *bodyStringBuf = sBuf != buf ? &bodyStringBuffer
                                            : &bodyBuffer;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuffer.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuffer) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuffer, objSize, bodyEnd, stringEnd))
+        return fail();
     const auto readLong = [&](std::int32_t& value) {
         return readBitLongWithinBody(bodyBuf, version, bodyEnd, value);
     };
@@ -19323,22 +18753,10 @@ bool DRW_TableGeometry::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuff : buf;
     dwgBuffer bodyStringBuff = *sBuf;
     dwgBuffer *bodySBuf = version > DRW::AC1018 ? &bodyStringBuff : buf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuff.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuff, objSize, bodyEnd, stringEnd))
+        return fail();
     std::int32_t rowCount = 0;
     std::int32_t columnCount = 0;
     std::int32_t cellCount = 0;
@@ -19705,22 +19123,10 @@ bool DRW_EvaluationGraph::parseDwg(DRW::Version version, dwgBuffer *buf, std::ui
     dwgBuffer *bodyBuf = &bodyBuff;
     dwgBuffer bodyStringBuff = *sBuf;
     dwgBuffer *bodySBuf = &bodyStringBuff;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuff.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuff, objSize, bodyEnd, stringEnd))
+        return fail();
     std::int32_t value96 = 0;
     std::int32_t value97 = 0;
     if (!readBitLongWithinBody(bodyBuf, version, bodyEnd, value96)
@@ -20284,22 +19690,10 @@ bool DRW_Sun::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_t bs){
     dwgBuffer *bodyBuf = version > DRW::AC1018 ? &bodyBuff : buf;
     dwgBuffer *bodyStringBuf = version > DRW::AC1018
         ? &bodyStringBuff : sBuf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!bodyStringBuff.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&bodyStringBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, bodyStringBuff, objSize, bodyEnd, stringEnd))
+        return fail();
     dwgBuffer hBuff = *buf;
     std::int32_t classVersion = 0;
     bool isOn = false;
@@ -24413,22 +23807,10 @@ bool DRW_VisualStyle::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32
     dwgBuffer stringBuff = sBuff;
     dwgBuffer *bodyBuf = &bodyBuff;
     dwgBuffer *bodySBuf = version > DRW::AC1018 ? &stringBuff : bodyBuf;
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!sBuff.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&sBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, sBuff, objSize, bodyEnd, stringEnd))
+        return fail();
     const auto bodyBytesRemaining = [&]() {
         if (version >= DRW::AC1015 && bodyEnd != 0)
             return currentObjectDwgBit(bodyBuf) < bodyEnd;
@@ -24829,22 +24211,10 @@ bool DRW_DbColor::parseDwg(DRW::Version version, dwgBuffer *buf, std::uint32_t b
     if (!ret)
         return fail();
 
-    std::uint32_t bodyEnd = objSize;
-    std::uint32_t stringEnd = objSize;
-    if (version > DRW::AC1018 && objSize != 0) {
-        std::uint64_t stringStartBit = 0;
-        std::uint64_t stringEndBit = 0;
-        if (!sBuff.getR2007StringStreamBounds(
-                objSize, stringStartBit, stringEndBit)
-            || stringStartBit > objSize || stringEndBit > objSize
-            || stringEndBit < stringStartBit
-            || stringStartBit > std::numeric_limits<std::uint32_t>::max()
-            || stringEndBit > std::numeric_limits<std::uint32_t>::max()
-            || currentObjectDwgBit(&sBuff) != stringStartBit)
-            return fail();
-        bodyEnd = static_cast<std::uint32_t>(stringStartBit);
-        stringEnd = static_cast<std::uint32_t>(stringEndBit);
-    }
+    std::uint32_t bodyEnd = 0;
+    std::uint32_t stringEnd = 0;
+    if (!resolveR2007StreamBounds(version, sBuff, objSize, bodyEnd, stringEnd))
+        return fail();
 
     // Single FIELD_CMC per the spec. Stage the complete payload so a short
     // RGB/method/name field cannot advance the body or string cursor.

--- a/libraries/libdxfrw/src/intern/dwgwriter.h
+++ b/libraries/libdxfrw/src/intern/dwgwriter.h
@@ -19,6 +19,7 @@
 #include <limits>
 #include <map>
 #include <set>
+#include <cstring>
 #include <string>
 #include <utility>
 #include <vector>
@@ -83,6 +84,57 @@ struct DwgRawClassIdentityKey {
 /// Mirror of `class dwgReader` ([intern/dwgreader.h](dwgreader.h)).
 /// Read side dispatches via `dwgRW::createReaderForVersion`; write
 /// side will dispatch similarly once additional target versions land.
+// Class metadata for the typed OBJECT registrars below.  Every row holds the
+// six DwgClassDefinition fields those registrars used to assign one by one;
+// collecting them here makes the per-type values reviewable side by side and
+// leaves each registrar a single lookup.  Registrars that do more than fill
+// these six fields (PlotSettings, LightList, ImageDefReactor and the
+// DimensionAssociation variants) keep their own bodies.
+struct DwgTypedClassRow {
+    const char* key;
+    std::uint16_t classNum;
+    std::uint16_t proxyFlag;
+    const char* appName;
+    const char* className;
+    const char* recordName;
+    std::uint16_t entityFlagRaw;
+};
+
+inline constexpr DwgTypedClassRow kDwgTypedClassRows[] = {
+    {"Sun", DRW_Sun::kDwgClassNum, 0x401, "SCENEOE", "AcDbSun", "SUN", 0x1F3},
+    {"TvDeviceProperties", DRW_TvDeviceProperties::kDwgClassNum, 0x401, "ACTION", "AcDbTvDeviceProperties", "TVDEVICEPROPERTIES", 0x1F3},
+    {"VxControl", DRW_VxControl::kDwgClassNum, 0x401, "ObjectDBX Classes", "AcDbVxControl", "VXCONTROL", 0x1F3},
+    {"VxTableRecord", DRW_VxTableRecord::kDwgClassNum, 0x401, "ObjectDBX Classes", "AcDbVxTableRecord", "VXTABLERECORD", 0x1F3},
+    {"MLeaderStyle", DRW_MLeaderStyle::kDwgClassNum, 0x401, "ACDB_MLEADERSTYLE_CLASS", "AcDbMLeaderStyle", "MLEADERSTYLE", 0x1F3},
+    {"TableStyle", DRW_TableStyle::kDwgClassNum, 0xFFF, "ObjectDBX Classes", "AcDbTableStyle", "TABLESTYLE", 0x1F3},
+    {"Material", DRW_Material::kDwgClassNum, 0x401, "ObjectDBX Classes", "AcDbMaterial", "MATERIAL", 0x1F3},
+    {"DbColor", DRW_DbColor::kDwgClassNum, 0x401, "ACTION", "AcDbColor", "DBCOLOR", 0x1F3},
+    {"SunStudy", DRW_SunStudy::kDwgClassNum, 0x401, "SCENEOE", "AcDbSunStudy", "SUNSTUDY", 0x1F3},
+    {"MotionPath", DRW_MotionPath::kDwgClassNum, 0x401, "ACTION", "AcDbMotionPath", "MOTIONPATH", 0x1F3},
+    {"CurvePath", DRW_CurvePath::kDwgClassNum, 0x401, "ACTION", "AcDbCurvePath", "CURVEPATH", 0x1F3},
+    {"PointPath", DRW_PointPath::kDwgClassNum, 0x401, "ACTION", "AcDbPointPath", "POINTPATH", 0x1F3},
+    {"PartialViewingIndex", DRW_PartialViewingIndex::kDwgClassNum, 0x401, "ObjectDBX Classes", "AcDbPartialViewingIndex", "PARTIAL_VIEWING_INDEX", 0x1F3},
+    {"ObjectPtr", DRW_ObjectPtr::kDwgClassNum, 0x401, "ObjectDBX Classes", "AcDbObjectPtr", "OBJECT_PTR", 0x1F3},
+    {"VisualStyle", DRW_VisualStyle::kDwgClassNum, 0x401, "ObjectDBX Classes", "AcDbVisualStyle", "VISUALSTYLE", 0x1F3},
+    {"EvaluationGraph", DRW_EvaluationGraph::kDwgClassNum, 0x481, "ObjectDBX Classes", "AcDbEvalGraph", "ACAD_EVALUATION_GRAPH", 0x1F3},
+    {"DimensionAssociation", DRW_DimensionAssociation::kDwgClassNum, 0, "AcDbDimAssoc|Product Desc: AcDim ARX App For Dimension|" "Company: Autodesk, Inc.|WEB Address: www.autodesk.com", "AcDbDimAssoc", "DIMASSOC", 0x1F3},
+    {"RasterVariables", DRW_RasterVariables::kDwgClassNum, 0x401, "ISM", "AcDbRasterVariables", "RASTERVARIABLES", 0x1F3},
+    {"WipeoutVariables", DRW_WipeoutVariables::kDwgClassNum, 0x401, "WipeOut", "AcDbWipeoutVariables", "WIPEOUTVARIABLES", 0x1F3},
+    {"NavisworksModelDef", DRW_NavisworksModelDef::kDwgClassNum, 0x401, "ObjectDBX Classes", "AcDbNavisworksModelDef", "NAVISWORKSMODELDEF", 0x1F3},
+    {"PointCloudColorMap", DRW_PointCloudColorMap::kDwgClassNum, 0x401, "ObjectDBX Classes", "AcDbPointCloudColorMap", "POINTCLOUDCOLORMAP", 0x1F3},
+    {"GeoData", DRW_GeoData::kDwgClassNum, 0xFFF, "ObjectDBX Classes", "AcDbGeoData", "GEODATA", 0x1F3},
+    {"SpatialFilter", DRW_SpatialFilter::kDwgClassNum, 0x401, "ACAD", "AcDbSpatialFilter", "SPATIAL_FILTER", 0x1F3},
+    {"Scale", DRW_Scale::kDwgClassNum, 0x401, "ACAD", "AcDbScale", "SCALE", 0x1F3},
+    {"IDBuffer", DRW_IDBuffer::kDwgClassNum, 0x401, "ACAD", "AcDbIdBuffer", "IDBUFFER", 0x1F3},
+    {"LayerIndex", DRW_LayerIndex::kDwgClassNum, 0x401, "ACAD", "AcDbLayerIndex", "LAYER_INDEX", 0x1F3},
+    {"SpatialIndex", DRW_SpatialIndex::kDwgClassNum, 0x401, "ACAD", "AcDbSpatialIndex", "SPATIAL_INDEX", 0x1F3},
+    {"DictionaryVar", DRW_DictionaryVar::kDwgClassNum, 0x401, "ACAD", "AcDbDictionaryVar", "DICTIONARYVAR", 0x1F3},
+    {"DictionaryWithDefault", DRW_DictionaryWithDefault::kDwgClassNum, 0x401, "ACAD", "AcDbDictionaryWithDefault", "ACDBDICTIONARYWDFLT", 0x1F3},
+    {"SortEntsTable", DRW_SortEntsTable::kDwgClassNum, 0x401, "ACAD", "AcDbSortentsTable", "SORTENTSTABLE", 0x1F3},
+    {"FieldList", DRW_FieldList::kDwgClassNum, 0x401, "ACAD", "AcDbFieldList", "FIELDLIST", 0x1F3},
+    {"Field", DRW_Field::kDwgClassNum, 0x401, "ACAD", "AcDbField", "FIELD", 0x1F3},
+};
+
 class dwgWriter {
 public:
     /// Construct around an output stream and a populated header.
@@ -724,92 +776,55 @@ public:
         return m_rawObjectOverrides.count({objectType, handle}) != 0;
     }
 
+    /// Register a typed OBJECT class from kDwgTypedClassRows.  The per-type
+    /// registrars below are thin wrappers so their names remain the writer's
+    /// API; registrars needing extra logic keep their own bodies.
+    bool registerTypedObjectClassRow(const char* key, std::uint32_t handle) {
+        for (const DwgTypedClassRow& row : kDwgTypedClassRows) {
+            if (std::strcmp(row.key, key) != 0)
+                continue;
+            DwgClassDefinition definition;
+            definition.m_classNum = row.classNum;
+            definition.m_proxyFlag = row.proxyFlag;
+            definition.m_appName = row.appName;
+            definition.m_className = row.className;
+            definition.m_recordName = row.recordName;
+            definition.m_entityFlagRaw = row.entityFlagRaw;
+            return registerTypedObjectClass(definition, handle);
+        }
+        return false;
+    }
+
     bool registerSunObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_Sun::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "SCENEOE";
-        definition.m_className = "AcDbSun";
-        definition.m_recordName = "SUN";
-        definition.m_entityFlagRaw = 0x1F3;  // object class (ODA item_class_id)
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("Sun", handle);
     }
 
     bool registerTvDevicePropertiesObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_TvDeviceProperties::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ACTION";
-        definition.m_className = "AcDbTvDeviceProperties";
-        definition.m_recordName = "TVDEVICEPROPERTIES";
-        definition.m_entityFlagRaw = 0x1F3;
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("TvDeviceProperties", handle);
     }
 
     bool registerVxControlObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_VxControl::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ObjectDBX Classes";
-        definition.m_className = "AcDbVxControl";
-        definition.m_recordName = "VXCONTROL";
-        definition.m_entityFlagRaw = 0x1F3;
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("VxControl", handle);
     }
 
     bool registerVxTableRecordObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_VxTableRecord::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ObjectDBX Classes";
-        definition.m_className = "AcDbVxTableRecord";
-        definition.m_recordName = "VXTABLERECORD";
-        definition.m_entityFlagRaw = 0x1F3;
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("VxTableRecord", handle);
     }
 
     bool registerMLeaderStyleObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_MLeaderStyle::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ACDB_MLEADERSTYLE_CLASS";
-        definition.m_className = "AcDbMLeaderStyle";
-        definition.m_recordName = "MLEADERSTYLE";
-        definition.m_entityFlagRaw = 0x1F3;  // object class (ODA item_class_id)
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("MLeaderStyle", handle);
     }
 
     bool registerTableStyleObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_TableStyle::kDwgClassNum;
-        definition.m_proxyFlag = 0xFFF;
-        definition.m_appName = "ObjectDBX Classes";
-        definition.m_className = "AcDbTableStyle";
-        definition.m_recordName = "TABLESTYLE";
-        definition.m_entityFlagRaw = 0x1F3;
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("TableStyle", handle);
     }
 
     bool registerMaterialObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_Material::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ObjectDBX Classes";
-        definition.m_className = "AcDbMaterial";
-        definition.m_recordName = "MATERIAL";
-        definition.m_entityFlagRaw = 0x1F3;  // object class
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("Material", handle);
     }
 
     bool registerDbColorObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_DbColor::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ACTION";
-        definition.m_className = "AcDbColor";
-        definition.m_recordName = "DBCOLOR";
-        definition.m_entityFlagRaw = 0x1F3;
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("DbColor", handle);
     }
 
     bool registerPlotSettingsObjectClass(std::uint32_t handle = 0) {
@@ -885,69 +900,27 @@ public:
     }
 
     bool registerSunStudyObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_SunStudy::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "SCENEOE";
-        definition.m_className = "AcDbSunStudy";
-        definition.m_recordName = "SUNSTUDY";
-        definition.m_entityFlagRaw = 0x1F3;
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("SunStudy", handle);
     }
 
     bool registerMotionPathObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_MotionPath::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ACTION";
-        definition.m_className = "AcDbMotionPath";
-        definition.m_recordName = "MOTIONPATH";
-        definition.m_entityFlagRaw = 0x1F3;
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("MotionPath", handle);
     }
 
     bool registerCurvePathObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_CurvePath::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ACTION";
-        definition.m_className = "AcDbCurvePath";
-        definition.m_recordName = "CURVEPATH";
-        definition.m_entityFlagRaw = 0x1F3;
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("CurvePath", handle);
     }
 
     bool registerPointPathObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_PointPath::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ACTION";
-        definition.m_className = "AcDbPointPath";
-        definition.m_recordName = "POINTPATH";
-        definition.m_entityFlagRaw = 0x1F3;
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("PointPath", handle);
     }
 
     bool registerPartialViewingIndexObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_PartialViewingIndex::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ObjectDBX Classes";
-        definition.m_className = "AcDbPartialViewingIndex";
-        definition.m_recordName = "PARTIAL_VIEWING_INDEX";
-        definition.m_entityFlagRaw = 0x1F3;
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("PartialViewingIndex", handle);
     }
 
     bool registerObjectPtrObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_ObjectPtr::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ObjectDBX Classes";
-        definition.m_className = "AcDbObjectPtr";
-        definition.m_recordName = "OBJECT_PTR";
-        definition.m_entityFlagRaw = 0x1F3;
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("ObjectPtr", handle);
     }
 
     bool registerRenderSettingsObjectClass(
@@ -997,60 +970,23 @@ public:
     }
 
     bool registerVisualStyleObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_VisualStyle::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ObjectDBX Classes";
-        definition.m_className = "AcDbVisualStyle";
-        definition.m_recordName = "VISUALSTYLE";
-        definition.m_entityFlagRaw = 0x1F3;
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("VisualStyle", handle);
     }
 
     bool registerEvaluationGraphObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_EvaluationGraph::kDwgClassNum;
-        definition.m_proxyFlag = 0x481;
-        definition.m_appName = "ObjectDBX Classes";
-        definition.m_className = "AcDbEvalGraph";
-        definition.m_recordName = "ACAD_EVALUATION_GRAPH";
-        definition.m_entityFlagRaw = 0x1F3;
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("EvaluationGraph", handle);
     }
 
     bool registerDimensionAssociationObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_DimensionAssociation::kDwgClassNum;
-        definition.m_proxyFlag = 0;
-        definition.m_appName =
-            "AcDbDimAssoc|Product Desc:     AcDim ARX App For Dimension|"
-            "Company:          Autodesk, Inc.|WEB Address:      www.autodesk.com";
-        definition.m_className = "AcDbDimAssoc";
-        definition.m_recordName = "DIMASSOC";
-        definition.m_entityFlagRaw = 0x1F3;
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("DimensionAssociation", handle);
     }
 
     bool registerRasterVariablesObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_RasterVariables::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ISM";
-        definition.m_className = "AcDbRasterVariables";
-        definition.m_recordName = "RASTERVARIABLES";
-        definition.m_entityFlagRaw = 0x1F3;  // object class (ODA item_class_id)
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("RasterVariables", handle);
     }
 
     bool registerWipeoutVariablesObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_WipeoutVariables::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "WipeOut";
-        definition.m_className = "AcDbWipeoutVariables";
-        definition.m_recordName = "WIPEOUTVARIABLES";
-        definition.m_entityFlagRaw = 0x1F3;  // object class (ODA item_class_id)
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("WipeoutVariables", handle);
     }
 
     bool registerWipeoutEntityClass() {
@@ -1111,152 +1047,61 @@ public:
     }
 
     bool registerNavisworksModelDefObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_NavisworksModelDef::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ObjectDBX Classes";
-        definition.m_className = "AcDbNavisworksModelDef";
-        definition.m_recordName = "NAVISWORKSMODELDEF";
-        definition.m_entityFlagRaw = 0x1F3;
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("NavisworksModelDef", handle);
     }
 
     bool registerPointCloudColorMapObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_PointCloudColorMap::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ObjectDBX Classes";
-        definition.m_className = "AcDbPointCloudColorMap";
-        definition.m_recordName = "POINTCLOUDCOLORMAP";
-        definition.m_entityFlagRaw = 0x1F3;
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("PointCloudColorMap", handle);
     }
 
     bool registerGeoDataObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_GeoData::kDwgClassNum;
-        definition.m_proxyFlag = 0xFFF;
-        definition.m_appName = "ObjectDBX Classes";
-        definition.m_className = "AcDbGeoData";
-        definition.m_recordName = "GEODATA";
-        definition.m_entityFlagRaw = 0x1F3;  // object class (ODA item_class_id)
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("GeoData", handle);
     }
 
     bool registerSpatialFilterObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_SpatialFilter::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ACAD";
-        definition.m_className = "AcDbSpatialFilter";
-        definition.m_recordName = "SPATIAL_FILTER";
-        definition.m_entityFlagRaw = 0x1F3;  // object class (ODA item_class_id)
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("SpatialFilter", handle);
     }
 
     // PR 8d.2a — five small no-storage OBJECTS families.  All are custom-class
     // (≥ 500); recName / className strings follow the dwgreader.cpp dispatch
     // (case-sensitive look-up against classesmap).
     bool registerScaleObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_Scale::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ACAD";
-        definition.m_className = "AcDbScale";
-        definition.m_recordName = "SCALE";
-        definition.m_entityFlagRaw = 0x1F3;  // object class (ODA item_class_id)
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("Scale", handle);
     }
 
     bool registerIDBufferObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_IDBuffer::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ACAD";
-        definition.m_className = "AcDbIdBuffer";
-        definition.m_recordName = "IDBUFFER";
-        definition.m_entityFlagRaw = 0x1F3;  // object class (ODA item_class_id)
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("IDBuffer", handle);
     }
 
     bool registerLayerIndexObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_LayerIndex::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ACAD";
-        definition.m_className = "AcDbLayerIndex";
-        definition.m_recordName = "LAYER_INDEX";
-        definition.m_entityFlagRaw = 0x1F3;  // object class (ODA item_class_id)
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("LayerIndex", handle);
     }
 
     bool registerSpatialIndexObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_SpatialIndex::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ACAD";
-        definition.m_className = "AcDbSpatialIndex";
-        definition.m_recordName = "SPATIAL_INDEX";
-        definition.m_entityFlagRaw = 0x1F3;  // object class (ODA item_class_id)
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("SpatialIndex", handle);
     }
 
     bool registerDictionaryVarObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_DictionaryVar::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ACAD";
-        definition.m_className = "AcDbDictionaryVar";
-        definition.m_recordName = "DICTIONARYVAR";
-        definition.m_entityFlagRaw = 0x1F3;  // object class (ODA item_class_id)
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("DictionaryVar", handle);
     }
 
     // PR 8d.2b — four larger no-storage OBJECTS families.  Same shape as
     // PR 8d.2a; recName / className strings follow the dwgreader.cpp dispatch
     // (case-sensitive look-up against classesmap).
     bool registerDictionaryWithDefaultObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_DictionaryWithDefault::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ACAD";
-        definition.m_className = "AcDbDictionaryWithDefault";
-        definition.m_recordName = "ACDBDICTIONARYWDFLT";
-        definition.m_entityFlagRaw = 0x1F3;  // object class (ODA item_class_id)
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("DictionaryWithDefault", handle);
     }
 
     bool registerSortEntsTableObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_SortEntsTable::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ACAD";
-        definition.m_className = "AcDbSortentsTable";
-        definition.m_recordName = "SORTENTSTABLE";
-        definition.m_entityFlagRaw = 0x1F3;  // object class (ODA item_class_id)
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("SortEntsTable", handle);
     }
 
     bool registerFieldListObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_FieldList::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ACAD";
-        definition.m_className = "AcDbFieldList";
-        definition.m_recordName = "FIELDLIST";
-        definition.m_entityFlagRaw = 0x1F3;  // object class (ODA item_class_id)
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("FieldList", handle);
     }
 
     bool registerFieldObjectClass(std::uint32_t handle = 0) {
-        DwgClassDefinition definition;
-        definition.m_classNum = DRW_Field::kDwgClassNum;
-        definition.m_proxyFlag = 0x401;
-        definition.m_appName = "ACAD";
-        definition.m_className = "AcDbField";
-        definition.m_recordName = "FIELD";
-        definition.m_entityFlagRaw = 0x1F3;  // object class (ODA item_class_id)
-        return registerTypedObjectClass(definition, handle);
+        return registerTypedObjectClassRow("Field", handle);
     }
 
     bool registerSectionObjectClass(DRW_Section::Kind kind,

--- a/libraries/libdxfrw/src/intern/dwgwriter.h
+++ b/libraries/libdxfrw/src/intern/dwgwriter.h
@@ -15,11 +15,11 @@
 #define DWGWRITER_H
 
 #include <algorithm>
+#include <cstddef>
 #include <fstream>
 #include <limits>
 #include <map>
 #include <set>
-#include <cstring>
 #include <string>
 #include <utility>
 #include <vector>
@@ -168,9 +168,23 @@ constexpr bool dwgClassTextNonEmpty(const char* text) {
     return text != nullptr && *text != '\0';
 }
 
+constexpr std::size_t kDwgTypedClassRowCount =
+    sizeof(kDwgTypedClassRows) / sizeof(kDwgTypedClassRows[0]);
+
+// Resolve a row key to its index while compiling.  Returns the row count for a
+// key that is not in the table; registerTypedObjectClassRow() turns that into a
+// build failure, so a mistyped key can no longer compile and then show up at
+// write time as a class registration that quietly refused.
+constexpr std::size_t dwgTypedClassRowIndex(const char* key) {
+    for (std::size_t i = 0; i < kDwgTypedClassRowCount; ++i) {
+        if (dwgClassTextEqual(kDwgTypedClassRows[i].key, key))
+            return i;
+    }
+    return kDwgTypedClassRowCount;
+}
+
 constexpr bool dwgTypedClassRowsAreWellFormed() {
-    constexpr std::size_t count =
-        sizeof(kDwgTypedClassRows) / sizeof(kDwgTypedClassRows[0]);
+    constexpr std::size_t count = kDwgTypedClassRowCount;
     for (std::size_t i = 0; i < count; ++i) {
         const DwgTypedClassRow& a = kDwgTypedClassRows[i];
         if (!dwgClassTextNonEmpty(a.key) || !dwgClassTextNonEmpty(a.appName)
@@ -836,55 +850,56 @@ public:
         return m_rawObjectOverrides.count({objectType, handle}) != 0;
     }
 
-    /// Register a typed OBJECT class from kDwgTypedClassRows.  The per-type
-    /// registrars below are thin wrappers so their names remain the writer's
-    /// API; registrars needing extra logic keep their own bodies.
-    bool registerTypedObjectClassRow(const char* key, std::uint32_t handle) {
-        for (const DwgTypedClassRow& row : kDwgTypedClassRows) {
-            if (std::strcmp(row.key, key) != 0)
-                continue;
-            DwgClassDefinition definition;
-            definition.m_classNum = row.classNum;
-            definition.m_proxyFlag = row.proxyFlag;
-            definition.m_appName = row.appName;
-            definition.m_className = row.className;
-            definition.m_recordName = row.recordName;
-            definition.m_entityFlagRaw = row.entityFlagRaw;
-            return registerTypedObjectClass(definition, handle);
-        }
-        return false;
+    /// Register a typed OBJECT class from kDwgTypedClassRows.  The row is
+    /// selected by index, resolved from its key by dwgTypedClassRowIndex()
+    /// while compiling, so a key the table does not carry fails the build.
+    /// The per-type registrars below are thin wrappers so their names remain
+    /// the writer's API; registrars needing extra logic keep their own bodies.
+    template <std::size_t Index>
+    bool registerTypedObjectClassRow(std::uint32_t handle) {
+        static_assert(Index < kDwgTypedClassRowCount,
+                      "no row in kDwgTypedClassRows carries this key");
+        const DwgTypedClassRow& row = kDwgTypedClassRows[Index];
+        DwgClassDefinition definition;
+        definition.m_classNum = row.classNum;
+        definition.m_proxyFlag = row.proxyFlag;
+        definition.m_appName = row.appName;
+        definition.m_className = row.className;
+        definition.m_recordName = row.recordName;
+        definition.m_entityFlagRaw = row.entityFlagRaw;
+        return registerTypedObjectClass(definition, handle);
     }
 
     bool registerSunObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("Sun", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("Sun")>(handle);
     }
 
     bool registerTvDevicePropertiesObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("TvDeviceProperties", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("TvDeviceProperties")>(handle);
     }
 
     bool registerVxControlObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("VxControl", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("VxControl")>(handle);
     }
 
     bool registerVxTableRecordObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("VxTableRecord", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("VxTableRecord")>(handle);
     }
 
     bool registerMLeaderStyleObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("MLeaderStyle", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("MLeaderStyle")>(handle);
     }
 
     bool registerTableStyleObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("TableStyle", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("TableStyle")>(handle);
     }
 
     bool registerMaterialObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("Material", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("Material")>(handle);
     }
 
     bool registerDbColorObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("DbColor", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("DbColor")>(handle);
     }
 
     bool registerPlotSettingsObjectClass(std::uint32_t handle = 0) {
@@ -960,27 +975,27 @@ public:
     }
 
     bool registerSunStudyObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("SunStudy", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("SunStudy")>(handle);
     }
 
     bool registerMotionPathObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("MotionPath", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("MotionPath")>(handle);
     }
 
     bool registerCurvePathObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("CurvePath", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("CurvePath")>(handle);
     }
 
     bool registerPointPathObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("PointPath", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("PointPath")>(handle);
     }
 
     bool registerPartialViewingIndexObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("PartialViewingIndex", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("PartialViewingIndex")>(handle);
     }
 
     bool registerObjectPtrObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("ObjectPtr", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("ObjectPtr")>(handle);
     }
 
     bool registerRenderSettingsObjectClass(
@@ -1030,23 +1045,23 @@ public:
     }
 
     bool registerVisualStyleObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("VisualStyle", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("VisualStyle")>(handle);
     }
 
     bool registerEvaluationGraphObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("EvaluationGraph", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("EvaluationGraph")>(handle);
     }
 
     bool registerDimensionAssociationObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("DimensionAssociation", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("DimensionAssociation")>(handle);
     }
 
     bool registerRasterVariablesObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("RasterVariables", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("RasterVariables")>(handle);
     }
 
     bool registerWipeoutVariablesObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("WipeoutVariables", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("WipeoutVariables")>(handle);
     }
 
     bool registerWipeoutEntityClass() {
@@ -1107,61 +1122,61 @@ public:
     }
 
     bool registerNavisworksModelDefObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("NavisworksModelDef", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("NavisworksModelDef")>(handle);
     }
 
     bool registerPointCloudColorMapObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("PointCloudColorMap", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("PointCloudColorMap")>(handle);
     }
 
     bool registerGeoDataObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("GeoData", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("GeoData")>(handle);
     }
 
     bool registerSpatialFilterObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("SpatialFilter", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("SpatialFilter")>(handle);
     }
 
     // PR 8d.2a — five small no-storage OBJECTS families.  All are custom-class
     // (≥ 500); recName / className strings follow the dwgreader.cpp dispatch
     // (case-sensitive look-up against classesmap).
     bool registerScaleObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("Scale", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("Scale")>(handle);
     }
 
     bool registerIDBufferObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("IDBuffer", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("IDBuffer")>(handle);
     }
 
     bool registerLayerIndexObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("LayerIndex", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("LayerIndex")>(handle);
     }
 
     bool registerSpatialIndexObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("SpatialIndex", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("SpatialIndex")>(handle);
     }
 
     bool registerDictionaryVarObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("DictionaryVar", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("DictionaryVar")>(handle);
     }
 
     // PR 8d.2b — four larger no-storage OBJECTS families.  Same shape as
     // PR 8d.2a; recName / className strings follow the dwgreader.cpp dispatch
     // (case-sensitive look-up against classesmap).
     bool registerDictionaryWithDefaultObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("DictionaryWithDefault", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("DictionaryWithDefault")>(handle);
     }
 
     bool registerSortEntsTableObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("SortEntsTable", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("SortEntsTable")>(handle);
     }
 
     bool registerFieldListObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("FieldList", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("FieldList")>(handle);
     }
 
     bool registerFieldObjectClass(std::uint32_t handle = 0) {
-        return registerTypedObjectClassRow("Field", handle);
+        return registerTypedObjectClassRow<dwgTypedClassRowIndex("Field")>(handle);
     }
 
     bool registerSectionObjectClass(DRW_Section::Kind kind,

--- a/libraries/libdxfrw/src/intern/dwgwriter.h
+++ b/libraries/libdxfrw/src/intern/dwgwriter.h
@@ -117,7 +117,13 @@ inline constexpr DwgTypedClassRow kDwgTypedClassRows[] = {
     {"ObjectPtr", DRW_ObjectPtr::kDwgClassNum, 0x401, "ObjectDBX Classes", "AcDbObjectPtr", "OBJECT_PTR", 0x1F3},
     {"VisualStyle", DRW_VisualStyle::kDwgClassNum, 0x401, "ObjectDBX Classes", "AcDbVisualStyle", "VISUALSTYLE", 0x1F3},
     {"EvaluationGraph", DRW_EvaluationGraph::kDwgClassNum, 0x481, "ObjectDBX Classes", "AcDbEvalGraph", "ACAD_EVALUATION_GRAPH", 0x1F3},
-    {"DimensionAssociation", DRW_DimensionAssociation::kDwgClassNum, 0, "AcDbDimAssoc|Product Desc: AcDim ARX App For Dimension|" "Company: Autodesk, Inc.|WEB Address: www.autodesk.com", "AcDbDimAssoc", "DIMASSOC", 0x1F3},
+    {"DimensionAssociation", DRW_DimensionAssociation::kDwgClassNum, 0,
+     // The padding inside this app name is what AutoCAD writes; it goes
+     // into the CLASSES section verbatim, so the runs of spaces are
+     // significant and must not be collapsed.
+     "AcDbDimAssoc|Product Desc:     AcDim ARX App For Dimension|"
+     "Company:          Autodesk, Inc.|WEB Address:      www.autodesk.com",
+     "AcDbDimAssoc", "DIMASSOC", 0x1F3},
     {"RasterVariables", DRW_RasterVariables::kDwgClassNum, 0x401, "ISM", "AcDbRasterVariables", "RASTERVARIABLES", 0x1F3},
     {"WipeoutVariables", DRW_WipeoutVariables::kDwgClassNum, 0x401, "WipeOut", "AcDbWipeoutVariables", "WIPEOUTVARIABLES", 0x1F3},
     {"NavisworksModelDef", DRW_NavisworksModelDef::kDwgClassNum, 0x401, "ObjectDBX Classes", "AcDbNavisworksModelDef", "NAVISWORKSMODELDEF", 0x1F3},

--- a/libraries/libdxfrw/src/intern/dwgwriter.h
+++ b/libraries/libdxfrw/src/intern/dwgwriter.h
@@ -135,6 +135,60 @@ inline constexpr DwgTypedClassRow kDwgTypedClassRows[] = {
     {"Field", DRW_Field::kDwgClassNum, 0x401, "ACAD", "AcDbField", "FIELD", 0x1F3},
 };
 
+// The table above is now the single source of truth for those registrars, so
+// the properties they used to hold simply by being written out one at a time
+// are checked here at compile time instead: every row needs a non-empty key,
+// application name, class name and record name, and the key, record name and
+// class name have to be unique. A copy-paste slip in a new row then fails the
+// build instead of silently registering the wrong metadata.
+//
+// Class numbers are deliberately NOT required to be unique. The custom-class
+// range (>= 500) is assigned per file, and several types share a default here
+// - MLEADERSTYLE with MATERIAL at 504, TABLESTYLE with IDBUFFER at 509, and
+// EVALUATION_GRAPH with FIELD at 516. registerTypedObjectClass() resolves a
+// collision by handing the later type the next free number, so the defaults
+// are a starting point rather than an identity.
+constexpr bool dwgClassTextEqual(const char* a, const char* b) {
+    if (a == nullptr || b == nullptr)
+        return a == b;
+    while (*a != '\0' && *a == *b) {
+        ++a;
+        ++b;
+    }
+    return *a == *b;
+}
+
+constexpr bool dwgClassTextNonEmpty(const char* text) {
+    return text != nullptr && *text != '\0';
+}
+
+constexpr bool dwgTypedClassRowsAreWellFormed() {
+    constexpr std::size_t count =
+        sizeof(kDwgTypedClassRows) / sizeof(kDwgTypedClassRows[0]);
+    for (std::size_t i = 0; i < count; ++i) {
+        const DwgTypedClassRow& a = kDwgTypedClassRows[i];
+        if (!dwgClassTextNonEmpty(a.key) || !dwgClassTextNonEmpty(a.appName)
+            || !dwgClassTextNonEmpty(a.className)
+            || !dwgClassTextNonEmpty(a.recordName))
+            return false;
+        for (std::size_t j = i + 1; j < count; ++j) {
+            const DwgTypedClassRow& b = kDwgTypedClassRows[j];
+            if (dwgClassTextEqual(a.key, b.key)
+                || dwgClassTextEqual(a.recordName, b.recordName)
+                || dwgClassTextEqual(a.className, b.className))
+                return false;
+        }
+    }
+    return true;
+}
+
+static_assert(dwgTypedClassRowsAreWellFormed(),
+              "kDwgTypedClassRows: every row needs a non-empty key, app name, "
+              "class name and record name, and the key, record name and class "
+              "name must each be unique across the table (class numbers may "
+              "collide and are remapped at registration)");
+
+
 class dwgWriter {
 public:
     /// Construct around an output stream and a populated header.

--- a/libraries/libdxfrw/src/intern/dwgwriter15.cpp
+++ b/libraries/libdxfrw/src/intern/dwgwriter15.cpp
@@ -1463,8 +1463,15 @@ bool dwgWriter15::getEmittedDwgBlockWriteResult(
     return true;
 }
 
-bool dwgWriter15::emitLtypeRecord(std::uint32_t handle, const DRW_LType& lt) {
-    DRW_LType object = lt;
+// Shared body of the per-type table-record emitters below.  Each of them
+// differs only in the DRW type it copies and the DWG object-type code it
+// stamps into the preamble, so the sequence - copy, prepare common object
+// state, prepare table-entry EED, open the object, write the standard
+// preamble, encode the payload, finish the record - lives here once.
+template <typename T>
+bool dwgWriter15::emitTableRecord(std::uint32_t handle, const T& source,
+                                  std::uint16_t objectType) {
+    T object = source;
     if (!prepareDwgCommonObjectState(object, m_version))
         return false;
     std::vector<DRW_Entity::PendingHandleRef> appIdRefs;
@@ -1473,7 +1480,7 @@ bool dwgWriter15::emitLtypeRecord(std::uint32_t handle, const DRW_LType& lt) {
         return false;
     dwgBufferW& body = beginObject(handle);
     dwgBufferW *sb, *hb;
-    if (!emitRecordPreamble(body, m_version, DRW::DwgLTypeObjectType, handle,
+    if (!emitRecordPreamble(body, m_version, objectType, handle,
                             m_objectStrings, m_objectHandles, sb, hb,
                             object.reactorCount(), object.extensionDictionaryFlag(),
                             object.hasDataStorageBinaryData(), &object.extData,
@@ -1483,6 +1490,10 @@ bool dwgWriter15::emitLtypeRecord(std::uint32_t handle, const DRW_LType& lt) {
         return false;
 
     return finishTableRecord(handle);
+}
+
+bool dwgWriter15::emitLtypeRecord(std::uint32_t handle, const DRW_LType& lt) {
+    return emitTableRecord(handle, lt, DRW::DwgLTypeObjectType);
 }
 
 bool dwgWriter15::emitLayerRecord(std::uint32_t handle, const DRW_Layer& lay) {
@@ -1519,91 +1530,19 @@ bool dwgWriter15::emitLayerRecord(std::uint32_t handle, const DRW_Layer& lay) {
 }
 
 bool dwgWriter15::emitStyleRecord(std::uint32_t handle, const DRW_Textstyle& ts) {
-    DRW_Textstyle object = ts;
-    if (!prepareDwgCommonObjectState(object, m_version))
-        return false;
-    std::vector<DRW_Entity::PendingHandleRef> appIdRefs;
-    std::vector<DRW_Entity::PendingHandleRef> layerRefs;
-    if (!prepareTableEntryEed(object, appIdRefs, layerRefs))
-        return false;
-    dwgBufferW& body = beginObject(handle);
-    dwgBufferW *sb, *hb;
-    if (!emitRecordPreamble(body, m_version, DRW::DwgStyleObjectType, handle,
-                            m_objectStrings, m_objectHandles, sb, hb,
-                            object.reactorCount(), object.extensionDictionaryFlag(),
-                            object.hasDataStorageBinaryData(), &object.extData,
-                            &appIdRefs, &layerRefs, fileCodePageId()))
-        return false;
-    if (!object.encodeDwg(m_version, &body, sb, hb))
-        return false;
-
-    return finishTableRecord(handle);
+    return emitTableRecord(handle, ts, DRW::DwgStyleObjectType);
 }
 
 bool dwgWriter15::emitUcsRecord(std::uint32_t handle, const DRW_UCS& ucs) {
-    DRW_UCS object = ucs;
-    if (!prepareDwgCommonObjectState(object, m_version))
-        return false;
-    std::vector<DRW_Entity::PendingHandleRef> appIdRefs;
-    std::vector<DRW_Entity::PendingHandleRef> layerRefs;
-    if (!prepareTableEntryEed(object, appIdRefs, layerRefs))
-        return false;
-    dwgBufferW& body = beginObject(handle);
-    dwgBufferW *sb, *hb;
-    if (!emitRecordPreamble(body, m_version, DRW::DwgUcsObjectType, handle,
-                            m_objectStrings, m_objectHandles, sb, hb,
-                            object.reactorCount(), object.extensionDictionaryFlag(),
-                            object.hasDataStorageBinaryData(), &object.extData,
-                            &appIdRefs, &layerRefs, fileCodePageId()))
-        return false;
-    if (!object.encodeDwg(m_version, &body, sb, hb))
-        return false;
-
-    return finishTableRecord(handle);
+    return emitTableRecord(handle, ucs, DRW::DwgUcsObjectType);
 }
 
 bool dwgWriter15::emitViewRecord(std::uint32_t handle, const DRW_View& view) {
-    DRW_View object = view;
-    if (!prepareDwgCommonObjectState(object, m_version))
-        return false;
-    std::vector<DRW_Entity::PendingHandleRef> appIdRefs;
-    std::vector<DRW_Entity::PendingHandleRef> layerRefs;
-    if (!prepareTableEntryEed(object, appIdRefs, layerRefs))
-        return false;
-    dwgBufferW& body = beginObject(handle);
-    dwgBufferW *sb, *hb;
-    if (!emitRecordPreamble(body, m_version, DRW::DwgViewObjectType, handle,
-                            m_objectStrings, m_objectHandles, sb, hb,
-                            object.reactorCount(), object.extensionDictionaryFlag(),
-                            object.hasDataStorageBinaryData(), &object.extData,
-                            &appIdRefs, &layerRefs, fileCodePageId()))
-        return false;
-    if (!object.encodeDwg(m_version, &body, sb, hb))
-        return false;
-
-    return finishTableRecord(handle);
+    return emitTableRecord(handle, view, DRW::DwgViewObjectType);
 }
 
 bool dwgWriter15::emitVportRecord(std::uint32_t handle, const DRW_Vport& vp) {
-    DRW_Vport object = vp;
-    if (!prepareDwgCommonObjectState(object, m_version))
-        return false;
-    std::vector<DRW_Entity::PendingHandleRef> appIdRefs;
-    std::vector<DRW_Entity::PendingHandleRef> layerRefs;
-    if (!prepareTableEntryEed(object, appIdRefs, layerRefs))
-        return false;
-    dwgBufferW& body = beginObject(handle);
-    dwgBufferW *sb, *hb;
-    if (!emitRecordPreamble(body, m_version, DRW::DwgVPortObjectType, handle,
-                            m_objectStrings, m_objectHandles, sb, hb,
-                            object.reactorCount(), object.extensionDictionaryFlag(),
-                            object.hasDataStorageBinaryData(), &object.extData,
-                            &appIdRefs, &layerRefs, fileCodePageId()))
-        return false;
-    if (!object.encodeDwg(m_version, &body, sb, hb))
-        return false;
-
-    return finishTableRecord(handle);
+    return emitTableRecord(handle, vp, DRW::DwgVPortObjectType);
 }
 
 bool dwgWriter15::emitViewportEntityHeaderRecord(
@@ -1640,47 +1579,11 @@ bool dwgWriter15::emitViewportEntityHeaderRecord(
 }
 
 bool dwgWriter15::emitAppIdRecord(std::uint32_t handle, const DRW_AppId& ai) {
-    DRW_AppId object = ai;
-    if (!prepareDwgCommonObjectState(object, m_version))
-        return false;
-    std::vector<DRW_Entity::PendingHandleRef> appIdRefs;
-    std::vector<DRW_Entity::PendingHandleRef> layerRefs;
-    if (!prepareTableEntryEed(object, appIdRefs, layerRefs))
-        return false;
-    dwgBufferW& body = beginObject(handle);
-    dwgBufferW *sb, *hb;
-    if (!emitRecordPreamble(body, m_version, DRW::DwgAppIdObjectType, handle,
-                            m_objectStrings, m_objectHandles, sb, hb,
-                            object.reactorCount(), object.extensionDictionaryFlag(),
-                            object.hasDataStorageBinaryData(), &object.extData,
-                            &appIdRefs, &layerRefs, fileCodePageId()))
-        return false;
-    if (!object.encodeDwg(m_version, &body, sb, hb))
-        return false;
-
-    return finishTableRecord(handle);
+    return emitTableRecord(handle, ai, DRW::DwgAppIdObjectType);
 }
 
 bool dwgWriter15::emitDimstyleRecord(std::uint32_t handle, const DRW_Dimstyle& ds) {
-    DRW_Dimstyle object = ds;
-    if (!prepareDwgCommonObjectState(object, m_version))
-        return false;
-    std::vector<DRW_Entity::PendingHandleRef> appIdRefs;
-    std::vector<DRW_Entity::PendingHandleRef> layerRefs;
-    if (!prepareTableEntryEed(object, appIdRefs, layerRefs))
-        return false;
-    dwgBufferW& body = beginObject(handle);
-    dwgBufferW *sb, *hb;
-    if (!emitRecordPreamble(body, m_version, DRW::DwgDimStyleObjectType, handle,
-                            m_objectStrings, m_objectHandles, sb, hb,
-                            object.reactorCount(), object.extensionDictionaryFlag(),
-                            object.hasDataStorageBinaryData(), &object.extData,
-                            &appIdRefs, &layerRefs, fileCodePageId()))
-        return false;
-    if (!object.encodeDwg(m_version, &body, sb, hb))
-        return false;
-
-    return finishTableRecord(handle);
+    return emitTableRecord(handle, ds, DRW::DwgDimStyleObjectType);
 }
 
 bool dwgWriter15::emitAcDbPlaceholderObject(

--- a/libraries/libdxfrw/src/intern/dwgwriter15.cpp
+++ b/libraries/libdxfrw/src/intern/dwgwriter15.cpp
@@ -2109,11 +2109,27 @@ bool dwgWriter15::emitMLeaderStyleObject(std::uint32_t handle,
     return !objectWriteFailed();
 }
 
-bool dwgWriter15::writeMLeaderStyle(const DRW_MLeaderStyle& style) {
-    if (m_version < DRW::AC1015)
+// Shared body of the typed OBJECT writers below.  Each differs only in the DRW
+// payload type, the minimum file version it supports and which register/emit
+// pair it drives; the sequence - version gate, copy, prepare common object
+// state, prepare table-entry EED (recording an EED failure so a caller can
+// tell it apart from a plain refusal), mint or reserve the handle, register
+// the class, emit the object - is identical.
+//
+// Writers whose gate inspects more than the version, or that keep extra state,
+// keep their own bodies.
+template <typename T>
+bool dwgWriter15::writeTypedObject(
+    const T& source, DRW::Version minVersion,
+    bool (dwgWriter::*registerClass)(std::uint32_t),
+    bool (dwgWriter15::*emitObject)(
+        std::uint32_t, const T&,
+        const std::vector<DRW_Entity::PendingHandleRef>&,
+        const std::vector<DRW_Entity::PendingHandleRef>&)) {
+    if (m_version < minVersion)
         return false;
 
-    DRW_MLeaderStyle object = style;
+    T object = source;
     if (!prepareDwgCommonObjectState(object, m_version))
         return false;
     std::vector<DRW_Entity::PendingHandleRef> appIdRefs;
@@ -2127,14 +2143,20 @@ bool dwgWriter15::writeMLeaderStyle(const DRW_MLeaderStyle& style) {
     } else {
         m_handles.reserve(object.handle);
     }
-    if (!registerMLeaderStyleObjectClass(object.handle))
+    if (!(this->*registerClass)(object.handle))
         return false;
 
-    if (!emitMLeaderStyleObject(object.handle, object, appIdRefs, layerRefs)) {
+    if (!(this->*emitObject)(object.handle, object, appIdRefs, layerRefs)) {
         m_objectEedWriteFailure = !object.extData.empty();
         return false;
     }
     return true;
+}
+
+bool dwgWriter15::writeMLeaderStyle(const DRW_MLeaderStyle& style) {
+    return writeTypedObject(style, DRW::AC1015,
+                            &dwgWriter::registerMLeaderStyleObjectClass,
+                            &dwgWriter15::emitMLeaderStyleObject);
 }
 
 bool dwgWriter15::emitTableStyleObject(std::uint32_t handle,
@@ -3115,35 +3137,13 @@ bool dwgWriter15::emitScaleObject(
     return !objectWriteFailed();
 }
 
-bool dwgWriter15::writeScale(const DRW_Scale& scale) {
     // PR 13g — broaden gate from AC1021+ to AC1015+.  Encoder is
     // version-clean (body-only emit; common handle prefix written by
     // emitScaleObject itself).
-    if (m_version < DRW::AC1015)
-        return false;
-
-    DRW_Scale object = scale;
-    if (!prepareDwgCommonObjectState(object, m_version))
-        return false;
-    std::vector<DRW_Entity::PendingHandleRef> appIdRefs;
-    std::vector<DRW_Entity::PendingHandleRef> layerRefs;
-    if (!prepareTableEntryEed(object, appIdRefs, layerRefs)) {
-        m_objectEedWriteFailure = !object.extData.empty();
-        return false;
-    }
-    if (object.handle == 0) {
-        object.handle = m_handles.next();
-    } else {
-        m_handles.reserve(object.handle);
-    }
-    if (!registerScaleObjectClass(object.handle))
-        return false;
-
-    if (!emitScaleObject(object.handle, object, appIdRefs, layerRefs)) {
-        m_objectEedWriteFailure = !object.extData.empty();
-        return false;
-    }
-    return true;
+bool dwgWriter15::writeScale(const DRW_Scale& scale) {
+    return writeTypedObject(scale, DRW::AC1015,
+                            &dwgWriter::registerScaleObjectClass,
+                            &dwgWriter15::emitScaleObject);
 }
 
 // IDBUFFER (AcDbIdBuffer, custom class 509) — class registration required.
@@ -3173,35 +3173,13 @@ bool dwgWriter15::emitIDBufferObject(
     return !objectWriteFailed();
 }
 
-bool dwgWriter15::writeIDBuffer(const DRW_IDBuffer& idBuffer) {
     // PR 13g — broaden gate from AC1021+ to AC1015+.  Encoder is
     // version-clean (only the standard hb = version > AC1018 split-buffer
     // routing).
-    if (m_version < DRW::AC1015)
-        return false;
-
-    DRW_IDBuffer object = idBuffer;
-    if (!prepareDwgCommonObjectState(object, m_version))
-        return false;
-    std::vector<DRW_Entity::PendingHandleRef> appIdRefs;
-    std::vector<DRW_Entity::PendingHandleRef> layerRefs;
-    if (!prepareTableEntryEed(object, appIdRefs, layerRefs)) {
-        m_objectEedWriteFailure = !object.extData.empty();
-        return false;
-    }
-    if (object.handle == 0) {
-        object.handle = m_handles.next();
-    } else {
-        m_handles.reserve(object.handle);
-    }
-    if (!registerIDBufferObjectClass(object.handle))
-        return false;
-
-    if (!emitIDBufferObject(object.handle, object, appIdRefs, layerRefs)) {
-        m_objectEedWriteFailure = !object.extData.empty();
-        return false;
-    }
-    return true;
+bool dwgWriter15::writeIDBuffer(const DRW_IDBuffer& idBuffer) {
+    return writeTypedObject(idBuffer, DRW::AC1015,
+                            &dwgWriter::registerIDBufferObjectClass,
+                            &dwgWriter15::emitIDBufferObject);
 }
 
 // LAYER_INDEX (AcDbLayerIndex, custom class 510) — class registration
@@ -3231,35 +3209,13 @@ bool dwgWriter15::emitLayerIndexObject(
     return !objectWriteFailed();
 }
 
-bool dwgWriter15::writeLayerIndex(const DRW_LayerIndex& layerIndex) {
     // PR 13g — broaden gate from AC1021+ to AC1015+.  Encoder is
     // version-clean (only the standard sb/hb = version > AC1018 split-
     // buffer routing).
-    if (m_version < DRW::AC1015)
-        return false;
-
-    DRW_LayerIndex object = layerIndex;
-    if (!prepareDwgCommonObjectState(object, m_version))
-        return false;
-    std::vector<DRW_Entity::PendingHandleRef> appIdRefs;
-    std::vector<DRW_Entity::PendingHandleRef> layerRefs;
-    if (!prepareTableEntryEed(object, appIdRefs, layerRefs)) {
-        m_objectEedWriteFailure = !object.extData.empty();
-        return false;
-    }
-    if (object.handle == 0) {
-        object.handle = m_handles.next();
-    } else {
-        m_handles.reserve(object.handle);
-    }
-    if (!registerLayerIndexObjectClass(object.handle))
-        return false;
-
-    if (!emitLayerIndexObject(object.handle, object, appIdRefs, layerRefs)) {
-        m_objectEedWriteFailure = !object.extData.empty();
-        return false;
-    }
-    return true;
+bool dwgWriter15::writeLayerIndex(const DRW_LayerIndex& layerIndex) {
+    return writeTypedObject(layerIndex, DRW::AC1015,
+                            &dwgWriter::registerLayerIndexObjectClass,
+                            &dwgWriter15::emitLayerIndexObject);
 }
 
 // SPATIAL_INDEX (AcDbSpatialIndex, custom class 511) — class registration
@@ -3290,36 +3246,14 @@ bool dwgWriter15::emitSpatialIndexObject(
     return !objectWriteFailed();
 }
 
-bool dwgWriter15::writeSpatialIndex(const DRW_SpatialIndex& spatialIndex) {
     // PR 13g — broaden gate from AC1021+ to AC1015+.  Encoder gates the
     // common handle prefix on `version > AC1018` (parser does the same),
     // so at AC1015/AC1018 the wrapper emits an opaque body and no handle
     // tail — matching the parser's expectation.
-    if (m_version < DRW::AC1015)
-        return false;
-
-    DRW_SpatialIndex object = spatialIndex;
-    if (!prepareDwgCommonObjectState(object, m_version))
-        return false;
-    std::vector<DRW_Entity::PendingHandleRef> appIdRefs;
-    std::vector<DRW_Entity::PendingHandleRef> layerRefs;
-    if (!prepareTableEntryEed(object, appIdRefs, layerRefs)) {
-        m_objectEedWriteFailure = !object.extData.empty();
-        return false;
-    }
-    if (object.handle == 0) {
-        object.handle = m_handles.next();
-    } else {
-        m_handles.reserve(object.handle);
-    }
-    if (!registerSpatialIndexObjectClass(object.handle))
-        return false;
-
-    if (!emitSpatialIndexObject(object.handle, object, appIdRefs, layerRefs)) {
-        m_objectEedWriteFailure = !object.extData.empty();
-        return false;
-    }
-    return true;
+bool dwgWriter15::writeSpatialIndex(const DRW_SpatialIndex& spatialIndex) {
+    return writeTypedObject(spatialIndex, DRW::AC1015,
+                            &dwgWriter::registerSpatialIndexObjectClass,
+                            &dwgWriter15::emitSpatialIndexObject);
 }
 
 // DICTIONARYVAR (AcDbDictionaryVar, custom class 512) — class registration
@@ -3350,35 +3284,13 @@ bool dwgWriter15::emitDictionaryVarObject(
     return !objectWriteFailed();
 }
 
-bool dwgWriter15::writeDictionaryVar(const DRW_DictionaryVar& dictionaryVar) {
     // PR 13g — broaden gate from AC1021+ to AC1015+.  Encoder is
     // version-clean (only the standard sb/hb = version > AC1018 split-
     // buffer routing).
-    if (m_version < DRW::AC1015)
-        return false;
-
-    DRW_DictionaryVar object = dictionaryVar;
-    if (!prepareDwgCommonObjectState(object, m_version))
-        return false;
-    std::vector<DRW_Entity::PendingHandleRef> appIdRefs;
-    std::vector<DRW_Entity::PendingHandleRef> layerRefs;
-    if (!prepareTableEntryEed(object, appIdRefs, layerRefs)) {
-        m_objectEedWriteFailure = !object.extData.empty();
-        return false;
-    }
-    if (object.handle == 0) {
-        object.handle = m_handles.next();
-    } else {
-        m_handles.reserve(object.handle);
-    }
-    if (!registerDictionaryVarObjectClass(object.handle))
-        return false;
-
-    if (!emitDictionaryVarObject(object.handle, object, appIdRefs, layerRefs)) {
-        m_objectEedWriteFailure = !object.extData.empty();
-        return false;
-    }
-    return true;
+bool dwgWriter15::writeDictionaryVar(const DRW_DictionaryVar& dictionaryVar) {
+    return writeTypedObject(dictionaryVar, DRW::AC1015,
+                            &dwgWriter::registerDictionaryVarObjectClass,
+                            &dwgWriter15::emitDictionaryVarObject);
 }
 
 // DICTIONARYWDFLT (AcDbDictionaryWithDefault, custom class 513) — class
@@ -3473,36 +3385,14 @@ bool dwgWriter15::emitSortEntsTableObject(
     return !objectWriteFailed();
 }
 
-bool dwgWriter15::writeSortEntsTable(const DRW_SortEntsTable& sortEntsTable) {
     // PR 13h — broaden gate from AC1021+ to AC1015+.  Encoder is
     // version-clean (inline sort handles in body, then standard hb =
     // version > AC1018 split-buffer routing for the common prefix +
     // block-owner + entity handles).
-    if (m_version < DRW::AC1015)
-        return false;
-
-    DRW_SortEntsTable object = sortEntsTable;
-    if (!prepareDwgCommonObjectState(object, m_version))
-        return false;
-    std::vector<DRW_Entity::PendingHandleRef> appIdRefs;
-    std::vector<DRW_Entity::PendingHandleRef> layerRefs;
-    if (!prepareTableEntryEed(object, appIdRefs, layerRefs)) {
-        m_objectEedWriteFailure = !object.extData.empty();
-        return false;
-    }
-    if (object.handle == 0) {
-        object.handle = m_handles.next();
-    } else {
-        m_handles.reserve(object.handle);
-    }
-    if (!registerSortEntsTableObjectClass(object.handle))
-        return false;
-
-    if (!emitSortEntsTableObject(object.handle, object, appIdRefs, layerRefs)) {
-        m_objectEedWriteFailure = !object.extData.empty();
-        return false;
-    }
-    return true;
+bool dwgWriter15::writeSortEntsTable(const DRW_SortEntsTable& sortEntsTable) {
+    return writeTypedObject(sortEntsTable, DRW::AC1015,
+                            &dwgWriter::registerSortEntsTableObjectClass,
+                            &dwgWriter15::emitSortEntsTableObject);
 }
 
 // FIELDLIST (AcDbFieldList, custom class 515) — class registration
@@ -3533,35 +3423,13 @@ bool dwgWriter15::emitFieldListObject(std::uint32_t handle,
     return !objectWriteFailed();
 }
 
-bool dwgWriter15::writeFieldList(const DRW_FieldList& fieldList) {
     // PR 13h — broaden gate from AC1021+ to AC1015+.  Encoder is
     // version-clean (no strings; only the standard hb = version > AC1018
     // split-buffer routing).
-    if (m_version < DRW::AC1015)
-        return false;
-
-    DRW_FieldList object = fieldList;
-    if (!prepareDwgCommonObjectState(object, m_version))
-        return false;
-    std::vector<DRW_Entity::PendingHandleRef> appIdRefs;
-    std::vector<DRW_Entity::PendingHandleRef> layerRefs;
-    if (!prepareTableEntryEed(object, appIdRefs, layerRefs)) {
-        m_objectEedWriteFailure = !object.extData.empty();
-        return false;
-    }
-    if (object.handle == 0) {
-        object.handle = m_handles.next();
-    } else {
-        m_handles.reserve(object.handle);
-    }
-    if (!registerFieldListObjectClass(object.handle))
-        return false;
-
-    if (!emitFieldListObject(object.handle, object, appIdRefs, layerRefs)) {
-        m_objectEedWriteFailure = !object.extData.empty();
-        return false;
-    }
-    return true;
+bool dwgWriter15::writeFieldList(const DRW_FieldList& fieldList) {
+    return writeTypedObject(fieldList, DRW::AC1015,
+                            &dwgWriter::registerFieldListObjectClass,
+                            &dwgWriter15::emitFieldListObject);
 }
 
 // FIELD (AcDbField, custom class 516) — class registration required.
@@ -3591,37 +3459,15 @@ bool dwgWriter15::emitFieldObject(
     return !objectWriteFailed();
 }
 
-bool dwgWriter15::writeField(const DRW_Field& field) {
     // PR 13h — broaden gate from AC1021+ to AC1015+.  Encoder has a
     // `version < AC1021` branch for m_formatString, mirrored in the
     // parser, so the pre-R2007 path is exercised; nested CadValue /
     // child values go through writeCadValue/readCadValue (also
     // version-clean).
-    if (m_version < DRW::AC1015)
-        return false;
-
-    DRW_Field object = field;
-    if (!prepareDwgCommonObjectState(object, m_version))
-        return false;
-    std::vector<DRW_Entity::PendingHandleRef> appIdRefs;
-    std::vector<DRW_Entity::PendingHandleRef> layerRefs;
-    if (!prepareTableEntryEed(object, appIdRefs, layerRefs)) {
-        m_objectEedWriteFailure = !object.extData.empty();
-        return false;
-    }
-    if (object.handle == 0) {
-        object.handle = m_handles.next();
-    } else {
-        m_handles.reserve(object.handle);
-    }
-    if (!registerFieldObjectClass(object.handle))
-        return false;
-
-    if (!emitFieldObject(object.handle, object, appIdRefs, layerRefs)) {
-        m_objectEedWriteFailure = !object.extData.empty();
-        return false;
-    }
-    return true;
+bool dwgWriter15::writeField(const DRW_Field& field) {
+    return writeTypedObject(field, DRW::AC1015,
+                            &dwgWriter::registerFieldObjectClass,
+                            &dwgWriter15::emitFieldObject);
 }
 
 bool dwgWriter15::emitUnderlayDefinitionObject(

--- a/libraries/libdxfrw/src/intern/dwgwriter15.h
+++ b/libraries/libdxfrw/src/intern/dwgwriter15.h
@@ -265,6 +265,15 @@ protected:
                          bool isEnd);
 
     /// Full table-record emitters — preamble + encodeDwg + finishObject.
+    /// Shared body of the table-record emitters: copy the record, prepare
+    /// common object state and table-entry EED, then wrap the type's own
+    /// encodeDwg() in the standard record preamble.  Only the DRW type and
+    /// the DWG object-type code differ between the emitters below, so each
+    /// of them is a single call into this.
+    template <typename T>
+    bool emitTableRecord(std::uint32_t handle, const T& source,
+                         std::uint16_t objectType);
+
     bool emitLtypeRecord(std::uint32_t handle, const DRW_LType& lt);
     bool emitLayerRecord(std::uint32_t handle, const DRW_Layer& lay);
     bool emitStyleRecord(std::uint32_t handle, const DRW_Textstyle& ts);

--- a/libraries/libdxfrw/src/intern/dwgwriter15.h
+++ b/libraries/libdxfrw/src/intern/dwgwriter15.h
@@ -274,6 +274,19 @@ protected:
     bool emitTableRecord(std::uint32_t handle, const T& source,
                          std::uint16_t objectType);
 
+    /// Shared body of the typed OBJECT writers: version gate, copy, prepare
+    /// common object state and table-entry EED, mint or reserve the handle,
+    /// register the class and emit the object.  Only the payload type, the
+    /// minimum version and the register/emit pair differ between them.
+    template <typename T>
+    bool writeTypedObject(
+        const T& source, DRW::Version minVersion,
+        bool (dwgWriter::*registerClass)(std::uint32_t),
+        bool (dwgWriter15::*emitObject)(
+            std::uint32_t, const T&,
+            const std::vector<DRW_Entity::PendingHandleRef>&,
+            const std::vector<DRW_Entity::PendingHandleRef>&));
+
     bool emitLtypeRecord(std::uint32_t handle, const DRW_LType& lt);
     bool emitLayerRecord(std::uint32_t handle, const DRW_Layer& lay);
     bool emitStyleRecord(std::uint32_t handle, const DRW_Textstyle& ts);

--- a/libraries/libdxfrw/src/intern/dwgwriter15.h
+++ b/libraries/libdxfrw/src/intern/dwgwriter15.h
@@ -269,7 +269,9 @@ protected:
     /// common object state and table-entry EED, then wrap the type's own
     /// encodeDwg() in the standard record preamble.  Only the DRW type and
     /// the DWG object-type code differ between the emitters below, so each
-    /// of them is a single call into this.
+    /// of them is a single call into this.  Defined in dwgwriter15.cpp and
+    /// instantiated only there, so a derived writer in another translation
+    /// unit cannot call it without moving the definition here first.
     template <typename T>
     bool emitTableRecord(std::uint32_t handle, const T& source,
                          std::uint16_t objectType);
@@ -278,6 +280,9 @@ protected:
     /// common object state and table-entry EED, mint or reserve the handle,
     /// register the class and emit the object.  Only the payload type, the
     /// minimum version and the register/emit pair differ between them.
+    /// Defined in dwgwriter15.cpp and instantiated only there, so a derived
+    /// writer in another translation unit cannot call it without moving the
+    /// definition here first.
     template <typename T>
     bool writeTypedObject(
         const T& source, DRW::Version minVersion,

--- a/libraries/libdxfrw/src/intern/dxfreader.h
+++ b/libraries/libdxfrw/src/intern/dxfreader.h
@@ -141,15 +141,17 @@ public:
 };
 
 
-/// Read one group code of a UCS triplet - origin, X axis and Y axis - into the
-/// three coordinates that carry it.  DXF spells this the same way wherever a
-/// record stores a UCS (VPORT, VIEW and VIEWPORT all do), so the nine cases
-/// live here once instead of being repeated per record.
+/// Read one group code of a coordinate triplet - an origin plus an X and a Y
+/// axis - into the three coordinates that carry it.  DXF spells this the same
+/// way wherever a record stores such a frame: VPORT, VIEW and VIEWPORT use it
+/// for their UCS, and MLEADER's context data for its content base point and
+/// base direction/vertical.  The nine cases live here once instead of being
+/// repeated per record.
 ///
 /// Returns true when the code belonged to the triplet and was consumed.
-inline bool readUcsTripletCode(int code, const std::unique_ptr<dxfReader>& reader,
-                               DRW_Coord& origin, DRW_Coord& xAxis,
-                               DRW_Coord& yAxis) {
+inline bool readCoordTripletCode(int code, const std::unique_ptr<dxfReader>& reader,
+                                 DRW_Coord& origin, DRW_Coord& xAxis,
+                                 DRW_Coord& yAxis) {
     switch (code) {
     case 110: origin.x = reader->getDouble(); return true;
     case 120: origin.y = reader->getDouble(); return true;

--- a/libraries/libdxfrw/src/intern/dxfreader.h
+++ b/libraries/libdxfrw/src/intern/dxfreader.h
@@ -140,4 +140,28 @@ public:
     virtual bool readBool();
 };
 
+
+/// Read one group code of a UCS triplet - origin, X axis and Y axis - into the
+/// three coordinates that carry it.  DXF spells this the same way wherever a
+/// record stores a UCS (VPORT, VIEW and VIEWPORT all do), so the nine cases
+/// live here once instead of being repeated per record.
+///
+/// Returns true when the code belonged to the triplet and was consumed.
+inline bool readUcsTripletCode(int code, const std::unique_ptr<dxfReader>& reader,
+                               DRW_Coord& origin, DRW_Coord& xAxis,
+                               DRW_Coord& yAxis) {
+    switch (code) {
+    case 110: origin.x = reader->getDouble(); return true;
+    case 120: origin.y = reader->getDouble(); return true;
+    case 130: origin.z = reader->getDouble(); return true;
+    case 111: xAxis.x = reader->getDouble(); return true;
+    case 121: xAxis.y = reader->getDouble(); return true;
+    case 131: xAxis.z = reader->getDouble(); return true;
+    case 112: yAxis.x = reader->getDouble(); return true;
+    case 122: yAxis.y = reader->getDouble(); return true;
+    case 132: yAxis.z = reader->getDouble(); return true;
+    default: return false;
+    }
+}
+
 #endif // DXFREADER_H

--- a/libraries/libdxfrw/src/libdxfrw.cpp
+++ b/libraries/libdxfrw/src/libdxfrw.cpp
@@ -11337,17 +11337,28 @@ bool dxfRW::processMaterial() {
 
 // DBCOLOR (AcDbColor): structured color/book fields plus raw-net preservation
 // for any producer-specific groups not represented by DRW_DbColor.
-bool dxfRW::processDbColor() {
-    DRW_DBG("dxfRW::processDbColor");
+// Shared body of the raw-capture object readers below.  Each of them differs
+// only in the DRW payload type, the debug label and which DRW_Interface
+// callback receives the decoded object, so the loop - capture every group into
+// a DRW_RawDxfObject for lossless re-emit, parse it into the typed payload,
+// and hand both to the interface at the object boundary - lives here once.
+//
+// The callback is passed in rather than deduced because a few readers take the
+// payload by pointer.  Readers that do more than this (a kind dispatch before
+// the loop, a finalize step or extra validation at the boundary) keep their
+// own bodies.
+template <typename T, typename AddFn>
+bool dxfRW::processRawCapturedObject(const char* debugName, AddFn addTyped) {
+    DRW_DBG(debugName);
     int code;
-    DRW_DbColor data;
+    T data;
     DRW_RawDxfObject raw;
     raw.name = nextentity;
     while (reader->readRec(&code)) {
         if (code == 0) {
             if (!acceptObjectBoundary(code))
                 return setError(DRW::BAD_READ_OBJECTS);
-            iface->addDbColor(data);
+            addTyped(data);
             iface->addRawDxfObject(raw);
             return true;
         }
@@ -11355,6 +11366,11 @@ bool dxfRW::processDbColor() {
             return setError(DRW::BAD_CODE_PARSED);
     }
     return setError(DRW::BAD_READ_OBJECTS);
+}
+
+bool dxfRW::processDbColor() {
+    return processRawCapturedObject<DRW_DbColor>(
+        "dxfRW::processDbColor", [this](DRW_DbColor& data) { iface->addDbColor(data); });
 }
 
 // GEODATA (AcDbGeoData): structured DXF read of the scalar geolocation fields,
@@ -11410,89 +11426,29 @@ bool dxfRW::processVisualStyle() {
 // IMAGEDEF_REACTOR (AcDbRasterImageDefReactor): structured DXF read of the
 // class-version field + raw-net preservation for lossless DXF re-emit.
 bool dxfRW::processImageDefReactor() {
-    DRW_DBG("dxfRW::processImageDefReactor");
-    int code;
-    DRW_ImageDefinitionReactor data;
-    DRW_RawDxfObject raw;
-    raw.name = nextentity;
-    while (reader->readRec(&code)) {
-        if (code == 0) {
-            if (!acceptObjectBoundary(code))
-                return setError(DRW::BAD_READ_OBJECTS);
-            iface->addImageDefinitionReactor(data);
-            iface->addRawDxfObject(raw);
-            return true;
-        }
-        if (!captureAndParseRawDxfGroup(raw, code, data))
-            return setError(DRW::BAD_CODE_PARSED);
-    }
-    return setError(DRW::BAD_READ_OBJECTS);
+    return processRawCapturedObject<DRW_ImageDefinitionReactor>(
+        "dxfRW::processImageDefReactor", [this](DRW_ImageDefinitionReactor& data) { iface->addImageDefinitionReactor(data); });
 }
 
 // SPATIAL_FILTER (AcDbSpatialFilter): structured DXF read of the clip boundary +
 // planes + raw-net preservation.
 bool dxfRW::processSpatialFilter() {
-    DRW_DBG("dxfRW::processSpatialFilter");
-    int code;
-    DRW_SpatialFilter data;
-    DRW_RawDxfObject raw;
-    raw.name = nextentity;
-    while (reader->readRec(&code)) {
-        if (code == 0) {
-            if (!acceptObjectBoundary(code))
-                return setError(DRW::BAD_READ_OBJECTS);
-            iface->addSpatialFilter(data);
-            iface->addRawDxfObject(raw);
-            return true;
-        }
-        if (!captureAndParseRawDxfGroup(raw, code, data))
-            return setError(DRW::BAD_CODE_PARSED);
-    }
-    return setError(DRW::BAD_READ_OBJECTS);
+    return processRawCapturedObject<DRW_SpatialFilter>(
+        "dxfRW::processSpatialFilter", [this](DRW_SpatialFilter& data) { iface->addSpatialFilter(data); });
 }
 
 // TABLESTYLE (AcDbTableStyle): structured DXF read of the top-level fields +
 // raw-net preservation (nested row/cell styles round-tripped raw only).
 bool dxfRW::processTableStyle() {
-    DRW_DBG("dxfRW::processTableStyle");
-    int code;
-    DRW_TableStyle data;
-    DRW_RawDxfObject raw;
-    raw.name = nextentity;
-    while (reader->readRec(&code)) {
-        if (code == 0) {
-            if (!acceptObjectBoundary(code))
-                return setError(DRW::BAD_READ_OBJECTS);
-            iface->addTableStyle(data);
-            iface->addRawDxfObject(raw);
-            return true;
-        }
-        if (!captureAndParseRawDxfGroup(raw, code, data))
-            return setError(DRW::BAD_CODE_PARSED);
-    }
-    return setError(DRW::BAD_READ_OBJECTS);
+    return processRawCapturedObject<DRW_TableStyle>(
+        "dxfRW::processTableStyle", [this](DRW_TableStyle& data) { iface->addTableStyle(data); });
 }
 
 // MLEADERSTYLE (AcDbMLeaderStyle): structured DXF read of the full scalar record
 // + raw-net preservation.  Delivered via addMLeaderStyle (pointer callback).
 bool dxfRW::processMLeaderStyle() {
-    DRW_DBG("dxfRW::processMLeaderStyle");
-    int code;
-    DRW_MLeaderStyle data;
-    DRW_RawDxfObject raw;
-    raw.name = nextentity;
-    while (reader->readRec(&code)) {
-        if (code == 0) {
-            if (!acceptObjectBoundary(code))
-                return setError(DRW::BAD_READ_OBJECTS);
-            iface->addMLeaderStyle(&data);
-            iface->addRawDxfObject(raw);
-            return true;
-        }
-        if (!captureAndParseRawDxfGroup(raw, code, data))
-            return setError(DRW::BAD_CODE_PARSED);
-    }
-    return setError(DRW::BAD_READ_OBJECTS);
+    return processRawCapturedObject<DRW_MLeaderStyle>(
+        "dxfRW::processMLeaderStyle", [this](DRW_MLeaderStyle& data) { iface->addMLeaderStyle(&data); });
 }
 
 // SORTENTSTABLE (AcDbSortentsTable): structured DXF read of the draw-order map
@@ -11522,23 +11478,8 @@ bool dxfRW::processSortEntsTable() {
 // DIMASSOC (AcDbDimAssoc): structured DXF read of the associative-dimension
 // metadata (dimension handle, flags, osnap refs) + raw-net preservation.
 bool dxfRW::processDimAssoc() {
-    DRW_DBG("dxfRW::processDimAssoc");
-    int code;
-    DRW_DimensionAssociation data;
-    DRW_RawDxfObject raw;
-    raw.name = nextentity;
-    while (reader->readRec(&code)) {
-        if (code == 0) {
-            if (!acceptObjectBoundary(code))
-                return setError(DRW::BAD_READ_OBJECTS);
-            iface->addDimensionAssociation(data);
-            iface->addRawDxfObject(raw);
-            return true;
-        }
-        if (!captureAndParseRawDxfGroup(raw, code, data))
-            return setError(DRW::BAD_CODE_PARSED);
-    }
-    return setError(DRW::BAD_READ_OBJECTS);
+    return processRawCapturedObject<DRW_DimensionAssociation>(
+        "dxfRW::processDimAssoc", [this](DRW_DimensionAssociation& data) { iface->addDimensionAssociation(data); });
 }
 
 // EVALUATION_GRAPH (AcDbEvalGraph): preserve the repeated node/edge payload in
@@ -11645,23 +11586,8 @@ bool dxfRW::processPointCloudDef() {
 }
 
 bool dxfRW::processNavisworksModelDef() {
-    DRW_DBG("dxfRW::processNavisworksModelDef");
-    int code;
-    DRW_NavisworksModelDef data;
-    DRW_RawDxfObject raw;
-    raw.name = nextentity;
-    while (reader->readRec(&code)) {
-        if (code == 0) {
-            if (!acceptObjectBoundary(code))
-                return setError(DRW::BAD_READ_OBJECTS);
-            iface->addNavisworksModelDef(data);
-            iface->addRawDxfObject(raw);
-            return true;
-        }
-        if (!captureAndParseRawDxfGroup(raw, code, data))
-            return setError(DRW::BAD_CODE_PARSED);
-    }
-    return setError(DRW::BAD_READ_OBJECTS);
+    return processRawCapturedObject<DRW_NavisworksModelDef>(
+        "dxfRW::processNavisworksModelDef", [this](DRW_NavisworksModelDef& data) { iface->addNavisworksModelDef(data); });
 }
 
 bool dxfRW::processPointCloudColorMap() {
@@ -11691,106 +11617,31 @@ bool dxfRW::processPointCloudColorMap() {
 // SUNSTUDY (AcDbSunStudy): structured DXF read of the scalar study config +
 // raw-net preservation (date/hour lists left raw).
 bool dxfRW::processSunStudy() {
-    DRW_DBG("dxfRW::processSunStudy");
-    int code;
-    DRW_SunStudy data;
-    DRW_RawDxfObject raw;
-    raw.name = nextentity;
-    while (reader->readRec(&code)) {
-        if (code == 0) {
-            if (!acceptObjectBoundary(code))
-                return setError(DRW::BAD_READ_OBJECTS);
-            iface->addSunStudy(data);
-            iface->addRawDxfObject(raw);
-            return true;
-        }
-        if (!captureAndParseRawDxfGroup(raw, code, data))
-            return setError(DRW::BAD_CODE_PARSED);
-    }
-    return setError(DRW::BAD_READ_OBJECTS);
+    return processRawCapturedObject<DRW_SunStudy>(
+        "dxfRW::processSunStudy", [this](DRW_SunStudy& data) { iface->addSunStudy(data); });
 }
 
 // MOTIONPATH (AcDbMotionPath): positional DXF fields plus raw-net
 // preservation.  The record name is accepted in both forms emitted by
 // current producers.
 bool dxfRW::processMotionPath() {
-    DRW_DBG("dxfRW::processMotionPath");
-    int code;
-    DRW_MotionPath data;
-    DRW_RawDxfObject raw;
-    raw.name = nextentity;
-    while (reader->readRec(&code)) {
-        if (code == 0) {
-            if (!acceptObjectBoundary(code))
-                return setError(DRW::BAD_READ_OBJECTS);
-            iface->addMotionPath(data);
-            iface->addRawDxfObject(raw);
-            return true;
-        }
-        if (!captureAndParseRawDxfGroup(raw, code, data))
-            return setError(DRW::BAD_CODE_PARSED);
-    }
-    return setError(DRW::BAD_READ_OBJECTS);
+    return processRawCapturedObject<DRW_MotionPath>(
+        "dxfRW::processMotionPath", [this](DRW_MotionPath& data) { iface->addMotionPath(data); });
 }
 
 bool dxfRW::processCurvePath() {
-    DRW_DBG("dxfRW::processCurvePath");
-    int code;
-    DRW_CurvePath data;
-    DRW_RawDxfObject raw;
-    raw.name = nextentity;
-    while (reader->readRec(&code)) {
-        if (code == 0) {
-            if (!acceptObjectBoundary(code))
-                return setError(DRW::BAD_READ_OBJECTS);
-            iface->addCurvePath(data);
-            iface->addRawDxfObject(raw);
-            return true;
-        }
-        if (!captureAndParseRawDxfGroup(raw, code, data))
-            return setError(DRW::BAD_CODE_PARSED);
-    }
-    return setError(DRW::BAD_READ_OBJECTS);
+    return processRawCapturedObject<DRW_CurvePath>(
+        "dxfRW::processCurvePath", [this](DRW_CurvePath& data) { iface->addCurvePath(data); });
 }
 
 bool dxfRW::processPointPath() {
-    DRW_DBG("dxfRW::processPointPath");
-    int code;
-    DRW_PointPath data;
-    DRW_RawDxfObject raw;
-    raw.name = nextentity;
-    while (reader->readRec(&code)) {
-        if (code == 0) {
-            if (!acceptObjectBoundary(code))
-                return setError(DRW::BAD_READ_OBJECTS);
-            iface->addPointPath(data);
-            iface->addRawDxfObject(raw);
-            return true;
-        }
-        if (!captureAndParseRawDxfGroup(raw, code, data))
-            return setError(DRW::BAD_CODE_PARSED);
-    }
-    return setError(DRW::BAD_READ_OBJECTS);
+    return processRawCapturedObject<DRW_PointPath>(
+        "dxfRW::processPointPath", [this](DRW_PointPath& data) { iface->addPointPath(data); });
 }
 
 bool dxfRW::processObjectPtr() {
-    DRW_DBG("dxfRW::processObjectPtr");
-    int code;
-    DRW_ObjectPtr data;
-    DRW_RawDxfObject raw;
-    raw.name = nextentity;
-    while (reader->readRec(&code)) {
-        if (code == 0) {
-            if (!acceptObjectBoundary(code))
-                return setError(DRW::BAD_READ_OBJECTS);
-            iface->addObjectPtr(data);
-            iface->addRawDxfObject(raw);
-            return true;
-        }
-        if (!captureAndParseRawDxfGroup(raw, code, data))
-            return setError(DRW::BAD_CODE_PARSED);
-    }
-    return setError(DRW::BAD_READ_OBJECTS);
+    return processRawCapturedObject<DRW_ObjectPtr>(
+        "dxfRW::processObjectPtr", [this](DRW_ObjectPtr& data) { iface->addObjectPtr(data); });
 }
 
 bool dxfRW::processPartialViewingIndex() {
@@ -12156,23 +12007,8 @@ bool dxfRW::processSpatialIndex() {
 }
 
 bool dxfRW::processIDBuffer() {
-    DRW_DBG("dxfRW::processIDBuffer");
-    int code;
-    DRW_IDBuffer data;
-    DRW_RawDxfObject raw;
-    raw.name = nextentity;
-    while (reader->readRec(&code)) {
-        if (code == 0) {
-            if (!acceptObjectBoundary(code))
-                return setError(DRW::BAD_READ_OBJECTS);
-            iface->addIDBuffer(data);
-            iface->addRawDxfObject(raw);
-            return true;
-        }
-        if (!captureAndParseRawDxfGroup(raw, code, data))
-            return setError(DRW::BAD_CODE_PARSED);
-    }
-    return setError(DRW::BAD_READ_OBJECTS);
+    return processRawCapturedObject<DRW_IDBuffer>(
+        "dxfRW::processIDBuffer", [this](DRW_IDBuffer& data) { iface->addIDBuffer(data); });
 }
 
 bool dxfRW::processGeoMapImage() {

--- a/libraries/libdxfrw/src/libdxfrw.h
+++ b/libraries/libdxfrw/src/libdxfrw.h
@@ -366,6 +366,14 @@ private:
     bool processBreakData();
     bool processBreakPointRef();
     bool processMaterial();
+    /// Shared body of the raw-capture object readers: capture every group
+    /// into a DRW_RawDxfObject for lossless re-emit, parse it into the typed
+    /// payload, and hand both to the interface at the object boundary.  Only
+    /// the payload type, the debug label and the interface callback differ
+    /// between the readers that use it.
+    template <typename T, typename AddFn>
+    bool processRawCapturedObject(const char* debugName, AddFn addTyped);
+
     bool processDbColor();
     bool processEvaluationGraph();
     bool processGeoData();

--- a/libraries/libdxfrw/src/libdxfrw.h
+++ b/libraries/libdxfrw/src/libdxfrw.h
@@ -370,7 +370,8 @@ private:
     /// into a DRW_RawDxfObject for lossless re-emit, parse it into the typed
     /// payload, and hand both to the interface at the object boundary.  Only
     /// the payload type, the debug label and the interface callback differ
-    /// between the readers that use it.
+    /// between the readers that use it.  Defined in libdxfrw.cpp and
+    /// instantiated only there.
     template <typename T, typename AddFn>
     bool processRawCapturedObject(const char* debugName, AddFn addTyped);
 

--- a/librecad/src/lib/filters/rs_filterdxfrw.cpp
+++ b/librecad/src/lib/filters/rs_filterdxfrw.cpp
@@ -31823,129 +31823,59 @@ QString RS_FilterDXFRW::lineTypeToName(RS2::LineType lineType) {
 /**
  * Converts a DRW_LW_Conv::lineWidth into a RS2::LineWidth.
  */
+namespace {
+// The DXF/DWG line-weight encoding and LibreCAD's RS2::LineWidth are a
+// one-to-one mapping. numberToWidth() and widthToNumber() are the two
+// directions of it; they used to be a pair of 27-case switches that had to be
+// kept in step by hand, so state the pairs once here instead.
+struct LineWidthPair {
+    DRW_LW_Conv::lineWidth drw;
+    RS2::LineWidth rs;
+};
+
+constexpr LineWidthPair kLineWidthPairs[] = {
+    {DRW_LW_Conv::widthByLayer, RS2::WidthByLayer},
+    {DRW_LW_Conv::widthByBlock, RS2::WidthByBlock},
+    {DRW_LW_Conv::widthDefault, RS2::WidthDefault},
+    {DRW_LW_Conv::width00, RS2::Width00},
+    {DRW_LW_Conv::width01, RS2::Width01},
+    {DRW_LW_Conv::width02, RS2::Width02},
+    {DRW_LW_Conv::width03, RS2::Width03},
+    {DRW_LW_Conv::width04, RS2::Width04},
+    {DRW_LW_Conv::width05, RS2::Width05},
+    {DRW_LW_Conv::width06, RS2::Width06},
+    {DRW_LW_Conv::width07, RS2::Width07},
+    {DRW_LW_Conv::width08, RS2::Width08},
+    {DRW_LW_Conv::width09, RS2::Width09},
+    {DRW_LW_Conv::width10, RS2::Width10},
+    {DRW_LW_Conv::width11, RS2::Width11},
+    {DRW_LW_Conv::width12, RS2::Width12},
+    {DRW_LW_Conv::width13, RS2::Width13},
+    {DRW_LW_Conv::width14, RS2::Width14},
+    {DRW_LW_Conv::width15, RS2::Width15},
+    {DRW_LW_Conv::width16, RS2::Width16},
+    {DRW_LW_Conv::width17, RS2::Width17},
+    {DRW_LW_Conv::width18, RS2::Width18},
+    {DRW_LW_Conv::width19, RS2::Width19},
+    {DRW_LW_Conv::width20, RS2::Width20},
+    {DRW_LW_Conv::width21, RS2::Width21},
+    {DRW_LW_Conv::width22, RS2::Width22},
+    {DRW_LW_Conv::width23, RS2::Width23},
+};
+} // namespace
+
 RS2::LineWidth RS_FilterDXFRW::numberToWidth(DRW_LW_Conv::lineWidth lw) {
-  switch (lw) {
-  case DRW_LW_Conv::widthByLayer:
-    return RS2::WidthByLayer;
-  case DRW_LW_Conv::widthByBlock:
-    return RS2::WidthByBlock;
-  case DRW_LW_Conv::widthDefault:
-    return RS2::WidthDefault;
-  case DRW_LW_Conv::width00:
-    return RS2::Width00;
-  case DRW_LW_Conv::width01:
-    return RS2::Width01;
-  case DRW_LW_Conv::width02:
-    return RS2::Width02;
-  case DRW_LW_Conv::width03:
-    return RS2::Width03;
-  case DRW_LW_Conv::width04:
-    return RS2::Width04;
-  case DRW_LW_Conv::width05:
-    return RS2::Width05;
-  case DRW_LW_Conv::width06:
-    return RS2::Width06;
-  case DRW_LW_Conv::width07:
-    return RS2::Width07;
-  case DRW_LW_Conv::width08:
-    return RS2::Width08;
-  case DRW_LW_Conv::width09:
-    return RS2::Width09;
-  case DRW_LW_Conv::width10:
-    return RS2::Width10;
-  case DRW_LW_Conv::width11:
-    return RS2::Width11;
-  case DRW_LW_Conv::width12:
-    return RS2::Width12;
-  case DRW_LW_Conv::width13:
-    return RS2::Width13;
-  case DRW_LW_Conv::width14:
-    return RS2::Width14;
-  case DRW_LW_Conv::width15:
-    return RS2::Width15;
-  case DRW_LW_Conv::width16:
-    return RS2::Width16;
-  case DRW_LW_Conv::width17:
-    return RS2::Width17;
-  case DRW_LW_Conv::width18:
-    return RS2::Width18;
-  case DRW_LW_Conv::width19:
-    return RS2::Width19;
-  case DRW_LW_Conv::width20:
-    return RS2::Width20;
-  case DRW_LW_Conv::width21:
-    return RS2::Width21;
-  case DRW_LW_Conv::width22:
-    return RS2::Width22;
-  case DRW_LW_Conv::width23:
-    return RS2::Width23;
-  default:
-    break;
+  for (const LineWidthPair &pair : kLineWidthPairs) {
+    if (pair.drw == lw)
+      return pair.rs;
   }
   return RS2::WidthDefault;
 }
 
-/**
- * Converts a RS2::LineWidth into an DRW_LW_Conv::lineWidth.
- */
 DRW_LW_Conv::lineWidth RS_FilterDXFRW::widthToNumber(RS2::LineWidth width) {
-  switch (width) {
-  case RS2::WidthByLayer:
-    return DRW_LW_Conv::widthByLayer;
-  case RS2::WidthByBlock:
-    return DRW_LW_Conv::widthByBlock;
-  case RS2::WidthDefault:
-    return DRW_LW_Conv::widthDefault;
-  case RS2::Width00:
-    return DRW_LW_Conv::width00;
-  case RS2::Width01:
-    return DRW_LW_Conv::width01;
-  case RS2::Width02:
-    return DRW_LW_Conv::width02;
-  case RS2::Width03:
-    return DRW_LW_Conv::width03;
-  case RS2::Width04:
-    return DRW_LW_Conv::width04;
-  case RS2::Width05:
-    return DRW_LW_Conv::width05;
-  case RS2::Width06:
-    return DRW_LW_Conv::width06;
-  case RS2::Width07:
-    return DRW_LW_Conv::width07;
-  case RS2::Width08:
-    return DRW_LW_Conv::width08;
-  case RS2::Width09:
-    return DRW_LW_Conv::width09;
-  case RS2::Width10:
-    return DRW_LW_Conv::width10;
-  case RS2::Width11:
-    return DRW_LW_Conv::width11;
-  case RS2::Width12:
-    return DRW_LW_Conv::width12;
-  case RS2::Width13:
-    return DRW_LW_Conv::width13;
-  case RS2::Width14:
-    return DRW_LW_Conv::width14;
-  case RS2::Width15:
-    return DRW_LW_Conv::width15;
-  case RS2::Width16:
-    return DRW_LW_Conv::width16;
-  case RS2::Width17:
-    return DRW_LW_Conv::width17;
-  case RS2::Width18:
-    return DRW_LW_Conv::width18;
-  case RS2::Width19:
-    return DRW_LW_Conv::width19;
-  case RS2::Width20:
-    return DRW_LW_Conv::width20;
-  case RS2::Width21:
-    return DRW_LW_Conv::width21;
-  case RS2::Width22:
-    return DRW_LW_Conv::width22;
-  case RS2::Width23:
-    return DRW_LW_Conv::width23;
-  default:
-    break;
+  for (const LineWidthPair &pair : kLineWidthPairs) {
+    if (pair.rs == width)
+      return pair.drw;
   }
   return DRW_LW_Conv::widthDefault;
 }

--- a/librecad/src/lib/filters/rs_filterdxfrw.cpp
+++ b/librecad/src/lib/filters/rs_filterdxfrw.cpp
@@ -31820,9 +31820,6 @@ QString RS_FilterDXFRW::lineTypeToName(RS2::LineType lineType) {
     return "CONTINUOUS";
 }*/
 
-/**
- * Converts a DRW_LW_Conv::lineWidth into a RS2::LineWidth.
- */
 namespace {
 // The DXF/DWG line-weight encoding and LibreCAD's RS2::LineWidth are a
 // one-to-one mapping. numberToWidth() and widthToNumber() are the two
@@ -31862,8 +31859,33 @@ constexpr LineWidthPair kLineWidthPairs[] = {
     {DRW_LW_Conv::width22, RS2::Width22},
     {DRW_LW_Conv::width23, RS2::Width23},
 };
+
+// The pair of switches this table replaced could not carry a duplicate case
+// label - the compiler rejected it.  Keep that guarantee here: both lookups
+// return the first matching row, so a repeated value on either side would
+// silently shadow a later one instead of failing the build.
+constexpr bool lineWidthPairsAreOneToOne() {
+    constexpr std::size_t count =
+        sizeof(kLineWidthPairs) / sizeof(kLineWidthPairs[0]);
+    for (std::size_t i = 0; i < count; ++i) {
+        for (std::size_t j = i + 1; j < count; ++j) {
+            if (kLineWidthPairs[i].drw == kLineWidthPairs[j].drw
+                || kLineWidthPairs[i].rs == kLineWidthPairs[j].rs)
+                return false;
+        }
+    }
+    return true;
+}
+
+static_assert(lineWidthPairsAreOneToOne(),
+              "kLineWidthPairs: every DRW_LW_Conv::lineWidth and every "
+              "RS2::LineWidth may appear once, so neither direction of the "
+              "lookup can shadow a later row");
 } // namespace
 
+/**
+ * Converts a DRW_LW_Conv::lineWidth into a RS2::LineWidth.
+ */
 RS2::LineWidth RS_FilterDXFRW::numberToWidth(DRW_LW_Conv::lineWidth lw) {
   for (const LineWidthPair &pair : kLineWidthPairs) {
     if (pair.drw == lw)
@@ -31872,6 +31894,9 @@ RS2::LineWidth RS_FilterDXFRW::numberToWidth(DRW_LW_Conv::lineWidth lw) {
   return RS2::WidthDefault;
 }
 
+/**
+ * Converts a RS2::LineWidth into an DRW_LW_Conv::lineWidth.
+ */
 DRW_LW_Conv::lineWidth RS_FilterDXFRW::widthToNumber(RS2::LineWidth width) {
   for (const LineWidthPair &pair : kLineWidthPairs) {
     if (pair.rs == width)

--- a/librecad/src/lib/filters/tests/dwg_class_table_tests.cpp
+++ b/librecad/src/lib/filters/tests/dwg_class_table_tests.cpp
@@ -1,0 +1,76 @@
+/****************************************************************************
+**
+** This file is part of the LibreCAD project, a 2D CAD program
+**
+** Copyright (C) 2026 LibreCAD.org
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+**********************************************************************/
+
+// The app name of a registered DWG class is written into the CLASSES section
+// verbatim, so any change to one of these strings changes the bytes of every
+// file that registers that class.
+//
+// AutoCAD pads the DIMASSOC app name into columns, and the runs of spaces are
+// part of the value. They are invisible in review and a reformatter or a
+// careless re-transcription silently collapses them, so pin the string here.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstring>
+#include <string>
+
+#include "dwgwriter.h"
+
+namespace {
+
+const DwgTypedClassRow* rowFor(const char* key) {
+    for (const DwgTypedClassRow& row : kDwgTypedClassRows) {
+        if (std::strcmp(row.key, key) == 0) {
+            return &row;
+        }
+    }
+    return nullptr;
+}
+
+} // namespace
+
+TEST_CASE("the DIMASSOC class app name keeps AutoCAD's column padding",
+          "[dwg][classes]") {
+    const DwgTypedClassRow* row = rowFor("DimensionAssociation");
+    REQUIRE(row != nullptr);
+
+    // Five, ten and six spaces after the three labels.
+    const std::string expected =
+        "AcDbDimAssoc|Product Desc:     AcDim ARX App For Dimension|"
+        "Company:          Autodesk, Inc.|WEB Address:      www.autodesk.com";
+
+    INFO("the runs of spaces in this app name are significant");
+    CHECK(std::string(row->appName) == expected);
+    CHECK(std::string(row->appName).size() == 126);
+}
+
+TEST_CASE("every registered class carries non-empty app and class names",
+          "[dwg][classes]") {
+    for (const DwgTypedClassRow& row : kDwgTypedClassRows) {
+        INFO("row " << row.key);
+        CHECK(row.appName != nullptr);
+        CHECK(row.className != nullptr);
+        CHECK(row.recordName != nullptr);
+        CHECK(std::strlen(row.appName) > 0);
+        CHECK(std::strlen(row.className) > 0);
+        CHECK(std::strlen(row.recordName) > 0);
+    }
+}

--- a/librecad/src/lib/filters/tests/dxf_line_width_mapping_tests.cpp
+++ b/librecad/src/lib/filters/tests/dxf_line_width_mapping_tests.cpp
@@ -26,6 +26,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <iterator>
 #include <vector>
 
 #include "drw_base.h"
@@ -98,4 +99,30 @@ TEST_CASE("DXF line-width mapping round-trips in both directions",
         const auto bogus = static_cast<DRW_LW_Conv::lineWidth>(99);
         CHECK(RS_FilterDXFRW::numberToWidth(bogus) == RS2::WidthDefault);
     }
+}
+
+TEST_CASE("DXF line widths map to the standard lineweight values",
+          "[dxf][filter][linewidth]") {
+    // The round-trip and injectivity checks above hold just as well for a table
+    // shifted by one, so pin the values themselves. RS2::LineWidth is the DXF
+    // lineweight in hundredths of a millimetre, and DRW_LW_Conv::widthNN is the
+    // index into AutoCAD's standard lineweight list, so the expected values are
+    // that list and do not come from the mapping under test.
+    static constexpr int kStandardLineweights[] = {
+        0, 5, 9, 13, 15, 18, 20, 25, 30, 35, 40, 50,
+        53, 60, 70, 80, 90, 100, 106, 120, 140, 158, 200, 211};
+
+    for (int i = 0; i < static_cast<int>(std::size(kStandardLineweights)); ++i) {
+        const auto encoded = static_cast<DRW_LW_Conv::lineWidth>(i);
+        INFO("width" << (i < 10 ? "0" : "") << i);
+        CHECK(static_cast<int>(RS_FilterDXFRW::numberToWidth(encoded))
+              == kStandardLineweights[i]);
+        CHECK(RS_FilterDXFRW::widthToNumber(
+                  static_cast<RS2::LineWidth>(kStandardLineweights[i])) == encoded);
+    }
+
+    // The three sentinels carry the negative DXF codes.
+    CHECK(static_cast<int>(RS_FilterDXFRW::numberToWidth(DRW_LW_Conv::widthByLayer)) == -1);
+    CHECK(static_cast<int>(RS_FilterDXFRW::numberToWidth(DRW_LW_Conv::widthByBlock)) == -2);
+    CHECK(static_cast<int>(RS_FilterDXFRW::numberToWidth(DRW_LW_Conv::widthDefault)) == -3);
 }

--- a/librecad/src/lib/filters/tests/dxf_line_width_mapping_tests.cpp
+++ b/librecad/src/lib/filters/tests/dxf_line_width_mapping_tests.cpp
@@ -1,0 +1,101 @@
+/****************************************************************************
+**
+** This file is part of the LibreCAD project, a 2D CAD program
+**
+** Copyright (C) 2026 LibreCAD (librecad.org)
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+**********************************************************************/
+
+// RS_FilterDXFRW::numberToWidth() and widthToNumber() are the two directions of
+// the mapping between the DXF/DWG line-weight encoding and RS2::LineWidth.
+// They used to be a pair of 27-case switches that had to be kept in step by
+// hand; they are now two lookups over one table. These tests pin the property
+// that made the pair correct - that the two directions agree - so a future edit
+// to the table cannot silently break one direction, and cover the sentinel
+// values that are easy to get wrong.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <vector>
+
+#include "drw_base.h"
+#include "rs.h"
+#include "rs_filterdxfrw.h"
+
+namespace {
+
+// Every DRW_LW_Conv::lineWidth the encoding defines, including the three
+// sentinels at the end of the enum.
+const std::vector<DRW_LW_Conv::lineWidth>& allDrwWidths() {
+    static const std::vector<DRW_LW_Conv::lineWidth> widths{
+        DRW_LW_Conv::width00, DRW_LW_Conv::width01, DRW_LW_Conv::width02,
+        DRW_LW_Conv::width03, DRW_LW_Conv::width04, DRW_LW_Conv::width05,
+        DRW_LW_Conv::width06, DRW_LW_Conv::width07, DRW_LW_Conv::width08,
+        DRW_LW_Conv::width09, DRW_LW_Conv::width10, DRW_LW_Conv::width11,
+        DRW_LW_Conv::width12, DRW_LW_Conv::width13, DRW_LW_Conv::width14,
+        DRW_LW_Conv::width15, DRW_LW_Conv::width16, DRW_LW_Conv::width17,
+        DRW_LW_Conv::width18, DRW_LW_Conv::width19, DRW_LW_Conv::width20,
+        DRW_LW_Conv::width21, DRW_LW_Conv::width22, DRW_LW_Conv::width23,
+        DRW_LW_Conv::widthByLayer, DRW_LW_Conv::widthByBlock,
+        DRW_LW_Conv::widthDefault};
+    return widths;
+}
+
+} // namespace
+
+TEST_CASE("DXF line-width mapping round-trips in both directions",
+          "[dxf][filter][linewidth]") {
+    SECTION("every encoded width survives a round trip") {
+        for (const DRW_LW_Conv::lineWidth lw : allDrwWidths()) {
+            const RS2::LineWidth rs = RS_FilterDXFRW::numberToWidth(lw);
+            INFO("encoded width " << static_cast<int>(lw));
+            CHECK(RS_FilterDXFRW::widthToNumber(rs) == lw);
+        }
+    }
+
+    SECTION("the mapping is injective, so no two widths collapse") {
+        std::vector<RS2::LineWidth> seen;
+        for (const DRW_LW_Conv::lineWidth lw : allDrwWidths()) {
+            const RS2::LineWidth rs = RS_FilterDXFRW::numberToWidth(lw);
+            for (const RS2::LineWidth other : seen) {
+                INFO("encoded width " << static_cast<int>(lw)
+                                      << " duplicates an earlier mapping");
+                CHECK(other != rs);
+            }
+            seen.push_back(rs);
+        }
+        CHECK(seen.size() == allDrwWidths().size());
+    }
+
+    SECTION("the three sentinels keep their meaning") {
+        CHECK(RS_FilterDXFRW::numberToWidth(DRW_LW_Conv::widthByLayer)
+              == RS2::WidthByLayer);
+        CHECK(RS_FilterDXFRW::numberToWidth(DRW_LW_Conv::widthByBlock)
+              == RS2::WidthByBlock);
+        CHECK(RS_FilterDXFRW::numberToWidth(DRW_LW_Conv::widthDefault)
+              == RS2::WidthDefault);
+        CHECK(RS_FilterDXFRW::widthToNumber(RS2::WidthByLayer)
+              == DRW_LW_Conv::widthByLayer);
+        CHECK(RS_FilterDXFRW::widthToNumber(RS2::WidthByBlock)
+              == DRW_LW_Conv::widthByBlock);
+        CHECK(RS_FilterDXFRW::widthToNumber(RS2::WidthDefault)
+              == DRW_LW_Conv::widthDefault);
+    }
+
+    SECTION("an unmapped value falls back to the default width") {
+        // The lookup has to answer something for a value outside the table;
+        // the switches it replaced fell through to the default arm.
+        const auto bogus = static_cast<DRW_LW_Conv::lineWidth>(99);
+        CHECK(RS_FilterDXFRW::numberToWidth(bogus) == RS2::WidthDefault);
+    }
+}

--- a/librecad/src/lib/filters/tests/dxf_line_width_mapping_tests.cpp
+++ b/librecad/src/lib/filters/tests/dxf_line_width_mapping_tests.cpp
@@ -95,9 +95,12 @@ TEST_CASE("DXF line-width mapping round-trips in both directions",
 
     SECTION("an unmapped value falls back to the default width") {
         // The lookup has to answer something for a value outside the table;
-        // the switches it replaced fell through to the default arm.
-        const auto bogus = static_cast<DRW_LW_Conv::lineWidth>(99);
-        CHECK(RS_FilterDXFRW::numberToWidth(bogus) == RS2::WidthDefault);
+        // the switches it replaced fell through to the default arm.  The enum
+        // has no fixed underlying type, so its value range stops at its
+        // largest enumerator (31): 24-28 are the only unmapped values that can
+        // be formed without undefined behaviour.
+        const auto unmapped = static_cast<DRW_LW_Conv::lineWidth>(25);
+        CHECK(RS_FilterDXFRW::numberToWidth(unmapped) == RS2::WidthDefault);
     }
 }
 


### PR DESCRIPTION
Section 2 of the DWG/DXF improvement plan, plus its section 4 follow-up: remove duplicated code with no behaviour change.

### What was extracted

| Family | Collapsed | Left alone |
| --- | --- | --- |
| R2007 stream-bounds prologue | 51 of 67 | 16 with extra bounds or a different string-end variable, and the 7 in `drw_entities.cpp` |
| Typed OBJECT class registrars | 32 of 39 | `PlotSettings`, `LightList`, `ImageDefReactor`, the `DimensionAssociation` pair |
| Raw-capture object readers | 13 of 26 | kind-dispatching, finalizing, extra-validation and group-tracing readers |
| Typed OBJECT writers | 9 of 44 | the 34 shapes whose gate inspects more than the version |
| Table-record emitters | 7 of 10 | `emitBlockRecord`, `emitLayerRecord`, `emitViewportEntityHeaderRecord` |
| UCS group-code triplet | 3 of 3 | — |
| Line-width mapping | 2 switches to 1 table | — |

The largest is the R2007 prologue. From R2007 a DWG object stores its strings in a separate stream whose bounds are declared at the end of the object, and every typed parser opened with the same 17 lines. That block appeared 67 times in `drw_objects.cpp`; 51 were identical once the buffer and object-size expressions are abstracted.

The writer family is worth a note: it looks like the biggest opportunity, but 44 members carry 34 distinct shapes, most gating on reactor counts, extension-dictionary flags or data-storage payloads. Only nine are genuinely uniform.

### Compile-time invariants

With the registrars driven from a table, the properties they held by being written out one at a time are asserted instead: non-empty key, application name, class name and record name, and uniqueness of key, record name and class name.

Class numbers are deliberately excluded, and finding that out was useful. The check originally required them to be unique and failed the build: MLEADERSTYLE shares 504 with MATERIAL, TABLESTYLE shares 509 with IDBUFFER, and EVALUATION_GRAPH shares 516 with FIELD. The custom-class range is assigned per file and `registerTypedObjectClass()` hands a colliding type the next free number, so those defaults are a starting point rather than an identity. That is now recorded at the table.

### How behaviour was checked

Two independent checks:

- The full suite reports exactly the `origin/master` baseline: **71968 assertions, 71936 passed, 32 failed**, with an identical failure distribution. Those 32 are pre-existing and are addressed in #2798.
- A byte-identity harness exports a fixed document to every writable format and hashes each; output is unchanged. The harness lands with #2798.

Three attempts were caught by those checks and redone rather than shipped. The registrar conversion first rewrote four registrars carrying extra logic, one with a multi-line application name, and the suite moved from 26 to 32 failures. The writer conversion was first validated against a baseline captured on the wrong branch. The class-number assertion failed the build, which is how the remapping behaviour above came to light.

### Net

1327 lines removed, same public API, same output.
