### PR TITLE
tests: report unavailable-fixture cases as skipped, not passed

### DIFF
--- a/librecad/src/lib/filters/tests/acad_table_tests.cpp
+++ b/librecad/src/lib/filters/tests/acad_table_tests.cpp
@@ -345,8 +345,7 @@ TEST_CASE("dxfRW reads the local ezdxf ACAD_TABLE sample",
   const std::filesystem::path fixture =
       "D:/data/dli/ezdxf/examples_dxf/acad_table_simple.dxf";
   if (!std::filesystem::is_regular_file(fixture)) {
-    SUCCEED("ACAD_TABLE fixture not found at " << fixture.string());
-    return;
+    SKIP("ACAD_TABLE fixture not found at " << fixture.string());
   }
 
   TableCapture cap;
@@ -422,8 +421,7 @@ TEST_CASE("dwgRW reads R2000 ACAD_TABLE grid + resolves *T block (TS1.dwg)",
           "[acad_table][dwg][fixture]") {
   const std::string path = libredwgFixturePath("2000", "TS1.dwg");
   if (path.empty() || !std::filesystem::is_regular_file(path)) {
-    SUCCEED("TS1.dwg fixture absent: " << path);
-    return;
+    SKIP("TS1.dwg fixture absent: " << path);
   }
 
   TableCapture cap;
@@ -475,8 +473,7 @@ TEST_CASE("dwgRW reads R2004 ACAD_TABLE + resolves *T block (example_2004.dwg)",
           "[acad_table][dwg][fixture]") {
   const std::string path = libredwgFixturePath("", "example_2004.dwg");
   if (path.empty() || !std::filesystem::is_regular_file(path)) {
-    SUCCEED("example_2004.dwg fixture absent: " << path);
-    return;
+    SKIP("example_2004.dwg fixture absent: " << path);
   }
 
   TableCapture cap;
@@ -529,8 +526,7 @@ TEST_CASE("dwgRW R2010 ACAD_TABLE read is unchanged (example_2010.dwg)",
   // transcript, pristine tree) — the fix must not alter any of them.
   const std::string path = libredwgFixturePath("", "example_2010.dwg");
   if (path.empty() || !std::filesystem::is_regular_file(path)) {
-    SUCCEED("example_2010.dwg fixture absent: " << path);
-    return;
+    SKIP("example_2010.dwg fixture absent: " << path);
   }
 
   TableCapture cap;

--- a/librecad/src/lib/filters/tests/acsh_shapes_tests.cpp
+++ b/librecad/src/lib/filters/tests/acsh_shapes_tests.cpp
@@ -174,8 +174,7 @@ const std::string kMakeall = std::string(LIBRECAD_TEST_DIR) + "/dynblock_r2018.d
 TEST_CASE("DWG ACSH BOOLEAN/CHAMFER/FILLET/TORUS/EXTRUSION decode (ATMOS AC1021)",
           "[dwg][acsh][parity][fixture]") {
   if (!std::filesystem::is_regular_file(kAtmos)) {
-    SUCCEED("acsh_r2007.dwg fixture not found; skipping");
-    return;
+    SKIP("acsh_r2007.dwg fixture not found; skipping");
   }
   AcShCapture cap;
   // Committed fixture -> a read failure is a real regression, not a skip.
@@ -267,8 +266,7 @@ TEST_CASE("DWG ACSH BOOLEAN/CHAMFER/FILLET/TORUS/EXTRUSION decode (ATMOS AC1021)
 TEST_CASE("DWG ACSH REVOLVE/LOFT/BOOLEAN decode (makeall AC1032 / R2018)",
           "[dwg][acsh][parity][fixture]") {
   if (!std::filesystem::is_regular_file(kMakeall)) {
-    SUCCEED("dynblock_r2018.dwg fixture not found; skipping");
-    return;
+    SKIP("dynblock_r2018.dwg fixture not found; skipping");
   }
   AcShCapture cap;
   // Committed fixture -> a read failure is a real regression, not a skip.

--- a/librecad/src/lib/filters/tests/acsh_tests.cpp
+++ b/librecad/src/lib/filters/tests/acsh_tests.cpp
@@ -150,8 +150,7 @@ TEST_CASE("DWG ACSH_* shape classes decode primitive dims (ATMOS / AC1021)",
           "[dwg][acsh][parity][fixture]") {
   const std::string path = std::string(LIBRECAD_TEST_DIR) + "/acsh_r2007.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("acsh_r2007.dwg fixture not found; skipping");
-    return;
+    SKIP("acsh_r2007.dwg fixture not found; skipping");
   }
 
   AcShCapture cap;

--- a/librecad/src/lib/filters/tests/assoc_tests.cpp
+++ b/librecad/src/lib/filters/tests/assoc_tests.cpp
@@ -169,7 +169,7 @@ public:
 // read fails outright. On success, asserts a clean read with no desync.
 bool tryReadAssoc(const std::string &path, AssocCapture &cap) {
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("fixture not found; skipping: " << path);
+    SKIP("fixture not found; skipping: " << path);
     return false;
   }
   dwgR reader(path.c_str());

--- a/librecad/src/lib/filters/tests/datastorage_tests.cpp
+++ b/librecad/src/lib/filters/tests/datastorage_tests.cpp
@@ -1658,8 +1658,7 @@ TEST_CASE("DWG surface entities retain typed and raw carriers",
   const std::string path =
       std::string(LIBRECAD_TEST_DIR) + "/assoc_surface_r2004.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("assoc_surface_r2004.dwg fixture not found; skipping");
-    return;
+    SKIP("assoc_surface_r2004.dwg fixture not found; skipping");
   }
 
   StubInterface cap;
@@ -1747,8 +1746,7 @@ TEST_CASE("DWG surface raw carriers replay through the filter",
   const std::string sourcePath =
       std::string(LIBRECAD_TEST_DIR) + "/assoc_surface_r2004.dwg";
   if (!std::filesystem::is_regular_file(sourcePath)) {
-    SUCCEED("assoc_surface_r2004.dwg fixture not found; skipping");
-    return;
+    SKIP("assoc_surface_r2004.dwg fixture not found; skipping");
   }
   ensureQtContext();
 
@@ -1795,8 +1793,7 @@ TEST_CASE("DWG dynblock_point has non-empty DataStorage records",
   const std::string path =
       std::string(LIBRECAD_TEST_DIR) + "/dynblock_point.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("dynblock_point.dwg fixture not found; skipping");
-    return;
+    SKIP("dynblock_point.dwg fixture not found; skipping");
   }
 
   StubInterface cap;
@@ -1890,7 +1887,7 @@ TEST_CASE("DWG DataStorage counts agree with independent TS reader",
     ++checked;
   }
   if (checked == 0u)
-    SUCCEED("DataStorage corpus fixtures not found; skipping");
+    SKIP("DataStorage corpus fixtures not found; skipping");
 }
 
 TEST_CASE("DWG AC1027 VISUALSTYLE keeps its physical DataStorage boundary",
@@ -1898,8 +1895,7 @@ TEST_CASE("DWG AC1027 VISUALSTYLE keeps its physical DataStorage boundary",
   const std::string path =
       std::string(LIBRECAD_TEST_DIR) + "/visualstyle_r2013.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("visualstyle_r2013.dwg fixture not found; skipping");
-    return;
+    SKIP("visualstyle_r2013.dwg fixture not found; skipping");
   }
 
   StubInterface cap;
@@ -1933,8 +1929,7 @@ TEST_CASE("DWG AC1027 modeler fixture binds DataStorage owner records",
   const std::string path =
       std::string(LIBRECAD_TEST_DIR) + "/datastorage_modeler_r2013.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("datastorage_modeler_r2013.dwg fixture not found; skipping");
-    return;
+    SKIP("datastorage_modeler_r2013.dwg fixture not found; skipping");
   }
 
   StubInterface cap;
@@ -2026,8 +2021,7 @@ TEST_CASE("DWG AC1027 fixture-derived DataStorage corruption stops publication",
   const std::filesystem::path sourcePath =
       std::string(LIBRECAD_TEST_DIR) + "/datastorage_modeler_r2013.dwg";
   if (!std::filesystem::is_regular_file(sourcePath)) {
-    SUCCEED("datastorage_modeler_r2013.dwg fixture not found; skipping");
-    return;
+    SKIP("datastorage_modeler_r2013.dwg fixture not found; skipping");
   }
 
   StubInterface source;
@@ -2142,8 +2136,7 @@ TEST_CASE("DWG AC1032 modeler fixture binds DataStorage owner records",
   const std::string path = std::string(LIBRECAD_TEST_DIR)
       + "/datastorage_modeler_r2018.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("datastorage_modeler_r2018.dwg fixture not found; skipping");
-    return;
+    SKIP("datastorage_modeler_r2018.dwg fixture not found; skipping");
   }
 
   StubInterface cap;
@@ -2224,8 +2217,7 @@ TEST_CASE("DWG AC1027 modeler fixture replays DataStorage through the filter",
   const std::filesystem::path sourcePath =
       std::string(LIBRECAD_TEST_DIR) + "/datastorage_modeler_r2013.dwg";
   if (!std::filesystem::is_regular_file(sourcePath)) {
-    SUCCEED("datastorage_modeler_r2013.dwg fixture not found; skipping");
-    return;
+    SKIP("datastorage_modeler_r2013.dwg fixture not found; skipping");
   }
 
   const std::filesystem::path sameVersionPath =
@@ -2415,8 +2407,7 @@ TEST_CASE("DWG AC1032 modeler fixture replays DataStorage through the filter",
   const std::filesystem::path sourcePath =
       std::string(LIBRECAD_TEST_DIR) + "/datastorage_modeler_r2018.dwg";
   if (!std::filesystem::is_regular_file(sourcePath)) {
-    SUCCEED("datastorage_modeler_r2018.dwg fixture not found; skipping");
-    return;
+    SKIP("datastorage_modeler_r2018.dwg fixture not found; skipping");
   }
 
   const std::filesystem::path sameVersionPath =
@@ -2861,8 +2852,7 @@ TEST_CASE("DWG DataStorage linkage is optional and handle keyed",
   }
 
   if (filesWithStorage == 0) {
-    SUCCEED("no DataStorage fixture available; linkage is optional");
-    return;
+    SKIP("no DataStorage fixture available; linkage is optional");
   }
   if (linkedModelers == 0)
     SUCCEED("available DataStorage fixtures contain no modeler entity");

--- a/librecad/src/lib/filters/tests/datatable_tests.cpp
+++ b/librecad/src/lib/filters/tests/datatable_tests.cpp
@@ -134,8 +134,7 @@ TEST_CASE("DWG DATATABLE prefix decodes (gh209_1.dwg / AC1024)",
           "[dwg][datatable][parity]") {
   const std::string path = std::string(LIBRECAD_TEST_DIR) + "/datatable_r2010.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("datatable_r2010.dwg fixture not found; skipping");
-    return;
+    SKIP("datatable_r2010.dwg fixture not found; skipping");
   }
 
   DataTableCapture cap;

--- a/librecad/src/lib/filters/tests/dwg_gui_import_repro_tests.cpp
+++ b/librecad/src/lib/filters/tests/dwg_gui_import_repro_tests.cpp
@@ -127,8 +127,7 @@ TEST_CASE("DWG load profiling: phase timing for an arbitrary file", "[.dwg_profi
                     : (home ? std::string(home) + "/doc/dwg4/\xe6\xa4\x8d\xe7\x89\xa9.dwg"
                             : std::string());
   if (path.empty() || !std::filesystem::is_regular_file(path)) {
-    SUCCEED("profiling target not present; skipping (path=" << path << ")");
-    return;
+    SKIP("profiling target not present; skipping (path=" << path << ")");
   }
 
   std::cout << "\n=== DWG load profiling: " << path << " ===\n";
@@ -215,14 +214,12 @@ TEST_CASE("DWG load profiling: phase timing for an arbitrary file", "[.dwg_profi
 TEST_CASE("GUI import of usa_dollar100_front.dwg completes", "[.dwg6_gui_import]") {
   const char *home = std::getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg6/usa_dollar100_front.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("usa_dollar100_front.dwg not present; skipping");
-    return;
+    SKIP("usa_dollar100_front.dwg not present; skipping");
   }
 
   static int qargc = 1;
@@ -272,14 +269,12 @@ TEST_CASE("GUI import of usa_dollar100_front.dwg completes", "[.dwg6_gui_import]
 TEST_CASE("GUI import of makeall-plus.dwg counts entities", "[.dwg_makeall_gui]") {
   const char *home = std::getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg3/makeall-plus.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("makeall-plus.dwg not present; skipping");
-    return;
+    SKIP("makeall-plus.dwg not present; skipping");
   }
 
   static int qargc = 1;
@@ -332,14 +327,12 @@ TEST_CASE("GUI import of makeall-plus.dwg counts entities", "[.dwg_makeall_gui]"
 TEST_CASE("GUI import of visualization_condominium.dwg counts entities", "[.dwg_condo]") {
   const char *home = std::getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg/visualization_-_condominium_with_skylight.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("condo dwg not present; skipping");
-    return;
+    SKIP("condo dwg not present; skipping");
   }
 
   static int qargc = 1;

--- a/librecad/src/lib/filters/tests/dwg_handle_stream_tests.cpp
+++ b/librecad/src/lib/filters/tests/dwg_handle_stream_tests.cpp
@@ -133,14 +133,12 @@ TEST_CASE("DWG <=AC1018 IMAGEDEF_REACTOR owner handle decodes correctly",
           "[.dwg6_imagedef_reactor]") {
   const char *home = std::getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg6/Big-Blocks-CAD.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("Big-Blocks-CAD.dwg not present; skipping");
-    return;
+    SKIP("Big-Blocks-CAD.dwg not present; skipping");
   }
 
   ReactorCapture cap;
@@ -168,14 +166,12 @@ TEST_CASE("DWG <=AC1018 dynamic-block object owner handle decodes correctly",
           "[.dwg6_dynblock_ac1015]") {
   const char *home = std::getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg6/sample_AC1015.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("sample_AC1015.dwg not present; skipping");
-    return;
+    SKIP("sample_AC1015.dwg not present; skipping");
   }
 
   DynBlockCapture cap;

--- a/librecad/src/lib/filters/tests/dwg_header_encode_round_trip_tests.cpp
+++ b/librecad/src/lib/filters/tests/dwg_header_encode_round_trip_tests.cpp
@@ -427,10 +427,10 @@ std::uint32_t leU32(const std::vector<std::uint8_t>& b, size_t off) {
 TEST_CASE("DRW_Header::encodeDwg replays a real fixture header round-trip",
           "[.dwg_header_fixture_replay]") {
     const char* home = std::getenv("HOME");
-    if (home == nullptr) { SUCCEED("HOME not set"); return; }
+    if (home == nullptr) { SKIP("HOME not set"); return; }
     const std::string path = std::string(home) + "/doc/dwg2/Patterns-art-block.dwg";
     if (!std::filesystem::is_regular_file(path)) {
-        SUCCEED("~/doc/dwg2/Patterns-art-block.dwg not found"); return;
+        SKIP("~/doc/dwg2/Patterns-art-block.dwg not found"); return;
     }
 
     // Slurp the file for the section locator + original HEADER body.

--- a/librecad/src/lib/filters/tests/dwg_safety_tests.cpp
+++ b/librecad/src/lib/filters/tests/dwg_safety_tests.cpp
@@ -6075,8 +6075,7 @@ TEST_CASE("DWG R2007 CRC primitives follow the specification",
     CHECK(dwgUtil::decodeCrcSeed(0xb4490d12407037daULL) == 0);
 
     if (!hasLocalFixture("visualstyle_r2007.dwg")) {
-        SUCCEED("visualstyle_r2007.dwg fixture absent; skipping");
-        return;
+        SKIP("visualstyle_r2007.dwg fixture absent; skipping");
     }
     const auto bytes = readFile(localFixture("visualstyle_r2007.dwg"));
     REQUIRE(bytes.size() >= r2007FileHeaderOffset + r2007EncodedHeaderSize);
@@ -6263,8 +6262,7 @@ TEST_CASE("DWG R2007 page CRC mismatch is surfaced", "[dwg][safety]") {
 TEST_CASE("DWG R2007 integrity diagnostics are exposed", "[dwg][safety]") {
     const auto source = localFixture("visualstyle_r2007.dwg");
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("visualstyle_r2007.dwg fixture absent; skipping");
-        return;
+        SKIP("visualstyle_r2007.dwg fixture absent; skipping");
     }
     DwgReadProbe interface;
     dwgRW reader(source.string().c_str());
@@ -6472,8 +6470,7 @@ TEST_CASE("DWG R2004 file-header CRC mismatch is surfaced",
           "[dwg][safety][fixture]") {
     const auto source = localFixture("xline/constructionline_2004.dwg");
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("constructionline_2004.dwg fixture absent; skipping");
-        return;
+        SKIP("constructionline_2004.dwg fixture absent; skipping");
     }
     auto bytes = readFile(source);
     REQUIRE(bytes.size() > 0x80 + 36);
@@ -6507,8 +6504,7 @@ TEST_CASE("DWG R2004 file-header tail magic is required",
           "[dwg][safety][fixture]") {
     const auto source = localFixture("xline/constructionline_2004.dwg");
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("constructionline_2004.dwg fixture absent; skipping");
-        return;
+        SKIP("constructionline_2004.dwg fixture absent; skipping");
     }
     auto bytes = readFile(source);
     REQUIRE(bytes.size() > 0xEC);
@@ -6523,8 +6519,7 @@ TEST_CASE("DWG R2004 file-header constants are required",
           "[dwg][safety][fixture]") {
     const auto source = localFixture("xline/constructionline_2004.dwg");
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("constructionline_2004.dwg fixture absent; skipping");
-        return;
+        SKIP("constructionline_2004.dwg fixture absent; skipping");
     }
     auto bytes = readFile(source);
     REQUIRE(bytes.size() > 0x80 + 20);
@@ -6574,7 +6569,7 @@ TEST_CASE("DWG optional version fixtures reject truncated containers",
         CHECK(reader.getVersion() == fixture.version);
     }
     if (!testedFixture)
-        SUCCEED("source-controlled DWG fixtures absent; skipping");
+        SKIP("source-controlled DWG fixtures absent; skipping");
 }
 
 TEST_CASE("DWG CLASSES CRC covers the section payload", "[dwg][safety]") {
@@ -6775,8 +6770,7 @@ TEST_CASE("DWG CLASSES report finalization is independent of DXF classes",
           "[dwg][safety][classes][fixture]") {
     const auto source = localFixture("visualstyle_r2007.dwg");
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("visualstyle_r2007.dwg fixture absent; skipping");
-        return;
+        SKIP("visualstyle_r2007.dwg fixture absent; skipping");
     }
     DwgReadProbe interface;
     dwgRW reader(source.string().c_str());
@@ -6826,8 +6820,7 @@ TEST_CASE("DWG process keeps a class-report callback failure best effort",
           "[dwg][safety][classes][fixture]") {
     const auto source = localFixture("visualstyle_r2007.dwg");
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("visualstyle_r2007.dwg fixture absent; skipping");
-        return;
+        SKIP("visualstyle_r2007.dwg fixture absent; skipping");
     }
     DwgThrowingClassCoverageProbe interface;
     dwgRW reader(source.string().c_str());
@@ -6869,8 +6862,7 @@ TEST_CASE("DWG R2000 rejects unsupported section locator counts",
           "[dwg][safety][fixture]") {
     const auto source = localFixture("xline/constructionline_2000.dwg");
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("constructionline_2000.dwg fixture absent; skipping");
-        return;
+        SKIP("constructionline_2000.dwg fixture absent; skipping");
     }
     auto bytes = readFile(source);
     REQUIRE(bytes.size() > 80u);
@@ -6887,8 +6879,7 @@ TEST_CASE("DWG R2000 rejects a corrupt file-header sentinel",
           "[dwg][safety][fixture]") {
     const auto source = localFixture("xline/constructionline_2000.dwg");
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("constructionline_2000.dwg fixture absent; skipping");
-        return;
+        SKIP("constructionline_2000.dwg fixture absent; skipping");
     }
     auto bytes = readFile(source);
     constexpr std::size_t locatorOffset = 21u;
@@ -6914,8 +6905,7 @@ TEST_CASE("DWG R2000 rejects a corrupt section locator CRC",
           "[dwg][safety][fixture]") {
     const auto source = localFixture("xline/constructionline_2000.dwg");
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("constructionline_2000.dwg fixture absent; skipping");
-        return;
+        SKIP("constructionline_2000.dwg fixture absent; skipping");
     }
     auto bytes = readFile(source);
     constexpr std::size_t locatorOffset = 21u;
@@ -6940,8 +6930,7 @@ TEST_CASE("DWG R2000 section locators publish transactionally",
           "[dwg][safety][fixture]") {
     const auto source = localFixture("xline/constructionline_2000.dwg");
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("constructionline_2000.dwg fixture absent; skipping");
-        return;
+        SKIP("constructionline_2000.dwg fixture absent; skipping");
     }
     const auto original = readFile(source);
     REQUIRE(original.size() > 80u);
@@ -7127,8 +7116,7 @@ TEST_CASE("DWG AC1018 CLASSES CRC mismatch is reported after parsing",
           "[dwg][safety][fixture]") {
     const auto source = localFixture("xline/constructionline_2004.dwg");
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("constructionline_2004.dwg fixture absent; skipping");
-        return;
+        SKIP("constructionline_2004.dwg fixture absent; skipping");
     }
     const auto original = readFile(source);
     REQUIRE(!original.empty());
@@ -7191,8 +7179,7 @@ TEST_CASE("DWG INSERT callbacks contain complete ATTRIB sequences",
     const std::filesystem::path source =
         std::filesystem::path(LIBRECAD_TEST_DIR) / "dynblock_r2018.dwg";
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("dynamic-block fixture not present; skipping");
-        return;
+        SKIP("dynamic-block fixture not present; skipping");
     }
 
     DwgReadProbe interface;
@@ -7222,8 +7209,7 @@ TEST_CASE("DWG R2018 POLYLINE trace is bounded by its object-map frame",
     const std::filesystem::path source =
         std::filesystem::path(LIBRECAD_TEST_DIR) / "dynblock_r2018.dwg";
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("dynamic-block fixture not present; skipping");
-        return;
+        SKIP("dynamic-block fixture not present; skipping");
     }
 
     auto bytes = readFile(source);
@@ -7260,8 +7246,7 @@ TEST_CASE("DWG AC1032 fixture commits direct POLYLINE child sequences",
     const std::filesystem::path source =
         std::filesystem::path(LIBRECAD_TEST_DIR) / "dynblock_r2018.dwg";
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("dynamic-block fixture not present; skipping");
-        return;
+        SKIP("dynamic-block fixture not present; skipping");
     }
 
     auto bytes = readFile(source);
@@ -7284,8 +7269,7 @@ TEST_CASE("DWG R2018 common handles preserve block owners and DBCOLOR references
     const std::filesystem::path source =
         std::filesystem::path(LIBRECAD_TEST_DIR) / "dynblock_r2018.dwg";
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("dynamic-block fixture not present; skipping");
-        return;
+        SKIP("dynamic-block fixture not present; skipping");
     }
 
     // dwg-parser and LibreDWG decode the R2004+ common handle stream as
@@ -13978,9 +13962,8 @@ TEST_CASE("DWG AC1015 FIELD/FIELDLIST fixture publishes typed receipts",
           "[dwg][safety][field][fieldlist][fixture]") {
     const std::filesystem::path source = findTs1Fixture();
     if (source.empty()) {
-        SUCCEED("TS1.dwg is an external fixture; set "
+        SKIP("TS1.dwg is an external fixture; set "
                 "LIBRECAD_EXTERNAL_DWG_FIXTURE_DIR to run this case");
-        return;
     }
     REQUIRE(std::filesystem::file_size(source) == 418007u);
 
@@ -14080,9 +14063,8 @@ TEST_CASE("DWG AC1015 3DSOLID skips opaque ACIS data before common handles",
           "[dwg][safety][modeler][fixture]") {
     const std::filesystem::path source = findTs1Fixture();
     if (source.empty()) {
-        SUCCEED("TS1.dwg is an external fixture; set "
+        SKIP("TS1.dwg is an external fixture; set "
                 "LIBRECAD_EXTERNAL_DWG_FIXTURE_DIR to run this case");
-        return;
     }
 
     auto bytes = readFile(source);
@@ -14130,9 +14112,8 @@ TEST_CASE("DWG AC1015 LEADER reads its mandatory arrowhead type",
           "[dwg][safety][leader][fixture]") {
     const std::filesystem::path source = findTs1Fixture();
     if (source.empty()) {
-        SUCCEED("TS1.dwg is an external fixture; set "
+        SKIP("TS1.dwg is an external fixture; set "
                 "LIBRECAD_EXTERNAL_DWG_FIXTURE_DIR to run this case");
-        return;
     }
 
     auto bytes = readFile(source);
@@ -14175,9 +14156,8 @@ TEST_CASE("DWG AC1015 model space completes legacy INSERT attributes",
           "[dwg][safety][compound][fixture]") {
     const std::filesystem::path source = findTs1Fixture();
     if (source.empty()) {
-        SUCCEED("TS1.dwg is an external fixture; set "
+        SKIP("TS1.dwg is an external fixture; set "
                 "LIBRECAD_EXTERNAL_DWG_FIXTURE_DIR to run this case");
-        return;
     }
     REQUIRE(std::filesystem::file_size(source) == 418007u);
 
@@ -14234,9 +14214,8 @@ TEST_CASE("DWG AC1015 fixture completes the BLOCKS phase",
           "[dwg][safety][compound][fixture]") {
     const std::filesystem::path source = findTs1Fixture();
     if (source.empty()) {
-        SUCCEED("TS1.dwg is an external fixture; set "
+        SKIP("TS1.dwg is an external fixture; set "
                 "LIBRECAD_EXTERNAL_DWG_FIXTURE_DIR to run this case");
-        return;
     }
 
     auto bytes = readFile(source);
@@ -16971,8 +16950,7 @@ TEST_CASE("DWG R2007 page-map header bounds are enforced before allocation",
           "[dwg][safety][fixture]") {
     const auto source = localFixture("visualstyle_r2007.dwg");
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("visualstyle_r2007.dwg fixture absent; skipping");
-        return;
+        SKIP("visualstyle_r2007.dwg fixture absent; skipping");
     }
     const auto original = readFile(source);
     REQUIRE(!original.empty());
@@ -17010,8 +16988,7 @@ TEST_CASE("DWG R2007 page-map count must match the decoded map",
           "[dwg][safety][fixture]") {
     const auto source = localFixture("visualstyle_r2007.dwg");
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("visualstyle_r2007.dwg fixture absent; skipping");
-        return;
+        SKIP("visualstyle_r2007.dwg fixture absent; skipping");
     }
     const auto original = readFile(source);
     REQUIRE(!original.empty());
@@ -17040,8 +17017,7 @@ TEST_CASE("DWG R2007 section-map count must match decoded descriptors",
           "[dwg][safety][fixture]") {
     const auto source = localFixture("visualstyle_r2007.dwg");
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("visualstyle_r2007.dwg fixture absent; skipping");
-        return;
+        SKIP("visualstyle_r2007.dwg fixture absent; skipping");
     }
     const auto original = readFile(source);
     REQUIRE(!original.empty());
@@ -17079,8 +17055,7 @@ TEST_CASE("DWG R2007 page-map rejects an out-of-range page ID",
           "[dwg][safety][fixture]") {
     const auto source = localFixture("visualstyle_r2007.dwg");
     if (!std::filesystem::is_regular_file(source)) {
-        SUCCEED("visualstyle_r2007.dwg fixture absent; skipping");
-        return;
+        SKIP("visualstyle_r2007.dwg fixture absent; skipping");
     }
     const auto original = readFile(source);
     REQUIRE(!original.empty());

--- a/librecad/src/lib/filters/tests/dwg_smoke_tests.cpp
+++ b/librecad/src/lib/filters/tests/dwg_smoke_tests.cpp
@@ -1562,8 +1562,7 @@ TEST_CASE("dwgRW::readBuffer matches file-path read for a committed fixture",
   const std::string path =
       std::string(LIBRECAD_TEST_DIR) + "/mpolygon_solid.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("mpolygon_solid.dwg fixture absent; skipping");
-    return;
+    SKIP("mpolygon_solid.dwg fixture absent; skipping");
   }
 
   CountingIface fileIface;
@@ -1595,8 +1594,7 @@ TEST_CASE("DWG R2007: section names decode via UTF-16 (no BAD_READ_HEADER)",
   const std::string path =
       std::string(LIBRECAD_TEST_DIR) + "/visualstyle_r2007.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("visualstyle_r2007.dwg fixture absent; skipping");
-    return;
+    SKIP("visualstyle_r2007.dwg fixture absent; skipping");
   }
   const DwgResult r = readDwg(path);
   REQUIRE(r.version == DRW::AC1021);
@@ -1630,8 +1628,7 @@ TEST_CASE("DWG pre-R13 R10: JUMP-split polyline recovered from EXTRAS section",
   const std::string path =
       std::string(LIBRECAD_TEST_DIR) + "/pre_r13_r10_entities.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("pre_r13_r10_entities.dwg fixture absent; skipping");
-    return;
+    SKIP("pre_r13_r10_entities.dwg fixture absent; skipping");
   }
   PolyCountIface iface;
   dwgR reader(path.c_str());
@@ -1674,8 +1671,7 @@ TEST_CASE("DWG pre-R13 R11: embedded APPID + DIMSTYLE tables decode name-only",
   const std::string path =
       std::string(LIBRECAD_TEST_DIR) + "/pre_r13_r11_tables.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("pre_r13_r11_tables.dwg fixture absent; skipping");
-    return;
+    SKIP("pre_r13_r11_tables.dwg fixture absent; skipping");
   }
   TableNameCapture iface;
   dwgR reader(path.c_str());
@@ -1764,7 +1760,7 @@ TEST_CASE("DWG pre-R10 tier (R2.6/R9/R2.10) reads entities with 2D bodies",
     const std::string path = std::string(LIBRECAD_TEST_DIR) + "/" + c.file;
     INFO("fixture: " << c.file);
     if (!std::filesystem::is_regular_file(path)) {
-      SUCCEED("fixture absent; skipping");
+      SKIP("fixture absent; skipping");
       continue;
     }
     LineCapture iface;
@@ -1787,16 +1783,14 @@ TEST_CASE("DWG pre-R13 external R2.6 dimensions use typed callbacks",
           "[dwg][pre-r13][external]") {
   const char *home = std::getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping external corpus");
-    return;
+    SKIP("HOME not set; skipping external corpus");
   }
   const std::string path =
       (std::filesystem::path(home) / "dev" / "dwg-writer" / "tests" /
        "fixtures" / "committed" / "libredwg" / "dim_r2_6.dwg")
           .string();
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("dwg-writer dim_r2_6.dwg absent; skipping external corpus");
-    return;
+    SKIP("dwg-writer dim_r2_6.dwg absent; skipping external corpus");
   }
 
   LegacyDimensionCapture iface;
@@ -1824,8 +1818,7 @@ TEST_CASE("DWG pre-R13 derived angular and ordinate dimensions use typed callbac
           "[dwg][pre-r13][external]") {
   const char *root = std::getenv("LIBRECAD_PRE_R13_DIMENSION_FIXTURES");
   if (!root || root[0] == '\0') {
-    SUCCEED("derived pre-R13 dimension fixtures not configured; skipping");
-    return;
+    SKIP("derived pre-R13 dimension fixtures not configured; skipping");
   }
   struct Case {
     const char *file;
@@ -1839,7 +1832,7 @@ TEST_CASE("DWG pre-R13 derived angular and ordinate dimensions use typed callbac
     const std::string path = (std::filesystem::path(root) / c.file).string();
     INFO("fixture: " << c.file);
     if (!std::filesystem::is_regular_file(path)) {
-      SUCCEED("derived fixture absent; skipping");
+      SKIP("derived fixture absent; skipping");
       continue;
     }
     LegacyDimensionCapture iface;
@@ -1871,8 +1864,7 @@ TEST_CASE("DWG R1.40 (AC1.40) dedicated reader decodes the entity stream",
   const std::string path =
       std::string(LIBRECAD_TEST_DIR) + "/pre_r10_r140_entities.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("pre_r10_r140_entities.dwg fixture absent; skipping");
-    return;
+    SKIP("pre_r10_r140_entities.dwg fixture absent; skipping");
   }
   LineCapture iface;
   dwgR reader(path.c_str());
@@ -1913,14 +1905,12 @@ TEST_CASE("DWG R2007 stored-page: usa_dollar100_front.dwg reads tables",
           "[.dwg6_stored_page]") {
   const char *home = std::getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg6/usa_dollar100_front.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("usa_dollar100_front.dwg not present; skipping");
-    return;
+    SKIP("usa_dollar100_front.dwg not present; skipping");
   }
   CountingIface iface;
   const DwgResult r = readDwg(path, /*verbose=*/false, &iface);
@@ -1953,7 +1943,7 @@ TEST_CASE("DWG XLINE reads as typed construction line across LibreDWG versions",
         std::string(LIBRECAD_TEST_DIR) + "/" + fixture.file;
     INFO("fixture: " << fixture.file);
     if (!std::filesystem::is_regular_file(path)) {
-      SUCCEED("fixture absent; skipping");
+      SKIP("fixture absent; skipping");
       continue;
     }
     testedFixture = true;
@@ -1978,7 +1968,7 @@ TEST_CASE("DWG XLINE reads as typed construction line across LibreDWG versions",
     CHECK(dirLen > 0.0);
   }
   if (!testedFixture)
-    SUCCEED("XLINE fixtures absent; skipping");
+    SKIP("XLINE fixtures absent; skipping");
 }
 
 TEST_CASE("DWG optional fixtures cover AC1015 through AC1032",
@@ -2003,7 +1993,7 @@ TEST_CASE("DWG optional fixtures cover AC1015 through AC1032",
         std::string(LIBRECAD_TEST_DIR) + "/" + fixture.file;
     INFO("fixture: " << fixture.file);
     if (!std::filesystem::is_regular_file(path)) {
-      SUCCEED("fixture absent; skipping");
+      SKIP("fixture absent; skipping");
       continue;
     }
     testedFixture = true;
@@ -2016,7 +2006,7 @@ TEST_CASE("DWG optional fixtures cover AC1015 through AC1032",
     CHECK(iface.entities > 0);
   }
   if (!testedFixture)
-    SUCCEED("source-controlled DWG fixtures absent; skipping");
+    SKIP("source-controlled DWG fixtures absent; skipping");
 }
 
 TEST_CASE("DWG sibling oracle fixtures preserve dictionary ownership",
@@ -2043,8 +2033,7 @@ TEST_CASE("DWG sibling oracle fixtures preserve dictionary ownership",
   const auto r14Path = findFixture("example_r14.dwg");
   const auto r13Path = findFixture("example_r13.dwg");
   if (r14Path.empty() || r13Path.empty()) {
-    SUCCEED("dwg-parser sibling fixtures absent; skipping");
-    return;
+    SKIP("dwg-parser sibling fixtures absent; skipping");
   }
 
   DictionaryFixtureIface r14Iface;
@@ -2118,8 +2107,7 @@ TEST_CASE("DWG sibling oracle fixtures deliver R13/R14 viewport headers",
   const auto r14Path = findFixture("example_r14.dwg");
   const auto r13Path = findFixture("example_r13.dwg");
   if (r14Path.empty() || r13Path.empty()) {
-    SUCCEED("dwg-parser sibling fixtures absent; skipping");
-    return;
+    SKIP("dwg-parser sibling fixtures absent; skipping");
   }
 
   struct Expected {
@@ -2263,13 +2251,11 @@ TEST_CASE("DWG smoke test: read ~/doc/dwg/*.dwg and report entity counts",
   // test passes for everyone else.
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping DWG corpus tests");
-    return;
+    SKIP("HOME not set; skipping DWG corpus tests");
   }
   const std::string dir = std::string(home) + "/doc/dwg/";
   if (!std::filesystem::is_directory(dir)) {
-    SUCCEED("DWG corpus directory not found at " << dir << "; skipping");
-    return;
+    SKIP("DWG corpus directory not found at " << dir << "; skipping");
   }
 
   // Print a header once
@@ -2317,13 +2303,11 @@ TEST_CASE("DWG lineweights: distribution in lineweights.dwg",
           "[.dwg_lineweights]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set");
-    return;
+    SKIP("HOME not set");
   }
   const std::string path = std::string(home) + "/doc/dwg/lineweights.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("lineweights.dwg not present; skipping");
-    return;
+    SKIP("lineweights.dwg not present; skipping");
   }
 
   CountingIface iface;
@@ -2365,13 +2349,11 @@ TEST_CASE("DWG lineweights: distribution in lineweights.dwg",
 TEST_CASE("DWG verbose debug: failing AC1021 files", "[.dwg_verbose]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping verbose DWG corpus tests");
-    return;
+    SKIP("HOME not set; skipping verbose DWG corpus tests");
   }
   const std::string dir = std::string(home) + "/doc/dwg/";
   if (!std::filesystem::is_directory(dir)) {
-    SUCCEED("DWG corpus directory not found at " << dir << "; skipping");
-    return;
+    SKIP("DWG corpus directory not found at " << dir << "; skipping");
   }
 
   const char *failingFiles[] = {
@@ -2400,13 +2382,11 @@ TEST_CASE("DWG deep diagnostic: entity type breakdown for target files",
           "[.dwg_deep]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string dir = std::string(home) + "/doc/dwg/";
   if (!std::filesystem::is_directory(dir)) {
-    SUCCEED("DWG corpus directory not found; skipping");
-    return;
+    SKIP("DWG corpus directory not found; skipping");
   }
 
   const char *targets[] = {
@@ -2440,13 +2420,11 @@ TEST_CASE("DWG deep diagnostic: entity type breakdown for target files",
 TEST_CASE("DWG Pool_Detail.dwg: dump every circle", "[.dwg_pool_circles]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg/Pool_Detail.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("Pool_Detail.dwg not present; skipping");
-    return;
+    SKIP("Pool_Detail.dwg not present; skipping");
   }
 
   struct CircleCollector : public TypeTrackingIface {
@@ -2527,13 +2505,11 @@ TEST_CASE("DWG Pool_Detail.dwg: dump every circle", "[.dwg_pool_circles]") {
 TEST_CASE("DWG Cover.dwg: deep entity/type breakdown", "[.dwg_cover]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg/Cover.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("Cover.dwg not present; skipping");
-    return;
+    SKIP("Cover.dwg not present; skipping");
   }
   const DeepResult dr = readDwgDeep(path);
   printDeepReport("Cover.dwg", dr);
@@ -2549,13 +2525,11 @@ TEST_CASE("DWG samples: load all files in ~/dev/dwg_samples/",
           "[.slow][dwg][corpus]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string dir = std::string(home) + "/dev/dwg_samples/";
   if (!std::filesystem::is_directory(dir)) {
-    SUCCEED("~/dev/dwg_samples/ not found; skipping");
-    return;
+    SKIP("~/dev/dwg_samples/ not found; skipping");
   }
 
   // Collect *.dwg paths, sorted for deterministic output.
@@ -2571,8 +2545,7 @@ TEST_CASE("DWG samples: load all files in ~/dev/dwg_samples/",
   std::sort(paths.begin(), paths.end());
 
   if (paths.empty()) {
-    SUCCEED("No .dwg files found in ~/dev/dwg_samples/; skipping");
-    return;
+    SKIP("No .dwg files found in ~/dev/dwg_samples/; skipping");
   }
 
   // Header
@@ -2615,14 +2588,12 @@ TEST_CASE("DWG samples: load all files in ~/dev/dwg_samples/",
 TEST_CASE("DWG polyline2d_line_R14: deep + verbose", "[.dwg_polyR14]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set");
-    return;
+    SKIP("HOME not set");
   }
   const std::string path =
       std::string(home) + "/dev/dwg_samples/polyline2d_line_R14.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("polyline2d_line_R14.dwg not present; skipping");
-    return;
+    SKIP("polyline2d_line_R14.dwg not present; skipping");
   }
 
   // readDwgDeep captures the full debug log internally — no separate verbose
@@ -2639,13 +2610,11 @@ TEST_CASE("DWG polyline2d_line_R14: deep + verbose", "[.dwg_polyR14]") {
 TEST_CASE("DWG Cover.dwg: verbose reader trace", "[.dwg_cover_verbose]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg/Cover.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("Cover.dwg not present; skipping");
-    return;
+    SKIP("Cover.dwg not present; skipping");
   }
   std::cout << "\n=== Cover.dwg (verbose) ===\n";
   const DwgResult r = readDwg(path, /*verbose=*/true);
@@ -2669,13 +2638,11 @@ TEST_CASE("DWG Cover.dwg: verbose reader trace", "[.dwg_cover_verbose]") {
 TEST_CASE("DWG verbose: example_*.dwg in ~/doc/dwg3/", "[.dwg3_verbose]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set");
-    return;
+    SKIP("HOME not set");
   }
   const std::string dir = std::string(home) + "/doc/dwg3/";
   if (!std::filesystem::is_directory(dir)) {
-    SUCCEED("~/doc/dwg3/ not found");
-    return;
+    SKIP("~/doc/dwg3/ not found");
   }
   const char *names[] = {
       "example_2007.dwg",
@@ -2704,13 +2671,11 @@ TEST_CASE("DWG verbose: example_*.dwg in ~/doc/dwg3/", "[.dwg3_verbose]") {
 TEST_CASE("DWG corpus: load all files in ~/doc/dwg3/", "[.dwg3]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string dir = std::string(home) + "/doc/dwg3/";
   if (!std::filesystem::is_directory(dir)) {
-    SUCCEED("~/doc/dwg3/ not found; skipping");
-    return;
+    SKIP("~/doc/dwg3/ not found; skipping");
   }
 
   std::vector<std::string> paths;
@@ -2727,8 +2692,7 @@ TEST_CASE("DWG corpus: load all files in ~/doc/dwg3/", "[.dwg3]") {
   }
   std::sort(paths.begin(), paths.end());
   if (paths.empty()) {
-    SUCCEED("No .dwg files in ~/doc/dwg3/; skipping");
-    return;
+    SKIP("No .dwg files in ~/doc/dwg3/; skipping");
   }
 
   std::cout << "\n"
@@ -2764,13 +2728,11 @@ TEST_CASE("DWG corpus: load all files in ~/doc/dwg3/", "[.dwg3]") {
 TEST_CASE("DWG makeall-plus.dwg: deep coverage diagnostic", "[.dwg_makeall]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg3/makeall-plus.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("makeall-plus.dwg not present; skipping");
-    return;
+    SKIP("makeall-plus.dwg not present; skipping");
   }
 
   // Counts EVERY delivery path, including those the shared TypeTrackingIface
@@ -2856,13 +2818,11 @@ TEST_CASE("DWG corpus: load all files in ~/doc/dwg2/",
           "[.slow][dwg][corpus]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string dir = std::string(home) + "/doc/dwg2/";
   if (!std::filesystem::is_directory(dir)) {
-    SUCCEED("~/doc/dwg2/ not found; skipping");
-    return;
+    SKIP("~/doc/dwg2/ not found; skipping");
   }
 
   std::vector<std::string> paths;
@@ -2882,8 +2842,7 @@ TEST_CASE("DWG corpus: load all files in ~/doc/dwg2/",
   std::sort(paths.begin(), paths.end());
 
   if (paths.empty()) {
-    SUCCEED("No .dwg files found in ~/doc/dwg2/; skipping");
-    return;
+    SKIP("No .dwg files found in ~/doc/dwg2/; skipping");
   }
 
   std::cout << "\n"
@@ -2925,14 +2884,12 @@ TEST_CASE("DWG Architectural-Modern-Building-Design: hatch parsing",
           "[.dwg_arch_hatch]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg2/Architectural-Modern-Building-Design.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("Architectural-Modern-Building-Design.dwg not present; skipping");
-    return;
+    SKIP("Architectural-Modern-Building-Design.dwg not present; skipping");
   }
 
   const DeepResult dr = readDwgDeep(path);
@@ -2966,14 +2923,12 @@ TEST_CASE("DWG Architectural-Modern-Building-Design: hatch fill pipeline",
           "[.dwg_arch_hatch_fill]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg2/Architectural-Modern-Building-Design.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("Architectural-Modern-Building-Design.dwg not present; skipping");
-    return;
+    SKIP("Architectural-Modern-Building-Design.dwg not present; skipping");
   }
 
   HatchFillIface iface;
@@ -3043,13 +2998,11 @@ TEST_CASE("DWG Sport-Man-Signs: SOLID hatches render with positive area",
           "[.dwg_sport_signs]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg2/Sport-Man-Signs.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("Sport-Man-Signs.dwg not present; skipping");
-    return;
+    SKIP("Sport-Man-Signs.dwg not present; skipping");
   }
 
   HatchFillIface iface;
@@ -3152,14 +3105,12 @@ TEST_CASE("DWG Sport-Man-Signs: SOLID hatches render with positive area",
 TEST_CASE("DWG trolley_structure: entity population", "[.dwg_trolley]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg2/trolley_structure.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("trolley_structure.dwg not present; skipping");
-    return;
+    SKIP("trolley_structure.dwg not present; skipping");
   }
 
   const DeepResult dr = readDwgDeep(path);
@@ -3209,14 +3160,12 @@ TEST_CASE("DWG trolley_structure: entity population", "[.dwg_trolley]") {
 TEST_CASE("DWG gear_pump_subassy: entity population", "[.dwg_gear_pump]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg2/gear_pump_subassy.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("gear_pump_subassy.dwg not present; skipping");
-    return;
+    SKIP("gear_pump_subassy.dwg not present; skipping");
   }
 
   const DeepResult dr = readDwgDeep(path);
@@ -3285,13 +3234,11 @@ TEST_CASE("DWG gear_pump_subassy: entity population", "[.dwg_gear_pump]") {
 TEST_CASE("DWG lever_detail: entity population", "[.dwg_lever]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg2/lever_detail.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("lever_detail.dwg not present; skipping");
-    return;
+    SKIP("lever_detail.dwg not present; skipping");
   }
 
   const DeepResult dr = readDwgDeep(path);
@@ -3385,13 +3332,11 @@ TEST_CASE("DWG lever_detail: filter pipeline + visibility audit",
           "[.dwg_lever_filter]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg2/lever_detail.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("lever_detail.dwg not present; skipping");
-    return;
+    SKIP("lever_detail.dwg not present; skipping");
   }
 
   // Bootstrap a minimal Qt app context so RS_Graphic ctor's
@@ -3535,14 +3480,12 @@ TEST_CASE("DWG gear_pump_subassy: filter pipeline + block routing audit",
           "[.dwg_gear_pump_filter]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg2/gear_pump_subassy.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("gear_pump_subassy.dwg not present; skipping");
-    return;
+    SKIP("gear_pump_subassy.dwg not present; skipping");
   }
 
   static int qargc = 1;
@@ -3701,20 +3644,17 @@ TEST_CASE("DWG lever_detail: XREF resolution embeds external geometry",
           "[.dwg_lever_xref_resolve]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string hostPath = std::string(home) + "/doc/dwg2/lever_detail.dwg";
   const std::string xrefPath =
       std::string(home) + "/doc/dwg2/gripper_assembly_new.dwg";
   if (!std::filesystem::is_regular_file(hostPath)) {
-    SUCCEED("lever_detail.dwg not present; skipping");
-    return;
+    SKIP("lever_detail.dwg not present; skipping");
   }
   if (!std::filesystem::is_regular_file(xrefPath)) {
-    SUCCEED("gripper_assembly_new.dwg (XREF source) not present; "
+    SKIP("gripper_assembly_new.dwg (XREF source) not present; "
             "skipping");
-    return;
   }
 
   static int qargc = 1;
@@ -3879,14 +3819,12 @@ TEST_CASE("DWG gripper_assembly_new: XREF source population",
           "[.dwg_gripper_xref]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg2/gripper_assembly_new.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("gripper_assembly_new.dwg not present; skipping");
-    return;
+    SKIP("gripper_assembly_new.dwg not present; skipping");
   }
   const DeepResult dr = readDwgDeep(path);
   REQUIRE(dr.ok);
@@ -4050,13 +3988,11 @@ TEST_CASE("DWG lever_detail: per-block entity delivery",
           "[.dwg_lever_blocks]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg2/lever_detail.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("lever_detail.dwg not present; skipping");
-    return;
+    SKIP("lever_detail.dwg not present; skipping");
   }
 
   BlockTrackingIface iface;
@@ -4140,14 +4076,12 @@ TEST_CASE("DWG lever_detail: per-block entity delivery",
 TEST_CASE("DWG gear_pump_subassy: ATTRIB pipeline", "[.dwg_gear_pump_attrib]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg2/gear_pump_subassy.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("gear_pump_subassy.dwg not present; skipping");
-    return;
+    SKIP("gear_pump_subassy.dwg not present; skipping");
   }
 
   HatchFillIface iface;
@@ -4178,14 +4112,12 @@ TEST_CASE("DWG gear_pump_subassy: ATTRIB pipeline", "[.dwg_gear_pump_attrib]") {
 TEST_CASE("DWG House-Dwgfree.com_-1: entity population", "[.dwg_house]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg2/House-Dwgfree.com_-1.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("House-Dwgfree.com_-1.dwg not present; skipping");
-    return;
+    SKIP("House-Dwgfree.com_-1.dwg not present; skipping");
   }
 
   const DeepResult dr = readDwgDeep(path);
@@ -4219,13 +4151,11 @@ TEST_CASE("DWG House-Dwgfree.com_-1: entity population", "[.dwg_house]") {
 TEST_CASE("DWG pump_wheel: entity population", "[.dwg_pump_wheel]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg2/pump_wheel.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("pump_wheel.dwg not present; skipping");
-    return;
+    SKIP("pump_wheel.dwg not present; skipping");
   }
 
   const DeepResult dr = readDwgDeep(path);
@@ -4259,14 +4189,12 @@ TEST_CASE("DWG pump_wheel: entity population", "[.dwg_pump_wheel]") {
 TEST_CASE("DWG robot_handling_cell: entity population", "[.dwg_robot]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg2/robot_handling_cell.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("robot_handling_cell.dwg not present; skipping");
-    return;
+    SKIP("robot_handling_cell.dwg not present; skipping");
   }
 
   const DeepResult dr = readDwgDeep(path);
@@ -4303,20 +4231,17 @@ TEST_CASE("DWG robot_handling_cell: filter pipeline + XREF embed",
           "[.dwg_robot_filter]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg2/robot_handling_cell.dwg";
   const std::string xrefPath =
       std::string(home) + "/doc/dwg2/gripper_assembly_new.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("robot_handling_cell.dwg not present; skipping");
-    return;
+    SKIP("robot_handling_cell.dwg not present; skipping");
   }
   if (!std::filesystem::is_regular_file(xrefPath)) {
-    SUCCEED("gripper_assembly_new.dwg not present; skipping");
-    return;
+    SKIP("gripper_assembly_new.dwg not present; skipping");
   }
 
   static int qargc = 1;
@@ -4366,14 +4291,12 @@ TEST_CASE("DWG robot_handling_cell: negative extrusion arc placement",
           "[.dwg_robot_arc_ext]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg2/robot_handling_cell.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("robot_handling_cell.dwg not present; skipping");
-    return;
+    SKIP("robot_handling_cell.dwg not present; skipping");
   }
 
   struct ArcProbe : public DRW_Interface {
@@ -5022,13 +4945,11 @@ TEST_CASE("DWG 2带尺寸图库: entities near (120,35220)",
           "[.dwg_chicun_near]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg4/2带尺寸图库.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
 
   static int qargc = 1;
@@ -5236,13 +5157,11 @@ TEST_CASE("DWG 2带尺寸图库: block-local geometry near (1.026,301.026)",
           "[.dwg_chicun_blocklocal]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg4/2带尺寸图库.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
 
   constexpr double kDimScale = 117.0;
@@ -5437,13 +5356,11 @@ TEST_CASE("DWG 2带尺寸图库: deng1 circles at insert point (84004,115511)",
           "[.dwg_chicun_circle]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg4/2带尺寸图库.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
 
   Deng1RawIface rawIface;
@@ -5768,13 +5685,11 @@ TEST_CASE("DWG 2带尺寸图库: entities near (-774805.88,588320.79)",
           "[.dwg_chicun_stray]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg4/2带尺寸图库.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
 
   static int qargc = 1;
@@ -5955,13 +5870,11 @@ TEST_CASE("DWG 2带尺寸图库: entities near (52984.74,222052.06)",
           "[.dwg_chicun_stray2]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg4/2带尺寸图库.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
 
   static int qargc = 1;
@@ -6141,13 +6054,11 @@ TEST_CASE("DWG 2带尺寸图库: entities near (-294315.21,48571.66)",
           "[.dwg_chicun_stray3]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg4/2带尺寸图库.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
 
   static int qargc = 1;
@@ -6296,13 +6207,11 @@ TEST_CASE("DWG 2带尺寸图库: entities near stray WCS triple",
           "[.dwg_chicun_stray4]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg4/2带尺寸图库.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
 
   static int qargc = 1;
@@ -6556,13 +6465,11 @@ TEST_CASE("DWG 2带尺寸图库: entities near stray WCS triple (neg X)",
           "[.dwg_chicun_stray5]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg4/2带尺寸图库.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
 
   static int qargc = 1;
@@ -6753,13 +6660,11 @@ TEST_CASE("DWG 2带尺寸图库: entities near (-2230355.08,1646735.10)",
           "[.dwg_chicun_stray6]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg4/2带尺寸图库.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
 
   static int qargc = 1;
@@ -6907,13 +6812,11 @@ TEST_CASE("DWG 2带尺寸图库: entities near (-2230420.44,1646754.55)",
           "[.dwg_chicun_stray7]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg4/2带尺寸图库.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
 
   static int qargc = 1;
@@ -7060,8 +6963,7 @@ TEST_CASE("DWG 2带尺寸图库: entities near (-2230420.44,1646754.55)",
 TEST_CASE("DWG 2带尺寸图库: stray8 broad diagnostic",
           "[.dwg_chicun_stray8_diag]") {
   if (chicun::fixturePath().empty()) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
   chicun::ensureTestApp();
   RS_Graphic graphic;
@@ -7206,8 +7108,7 @@ TEST_CASE("DWG 2带尺寸图库: stray8 broad diagnostic",
 TEST_CASE("DWG 2带尺寸图库: stray8 after GUI onLoadingCompleted",
           "[.dwg_chicun_stray8_gui]") {
   if (chicun::fixturePath().empty()) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
   chicun::ensureTestApp();
   RS_Graphic graphic;
@@ -7231,8 +7132,7 @@ TEST_CASE("DWG 2带尺寸图库: stray8 after GUI onLoadingCompleted",
 TEST_CASE("DWG 2带尺寸图库: stray8 nearest-on-arc snap distance",
           "[.dwg_chicun_stray8_snap]") {
   if (chicun::fixturePath().empty()) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
   chicun::ensureTestApp();
   RS_Graphic graphic;
@@ -7270,13 +7170,11 @@ TEST_CASE("DWG 2带尺寸图库: entities near (-1099671.57,492101.30)",
           "[.dwg_chicun_stray8]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg4/2带尺寸图库.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
 
   static int qargc = 1;
@@ -7423,8 +7321,7 @@ TEST_CASE("DWG 2带尺寸图库: entities near (-1099671.57,492101.30)",
 TEST_CASE("DWG 2带尺寸图库: 015 insert transform audit",
           "[.dwg_chicun_015_audit]") {
   if (chicun::fixturePath().empty()) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
   chicun::ensureTestApp();
   RS_Graphic graphic;
@@ -7497,8 +7394,7 @@ TEST_CASE("DWG 2带尺寸图库: 015 insert transform audit",
 TEST_CASE("DWG 2带尺寸图库: LNG-13 wipeout insert audit",
           "[.dwg_chicun_lng13_audit]") {
   if (chicun::fixturePath().empty()) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
   chicun::ensureTestApp();
   RS_Graphic graphic;
@@ -7615,13 +7511,11 @@ TEST_CASE("DWG 2带尺寸图库: LNG-13 wipeout insert audit",
 TEST_CASE("DWG ACEB10: resolved bbox audit", "[.dwg_aceb10_bbox]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path = std::string(home) + "/doc/dwg3/ACEB10.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("ACEB10.dwg not present; skipping");
-    return;
+    SKIP("ACEB10.dwg not present; skipping");
   }
   chicun::ensureTestApp();
   RS_Graphic graphic;
@@ -7868,8 +7762,7 @@ TEST_CASE("DWG ACEB10: resolved bbox audit", "[.dwg_aceb10_bbox]") {
 TEST_CASE("DWG 2带尺寸图库: CUSH sofa insert chain diagnostic",
           "[.dwg_chicun_cush_diag]") {
   if (chicun::fixturePath().empty()) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
   chicun::ensureTestApp();
   RS_Graphic graphic;
@@ -7970,14 +7863,12 @@ TEST_CASE("DWG 全国通用节点详细解析: libdxfrw + filter load",
           "[.dwg_jiedian]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg4/全国通用节点详细解析.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
 
   dwgR reader(path.c_str());
@@ -8032,13 +7923,11 @@ TEST_CASE("DWG 全国通用节点详细解析: libdxfrw + filter load",
 TEST_CASE("DWG corpus: WIPEOUT entity inventory", "[.dwg_wipeout]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string dir = std::string(home) + "/doc/dwg2/";
   if (!std::filesystem::is_directory(dir)) {
-    SUCCEED("~/doc/dwg2/ not found; skipping");
-    return;
+    SKIP("~/doc/dwg2/ not found; skipping");
   }
 
   int totalWipeouts = 0;
@@ -8090,8 +7979,7 @@ TEST_CASE("DWG corpus: WIPEOUT entity inventory", "[.dwg_wipeout]") {
 TEST_CASE("DWG corpus: MULTILEADER entity inventory", "[.dwg_mleader]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::array<std::string, 2> dirs = {
       std::string(home) + "/doc/dwg/",  // primary corpus (has the
@@ -8155,8 +8043,7 @@ TEST_CASE("DWG visualstyle probe: count R2010+ visual-style flag triggers",
           "[.dwg_visualstyle_probe]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set");
-    return;
+    SKIP("HOME not set");
   }
 
   struct Witness {
@@ -8252,8 +8139,7 @@ TEST_CASE("DWG acdbcolor probe: count DBCOLOR objects + resolved entity refs",
           "[.dwg_acdbcolor_probe]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set");
-    return;
+    SKIP("HOME not set");
   }
 
   // Custom interface that counts DBCOLOR objects via addDbColor and
@@ -8386,14 +8272,12 @@ TEST_CASE("DWG acdbcolor: book color load + dbColor object inventory",
           "[.dwg_acdbcolor]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set");
-    return;
+    SKIP("HOME not set");
   }
   const std::string path =
       std::string(home) + "/doc/dwg2/Architectural-Modern-Building-Design.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("witness file not present; skipping");
-    return;
+    SKIP("witness file not present; skipping");
   }
 
   int dbColors = 0;
@@ -8439,8 +8323,7 @@ TEST_CASE("DWG acdbcolor: layer colorName probe",
           "[.dwg_acdbcolor_layer_probe]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set");
-    return;
+    SKIP("HOME not set");
   }
 
   class LayerColorIface : public TypeTrackingIface {
@@ -8533,8 +8416,7 @@ TEST_CASE("DWG plotsettings probe: count PLOTSETTINGS objects per file",
           "[.dwg_plotsettings_probe]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set");
-    return;
+    SKIP("HOME not set");
   }
 
   class PlotSettingsIface : public TypeTrackingIface {
@@ -8617,8 +8499,7 @@ TEST_CASE("DWG transparency probe: count entities with ENC alpha set",
           "[.dwg_transparency_probe]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set");
-    return;
+    SKIP("HOME not set");
   }
 
   class TransparencyIface : public TypeTrackingIface {
@@ -8815,14 +8696,12 @@ TEST_CASE("DWG hatch field parity: gradient + seed points populate",
           "[.dwg_hatch_fields]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/doc/dwg2/Architectural-Modern-Building-Design.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("Architectural-Modern-Building-Design.dwg not present; skipping");
-    return;
+    SKIP("Architectural-Modern-Building-Design.dwg not present; skipping");
   }
 
   FieldCaptureIface iface;
@@ -8868,13 +8747,11 @@ TEST_CASE("DWG dimension field parity: measureValue + flipArrow populate",
           "[.dwg_dim_fields]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string dir = std::string(home) + "/doc/dwg2/";
   if (!std::filesystem::is_directory(dir)) {
-    SUCCEED("DWG corpus directory not found; skipping");
-    return;
+    SKIP("DWG corpus directory not found; skipping");
   }
 
   int filesScanned = 0;
@@ -8927,13 +8804,11 @@ TEST_CASE("DWG pre-R13 detection: ~/doc/dwg3/block.dwg classifies AC2.10",
           "[.dwg_pre_r13]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set");
-    return;
+    SKIP("HOME not set");
   }
   const std::string path = std::string(home) + "/doc/dwg3/block.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("~/doc/dwg3/block.dwg not found");
-    return;
+    SKIP("~/doc/dwg3/block.dwg not found");
   }
   const DwgResult r = readDwg(path);
   CHECK_FALSE(r.ok);
@@ -8952,15 +8827,13 @@ TEST_CASE("DWG arch_multileaders: deep fidelity probe",
           "[.dwg_arch_mleader_probe]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set");
-    return;
+    SKIP("HOME not set");
   }
   const std::string path =
       std::string(home) +
       "/doc/dwg/architectural_-_annotation_scaling_and_multileaders.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("file not present; skipping");
-    return;
+    SKIP("file not present; skipping");
   }
 
   class Probe : public TypeTrackingIface {
@@ -9202,15 +9075,13 @@ TEST_CASE("DWG arch_multileaders: MLEADER body parser fidelity",
           "[.slow][dwg][corpus][mleader]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set");
-    return;
+    SKIP("HOME not set");
   }
   const std::string path =
       std::string(home) +
       "/doc/dwg/architectural_-_annotation_scaling_and_multileaders.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
 
   struct Snap {
@@ -9359,15 +9230,13 @@ TEST_CASE("DWG arch_multileaders: SCALE table delivery",
           "[.slow][dwg][corpus][scale]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set");
-    return;
+    SKIP("HOME not set");
   }
   const std::string path =
       std::string(home) +
       "/doc/dwg/architectural_-_annotation_scaling_and_multileaders.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
 
   class ScaleIface : public TypeTrackingIface {
@@ -9439,8 +9308,7 @@ TEST_CASE("DWG Mechanical and Annotative: object-context data delivery",
     }
   }
   if (path.empty()) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
 
   class ObjectContextIface : public TypeTrackingIface {
@@ -9502,15 +9370,13 @@ TEST_CASE("DWG arch_multileaders: OBJECTS metadata delivery",
           "[.slow][dwg][corpus][objects]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set");
-    return;
+    SKIP("HOME not set");
   }
   const std::string path =
       std::string(home) +
       "/doc/dwg/architectural_-_annotation_scaling_and_multileaders.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("fixture not present; skipping");
-    return;
+    SKIP("fixture not present; skipping");
   }
 
   class MetadataIface : public TypeTrackingIface {
@@ -9615,15 +9481,13 @@ TEST_CASE("DWG ACAD_TABLE entities render through anonymous table blocks",
           "[.slow][dwg][corpus][acad_table]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping ACAD_TABLE corpus test");
-    return;
+    SKIP("HOME not set; skipping ACAD_TABLE corpus test");
   }
 
   const std::string path =
       std::string(home) + "/doc/dwg/blocks_and_tables_-_metric.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("DWG table corpus file not found at " << path << "; skipping");
-    return;
+    SKIP("DWG table corpus file not found at " << path << "; skipping");
   }
 
   struct TableProbe : CountingIface {
@@ -9698,8 +9562,7 @@ TEST_CASE("DWG R2004 multi-page section (AcDbObjects at 3 x 0x7400) reads",
   // load that yields entities proves the multi-page (k x maxSize) buffer model.
   DwgResult r;
   if (!readSample("arc_2004.dwg", r)) {
-    SUCCEED("~/dev/dwg_samples/arc_2004.dwg absent; skipping multi-page pin");
-    return;
+    SKIP("~/dev/dwg_samples/arc_2004.dwg absent; skipping multi-page pin");
   }
   CHECK(r.error == DRW::BAD_NONE);
   CHECK(r.version == DRW::AC1018);
@@ -9713,8 +9576,7 @@ TEST_CASE("DWG R2010 CLASSES content past page uSize decodes",
   // uSize (the old uSize cap zeroed the string stream -> BAD_READ_CLASSES).
   DwgResult r;
   if (!readSample("arc_2010.dwg", r)) {
-    SUCCEED("~/dev/dwg_samples/arc_2010.dwg absent; skipping past-uSize pin");
-    return;
+    SKIP("~/dev/dwg_samples/arc_2010.dwg absent; skipping past-uSize pin");
   }
   CHECK(r.error == DRW::BAD_NONE);
   CHECK(r.version == DRW::AC1024);
@@ -9725,8 +9587,7 @@ TEST_CASE("DWG R2013 reads (dwgReader27 inherits the buffer-model fixes)",
           "[dwg][r2013][buffermodel]") {
   DwgResult r;
   if (!readSample("arc_2013.dwg", r)) {
-    SUCCEED("~/dev/dwg_samples/arc_2013.dwg absent; skipping R2013 pin");
-    return;
+    SKIP("~/dev/dwg_samples/arc_2013.dwg absent; skipping R2013 pin");
   }
   CHECK(r.error == DRW::BAD_NONE);
   CHECK(r.version == DRW::AC1027);
@@ -9896,8 +9757,7 @@ TEST_CASE("DWG R2013 writer round-trips a zero-source POINTCLOUD",
 TEST_CASE("LibreDWG reads a valid AC1027 POINTCLOUD container",
           "[.slow][dwg][r2013][pointcloud][external]") {
   if (std::system("command -v dwgread >/dev/null 2>&1") != 0) {
-    SUCCEED("dwgread is unavailable; external-reader gate skipped");
-    return;
+    SKIP("dwgread is unavailable; external-reader gate skipped");
   }
 
   const auto path = std::filesystem::temp_directory_path()
@@ -9936,8 +9796,7 @@ TEST_CASE("LibreDWG reads a valid AC1027 POINTCLOUD container",
 TEST_CASE("LibreDWG reads a valid AC1027 POINTCLOUDEX container",
           "[.slow][dwg][r2013][pointcloud][external]") {
   if (std::system("command -v dwgread >/dev/null 2>&1") != 0) {
-    SUCCEED("dwgread is unavailable; external-reader gate skipped");
-    return;
+    SKIP("dwgread is unavailable; external-reader gate skipped");
   }
 
   const auto path = std::filesystem::temp_directory_path()
@@ -10937,8 +10796,7 @@ TEST_CASE("DWG R2007 writer is readable by libreDWG",
     }
   }
   if (executable.empty()) {
-    SUCCEED("libreDWG dwgread not available; skipping cross-tool gate");
-    return;
+    SKIP("libreDWG dwgread not available; skipping cross-tool gate");
   }
 
   const auto path = std::filesystem::temp_directory_path()
@@ -10979,7 +10837,7 @@ TEST_CASE("DWG R2007 writer is readable by libreDWG",
 TEST_CASE("DWG R13/R14/R2000 sample files read OK (BLOCKS-walk regression)",
           "[.slow][dwg][r2000][blockswalk][corpus]") {
   const char* home = std::getenv("HOME");
-  if (!home) { SUCCEED("no HOME"); return; }
+  if (!home) { SKIP("no HOME"); return; }
   struct Want { const char* file; DRW::Version ver; };
   const Want wants[] = {
     {"example_r13.dwg",  DRW::AC1012},
@@ -11005,7 +10863,7 @@ TEST_CASE("DWG R13/R14/R2000 sample files read OK (BLOCKS-walk regression)",
     CHECK(r.entities >= 1);
   }
   if (checked == 0)
-    SUCCEED("~/doc/dwg{,2,3} canonical samples absent; skipping BLOCKS-walk pin");
+    SKIP("~/doc/dwg{,2,3} canonical samples absent; skipping BLOCKS-walk pin");
 }
 
 
@@ -11019,7 +10877,7 @@ TEST_CASE("DWG R13/R14/R2000 sample files read OK (BLOCKS-walk regression)",
 TEST_CASE("DWG coverage scan: aggregate skip telemetry across corpus",
           "[.coverage]") {
   const char* home = std::getenv("HOME");
-  if (!home) { SUCCEED("no HOME"); return; }
+  if (!home) { SKIP("no HOME"); return; }
   std::map<std::string, std::size_t> skippedClasses, skippedObjects;
   std::map<std::string, int> handledTypes;
   int files = 0, okFiles = 0;
@@ -11046,7 +10904,7 @@ TEST_CASE("DWG coverage scan: aggregate skip telemetry across corpus",
       } catch (...) {}
     }
   }
-  if (files == 0) { SUCCEED("~/doc/dwg{,2,3} absent; skipping coverage scan"); return; }
+  if (files == 0) { SKIP("~/doc/dwg{,2,3} absent; skipping coverage scan"); return; }
   auto dump = [](const char* title, std::map<std::string, std::size_t> m) {
     std::vector<std::pair<std::string, std::size_t>> v(m.begin(), m.end());
     std::sort(v.begin(), v.end(),
@@ -11068,7 +10926,7 @@ TEST_CASE("DWG coverage scan: aggregate skip telemetry across corpus",
 // divergence). Counts EVERY delivery path. Run: ./librecad_tests "[.audit]" -s
 TEST_CASE("DWG corpus audit: per-file TSV vs oracle", "[.audit]") {
   const char* home = std::getenv("HOME");
-  if (!home) { SUCCEED("no HOME"); return; }
+  if (!home) { SKIP("no HOME"); return; }
   struct AuditIface : public TypeTrackingIface {
     int meshes = 0, modelerGeoms = 0, unsupported = 0;
     void addMesh(const DRW_Mesh& e) override { trackT(e, "MESH"); ++meshes; }
@@ -11123,7 +10981,7 @@ TEST_CASE("DWG corpus audit: per-file TSV vs oracle", "[.audit]") {
 // it must deliver geometry. Skip-when-absent (corpus is developer-local).
 TEST_CASE("DWG MESH decoded + delivered, not skipped", "[.dwg_readback_corpus]") {
   const char* home = std::getenv("HOME");
-  if (!home) { SUCCEED("no HOME"); return; }
+  if (!home) { SKIP("no HOME"); return; }
   struct MeshProbe : public TypeTrackingIface {
     int meshCount = 0;
     std::size_t meshVertices = 0, meshFaces = 0;
@@ -11166,7 +11024,7 @@ TEST_CASE("DWG MESH decoded + delivered, not skipped", "[.dwg_readback_corpus]")
       } catch (...) {}
     }
   }
-  if (!anyFile) { SUCCEED("~/doc/dwg{,2,3} absent; skipping MESH probe"); return; }
+  if (!anyFile) { SKIP("~/doc/dwg{,2,3} absent; skipping MESH probe"); return; }
   std::cerr << "\nMESH probe: meshCount=" << meshCount << " vertices=" << meshVerts
             << " filesStillSkippingMESH=" << filesStillSkippingMesh << "\n";
   std::cerr << "PROXY probe: decodedPrimitives=" << proxyPrims
@@ -11705,9 +11563,9 @@ TEST_CASE("proxy op16/18/23 attribute resolution", "[proxy]") {
 // range.  Ground truth baked from the oracle cross-check on gripper.dwg.
 TEST_CASE("proxy attr layer-order oracle pin", "[.dwg_proxy_attr]") {
   const char* home = std::getenv("HOME");
-  if (!home) { SUCCEED("no HOME"); return; }
+  if (!home) { SKIP("no HOME"); return; }
   const std::string f = std::string(home) + "/doc/dwg2/gripper.dwg";
-  if (!std::filesystem::exists(f)) { SUCCEED("gripper.dwg absent"); return; }
+  if (!std::filesystem::exists(f)) { SKIP("gripper.dwg absent"); return; }
   TypeTrackingIface iface;
   dwgR reader(f.c_str());
   REQUIRE(reader.read(&iface, true));
@@ -11728,16 +11586,14 @@ TEST_CASE("proxy attr layer-order oracle pin", "[.dwg_proxy_attr]") {
 TEST_CASE("DWG pre-R13: read AC1009/R11 entities section") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping pre-R13 test");
-    return;
+    SKIP("HOME not set; skipping pre-R13 test");
   }
   const std::string dir =
       std::string(home) + "/dev/libredwg/test/test-data/r11/";
   const std::string path = dir + "entities-2d.dwg";
   std::ifstream probe(path, std::ios::binary);
   if (!probe.good()) {
-    SUCCEED("pre-R13 corpus absent; skipping");
-    return;
+    SKIP("pre-R13 corpus absent; skipping");
   }
   probe.close();
 
@@ -11761,13 +11617,11 @@ struct R11LineCollector : public CountingIface {
 TEST_CASE("DWG pre-R13: map R11 3DLINE to DRW_Line") {
   const std::string path = libredwgFixturePath("r11", "entities-3d.dwg");
   if (path.empty()) {
-    SUCCEED("pre-R13 corpus root absent; skipping");
-    return;
+    SKIP("pre-R13 corpus root absent; skipping");
   }
   std::ifstream probe(path, std::ios::binary);
   if (!probe.good()) {
-    SUCCEED("entities-3d.dwg absent; skipping");
-    return;
+    SKIP("entities-3d.dwg absent; skipping");
   }
   probe.close();
 
@@ -11824,14 +11678,13 @@ struct DimCollector : public CountingIface {
 TEST_CASE("DWG pre-R13: R11 typed DIMENSION (LINEAR + ALIGNED)") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   SECTION("entities-2d.dwg — 1 ALIGNED dim, no double-render") {
     const std::string path =
         std::string(home) + "/dev/libredwg/test/test-data/r11/entities-2d.dwg";
     std::ifstream probe(path, std::ios::binary);
-    if (!probe.good()) { SUCCEED("entities-2d.dwg absent"); return; }
+    if (!probe.good()) { SKIP("entities-2d.dwg absent"); return; }
     probe.close();
     DimCollector iface;
     const DwgResult r = readDwg(path, /*verbose=*/false, &iface);
@@ -11863,7 +11716,7 @@ TEST_CASE("DWG pre-R13: R11 typed DIMENSION (LINEAR + ALIGNED)") {
     const std::string path =
         std::string(home) + "/dev/libredwg/test/test-data/r11/ACEB10.dwg";
     std::ifstream probe(path, std::ios::binary);
-    if (!probe.good()) { SUCCEED("ACEB10.dwg absent"); return; }
+    if (!probe.good()) { SKIP("ACEB10.dwg absent"); return; }
     probe.close();
     DimCollector iface;
     const DwgResult r = readDwg(path, /*verbose=*/false, &iface);
@@ -11919,13 +11772,11 @@ TEST_CASE("DWG pre-R13: R11/R10 SHAPE style_id + ATTDEF/ATTRIB rotation") {
                           DRW::Version expectVer) {
     const std::string path = libredwgFixturePath(release, file);
     if (path.empty()) {
-      SUCCEED("pre-R13 corpus root absent; skipping");
-      return;
+      SKIP("pre-R13 corpus root absent; skipping");
     }
     std::ifstream probe(path, std::ios::binary);
     if (!probe.good()) {
-      SUCCEED(std::string(file) + " absent; skipping");
-      return;
+      SKIP(std::string(file) + " absent; skipping");
     }
     probe.close();
 
@@ -11996,15 +11847,13 @@ struct R10LineCollector : public CountingIface {
 TEST_CASE("DWG pre-R13: read AC1006/R10 entities section") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping pre-R13 R10 test");
-    return;
+    SKIP("HOME not set; skipping pre-R13 R10 test");
   }
   const std::string path =
       std::string(home) + "/dev/libredwg/test/test-data/r10/entities.dwg";
   std::ifstream probe(path, std::ios::binary);
   if (!probe.good()) {
-    SUCCEED("pre-R13 R10 corpus absent; skipping");
-    return;
+    SKIP("pre-R13 R10 corpus absent; skipping");
   }
   probe.close();
 
@@ -12094,14 +11943,13 @@ struct HdrCollector : public CountingIface {
 TEST_CASE("DWG pre-R13: R11 header variables decode") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   SECTION("entities-2d.dwg (defaults — minimal coverage)") {
     const std::string path =
         std::string(home) + "/dev/libredwg/test/test-data/r11/entities-2d.dwg";
     std::ifstream probe(path, std::ios::binary);
-    if (!probe.good()) { SUCCEED("entities-2d.dwg absent"); return; }
+    if (!probe.good()) { SKIP("entities-2d.dwg absent"); return; }
     probe.close();
     HdrCollector iface;
     const DwgResult r = readDwg(path, /*verbose=*/false, &iface);
@@ -12147,7 +11995,7 @@ TEST_CASE("DWG pre-R13: R11 header variables decode") {
     const std::string path =
         std::string(home) + "/dev/libredwg/test/test-data/r11/ACEB10.dwg";
     std::ifstream probe(path, std::ios::binary);
-    if (!probe.good()) { SUCCEED("ACEB10.dwg absent"); return; }
+    if (!probe.good()) { SKIP("ACEB10.dwg absent"); return; }
     probe.close();
     HdrCollector iface;
     const DwgResult r = readDwg(path, /*verbose=*/false, &iface);
@@ -12170,16 +12018,14 @@ TEST_CASE("DWG pre-R13: R11 header variables decode") {
 TEST_CASE("DWG pre-R13: R11 LAYER/LTYPE/STYLE table records") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   SECTION("entities-2d.dwg (minimal: 2 layers, 1 ltype, 2 styles)") {
     const std::string path =
         std::string(home) + "/dev/libredwg/test/test-data/r11/entities-2d.dwg";
     std::ifstream probe(path, std::ios::binary);
     if (!probe.good()) {
-      SUCCEED("entities-2d.dwg absent");
-      return;
+      SKIP("entities-2d.dwg absent");
     }
     probe.close();
     R11TableCollector iface;
@@ -12210,8 +12056,7 @@ TEST_CASE("DWG pre-R13: R11 LAYER/LTYPE/STYLE table records") {
         std::string(home) + "/dev/libredwg/test/test-data/r11/ACEB10.dwg";
     std::ifstream probe(path, std::ios::binary);
     if (!probe.good()) {
-      SUCCEED("ACEB10.dwg absent");
-      return;
+      SKIP("ACEB10.dwg absent");
     }
     probe.close();
     R11TableCollector iface;
@@ -12256,11 +12101,11 @@ TEST_CASE("DWG pre-R13: R11 LAYER/LTYPE/STYLE table records") {
 TEST_CASE("DWG pre-R13: ACEB10 resolves $DWGCODEPAGE = ANSI_1252",
           "[dwg][prer13][codepage]") {
   const char *home = getenv("HOME");
-  if (!home) { SUCCEED("HOME not set; skipping"); return; }
+  if (!home) { SKIP("HOME not set; skipping"); return; }
   const std::string path =
       std::string(home) + "/dev/libredwg/test/test-data/r11/ACEB10.dwg";
   std::ifstream probe(path, std::ios::binary);
-  if (!probe.good()) { SUCCEED("ACEB10.dwg absent"); return; }
+  if (!probe.good()) { SKIP("ACEB10.dwg absent"); return; }
   probe.close();
   CountingIface iface;
   dwgR reader(path.c_str());
@@ -12279,15 +12124,13 @@ TEST_CASE("DWG pre-R13: ACEB10 resolves $DWGCODEPAGE = ANSI_1252",
 TEST_CASE("DWG pre-R13: R10 LAYER/LTYPE/STYLE table records + header") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping");
-    return;
+    SKIP("HOME not set; skipping");
   }
   const std::string path =
       std::string(home) + "/dev/libredwg/test/test-data/r10/entities.dwg";
   std::ifstream probe(path, std::ios::binary);
   if (!probe.good()) {
-    SUCCEED("pre-R13 R10 corpus absent; skipping");
-    return;
+    SKIP("pre-R13 R10 corpus absent; skipping");
   }
   probe.close();
   SECTION("table records (used field absent in R10)") {
@@ -12357,7 +12200,7 @@ TEST_CASE("DWG pre-R13: R10 LAYER/LTYPE/STYLE table records + header") {
 // adjustOffsetControls → forcedCalculateBorders) vs zoomAuto
 // (LC_GraphicViewport::zoomAuto → calculateBorders).
 TEST_CASE("DWG chicun WNS2 drivers", "[.dwg_chicun_wns2]") {
-  if (chicun::fixturePath().empty()) { SUCCEED("skip"); return; }
+  if (chicun::fixturePath().empty()) { SKIP("skip"); return; }
   chicun::ensureTestApp();
   RS_Graphic graphic;
   REQUIRE(chicun::importFixture(graphic));

--- a/librecad/src/lib/filters/tests/dwg_tarch_tests.cpp
+++ b/librecad/src/lib/filters/tests/dwg_tarch_tests.cpp
@@ -474,8 +474,7 @@ void printEntityReport(const std::string &filename, const EntityValidationIface 
 TEST_CASE("DWG tArch: validate all entities", "[.dwg_tarch]") {
   const std::filesystem::path manifest = "D:/data/dli/doc/dwg_files.txt";
   if (!std::filesystem::is_regular_file(manifest)) {
-    SUCCEED("DWG manifest not found at " << manifest << "; skipping tArch tests");
-    return;
+    SKIP("DWG manifest not found at " << manifest << "; skipping tArch tests");
   }
 
   std::vector<std::string> paths;
@@ -495,8 +494,7 @@ TEST_CASE("DWG tArch: validate all entities", "[.dwg_tarch]") {
   std::sort(paths.begin(), paths.end());
 
   if (paths.empty()) {
-    SUCCEED("No valid .dwg files found in manifest; skipping");
-    return;
+    SKIP("No valid .dwg files found in manifest; skipping");
   }
 
   std::cout << "\n"
@@ -553,8 +551,7 @@ TEST_CASE("DWG tArch: validate all entities", "[.dwg_tarch]") {
 TEST_CASE("DWG tArch: deep validation of selected files", "[.dwg_tarch_deep]") {
   const std::string dir = LIBRECAD_TEST_DIR "/tarch/";
   if (!std::filesystem::is_directory(dir)) {
-    SUCCEED("DWG directory not found; skipping deep tArch tests");
-    return;
+    SKIP("DWG directory not found; skipping deep tArch tests");
   }
 
   const char *targets[] = {
@@ -620,8 +617,7 @@ TEST_CASE("DWG tArch: VIEWPORT preserved as replayable raw carrier",
           "[dwg_tarch_viewport][viewport]") {
   const std::string path = LIBRECAD_TEST_DIR "/tarch/t1.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("t1.dwg fixture not found; skipping");
-    return;
+    SKIP("t1.dwg fixture not found; skipping");
   }
 
   ViewportRawCaptureIface iface;

--- a/librecad/src/lib/filters/tests/dwg_write_smoke_tests.cpp
+++ b/librecad/src/lib/filters/tests/dwg_write_smoke_tests.cpp
@@ -4664,8 +4664,7 @@ TEST_CASE(
   const std::filesystem::path fixture = findFixture(
       "librecad/src/lib/filters/tests/testdata/blockvisibility.dwg");
   if (!std::filesystem::is_regular_file(fixture)) {
-    SUCCEED("blockvisibility.dwg fixture absent; skipping");
-    return;
+    SKIP("blockvisibility.dwg fixture absent; skipping");
   }
   REQUIRE(std::filesystem::file_size(fixture) == 38641u);
 
@@ -14074,8 +14073,7 @@ TEST_CASE(
   const std::string sourcePath =
       std::string(LIBRECAD_TEST_DIR) + "/datatable_r2010.dwg";
   if (!std::filesystem::is_regular_file(sourcePath)) {
-    SUCCEED("datatable_r2010.dwg fixture absent; skipping");
-    return;
+    SKIP("datatable_r2010.dwg fixture absent; skipping");
   }
 
   RS_Graphic source;
@@ -19662,8 +19660,7 @@ TEST_CASE("RS_FilterDXFRW retains final DWG reports for source graphs",
   const auto source =
       std::filesystem::path(LIBRECAD_TEST_DIR) / "visualstyle_r2007.dwg";
   if (!std::filesystem::is_regular_file(source)) {
-    SUCCEED("visualstyle_r2007.dwg fixture absent; skipping");
-    return;
+    SKIP("visualstyle_r2007.dwg fixture absent; skipping");
   }
   RS_Graphic graphic;
   RS_FilterDXFRW filter;
@@ -27712,7 +27709,7 @@ TEST_CASE("DWG ordinary ENC source fixtures preserve names and handle order",
     const std::filesystem::path path =
         std::filesystem::path(LIBRECAD_TEST_DIR) / fixture.name;
     if (!std::filesystem::is_regular_file(path)) {
-      SUCCEED("ordinary ENC fixture absent; skipping: " << fixture.name);
+      SKIP("ordinary ENC fixture absent; skipping: " << fixture.name);
       continue;
     }
 
@@ -29964,7 +29961,7 @@ TEST_CASE("DWG cross-tool readback: libreDWG decodes typed 3DLINE",
 
   const ReadbackResult result = dwgReadbackMinJson(path);
   if (!result.found) {
-    SUCCEED("DWGREAD minJSON unavailable; skipping typed 3DLINE readback gate");
+    SKIP("DWGREAD minJSON unavailable; skipping typed 3DLINE readback gate");
     std::remove(path.c_str());
     return;
   }
@@ -29994,8 +29991,7 @@ TEST_CASE("DWG cross-tool readback: libreDWG dwgread decodes libdxfrw output",
     }
     ReadbackResult r = dwgReadback(path);
     if (!r.found) {
-      SUCCEED("dwgread absent; skipping cross-tool readback gate");
-      return;
+      SKIP("dwgread absent; skipping cross-tool readback gate");
     }
     INFO(v.tag << " dwgread output:\n" << r.output);
     CHECK(r.ok);
@@ -30016,8 +30012,7 @@ TEST_CASE("DWG cross-tool readback: LibreDWG decodes typed SECTION objects",
   const ReadbackResult result = dwgReadbackMinJson(path);
   if (!result.found) {
     std::remove(path.c_str());
-    SUCCEED("DWGREAD minJSON unavailable; skipping Section readback gate");
-    return;
+    SKIP("DWGREAD minJSON unavailable; skipping Section readback gate");
   }
 
   INFO("dwgread output:\n" << result.output);
@@ -30055,8 +30050,7 @@ TEST_CASE(
   const ReadbackResult result = dwgReadbackMinJson(path);
   if (!result.found) {
     std::remove(path.c_str());
-    SUCCEED("DWGREAD absent; skipping embedded ATTRIB cross-tool gate");
-    return;
+    SKIP("DWGREAD absent; skipping embedded ATTRIB cross-tool gate");
   }
 
   INFO(result.output);
@@ -30089,8 +30083,7 @@ TEST_CASE("DWG cross-tool readback: libreDWG decodes user-block compounds",
   const ReadbackResult result = dwgReadbackMinJson(path);
   if (!result.found) {
     std::remove(path.c_str());
-    SUCCEED("DWGREAD absent; skipping user-block compound cross-tool gate");
-    return;
+    SKIP("DWGREAD absent; skipping user-block compound cross-tool gate");
   }
 
   INFO(result.output);
@@ -30167,8 +30160,7 @@ TEST_CASE(
   const ReadbackResult result = dwgReadbackMinJson(path);
   if (!result.found) {
     std::remove(path.c_str());
-    SUCCEED("DWGREAD absent; skipping legacy INSERT cross-tool gate");
-    return;
+    SKIP("DWGREAD absent; skipping legacy INSERT cross-tool gate");
   }
 
   INFO(result.output);
@@ -30200,8 +30192,7 @@ TEST_CASE("DWG cross-tool readback: libreDWG decodes native MLEADER",
   const ReadbackResult result = dwgReadbackMinJson(path);
   if (!result.found) {
     std::remove(path.c_str());
-    SUCCEED("DWGREAD absent; skipping native MLEADER cross-tool gate");
-    return;
+    SKIP("DWGREAD absent; skipping native MLEADER cross-tool gate");
   }
 
   INFO(result.output);
@@ -30233,8 +30224,7 @@ TEST_CASE("DWG cross-tool readback: libreDWG decodes native MLEADERSTYLE",
   const ReadbackResult result = dwgReadbackMinJson(path);
   if (!result.found) {
     std::remove(path.c_str());
-    SUCCEED("DWGREAD absent; skipping native MLEADERSTYLE cross-tool gate");
-    return;
+    SKIP("DWGREAD absent; skipping native MLEADERSTYLE cross-tool gate");
   }
 
   INFO(result.output);
@@ -30269,8 +30259,7 @@ TEST_CASE("DWG cross-tool readback: libreDWG decodes native MESH",
   const ReadbackResult result = dwgReadbackMinJson(path);
   if (!result.found) {
     std::remove(path.c_str());
-    SUCCEED("DWGREAD absent; skipping native MESH cross-tool gate");
-    return;
+    SKIP("DWGREAD absent; skipping native MESH cross-tool gate");
   }
 
   INFO(result.output);
@@ -30302,8 +30291,7 @@ TEST_CASE("DWG cross-tool readback: libreDWG decodes WIPEOUTVARIABLES",
   const ReadbackResult result = dwgReadbackMinJson(path);
   if (!result.found) {
     std::remove(path.c_str());
-    SUCCEED("DWGREAD absent; skipping WIPEOUTVARIABLES cross-tool gate");
-    return;
+    SKIP("DWGREAD absent; skipping WIPEOUTVARIABLES cross-tool gate");
   }
 
   INFO(result.output);
@@ -30338,8 +30326,7 @@ TEST_CASE("DWG cross-tool readback: libreDWG decodes native LIGHT",
   const ReadbackResult result = dwgReadbackMinJson(path);
   if (!result.found) {
     std::remove(path.c_str());
-    SUCCEED("DWGREAD absent; skipping LIGHT cross-tool gate");
-    return;
+    SKIP("DWGREAD absent; skipping LIGHT cross-tool gate");
   }
 
   INFO(result.output);
@@ -30373,8 +30360,7 @@ TEST_CASE("DWG cross-tool readback: libreDWG decodes native CAMERA",
   const ReadbackResult result = dwgReadbackMinJson(path);
   if (!result.found) {
     std::remove(path.c_str());
-    SUCCEED("DWGREAD absent; skipping CAMERA cross-tool gate");
-    return;
+    SKIP("DWGREAD absent; skipping CAMERA cross-tool gate");
   }
 
   INFO(result.output);
@@ -30411,8 +30397,7 @@ TEST_CASE("DWG cross-tool readback: libreDWG decodes native DBCOLOR",
   const ReadbackResult result = dwgReadbackMinJson(path);
   if (!result.found) {
     std::remove(path.c_str());
-    SUCCEED("DWGREAD absent; skipping DBCOLOR cross-tool gate");
-    return;
+    SKIP("DWGREAD absent; skipping DBCOLOR cross-tool gate");
   }
 
   INFO(path);
@@ -30464,8 +30449,7 @@ TEST_CASE("DWG cross-tool readback: libreDWG decodes native MATERIAL",
   const ReadbackResult result = dwgReadbackMinJson(path);
   if (!result.found) {
     std::remove(path.c_str());
-    SUCCEED("DWGREAD absent; skipping MATERIAL cross-tool gate");
-    return;
+    SKIP("DWGREAD absent; skipping MATERIAL cross-tool gate");
   }
 
   INFO(result.output);
@@ -30550,8 +30534,7 @@ TEST_CASE("DWG cross-tool readback: libreDWG decodes native LIGHTLIST",
   const ReadbackResult result = dwgReadbackMinJson(path);
   if (!result.found) {
     std::remove(path.c_str());
-    SUCCEED("DWGREAD absent; skipping LIGHTLIST cross-tool gate");
-    return;
+    SKIP("DWGREAD absent; skipping LIGHTLIST cross-tool gate");
   }
 
   INFO(result.output);
@@ -30589,8 +30572,7 @@ TEST_CASE("DWG cross-tool readback: libreDWG decodes ordinary ENC LINE records",
     const ReadbackResult result = dwgReadbackMinJson(path);
     if (!result.found) {
       std::remove(path.c_str());
-      SUCCEED("DWGREAD absent; skipping ordinary ENC cross-tool gate");
-      return;
+      SKIP("DWGREAD absent; skipping ordinary ENC cross-tool gate");
     }
 
     INFO(result.output);
@@ -30628,8 +30610,7 @@ TEST_CASE("DWG cross-tool readback: libreDWG decodes native VISUALSTYLE",
   const ReadbackResult result = dwgReadbackMinJson(path);
   if (!result.found) {
     std::remove(path.c_str());
-    SUCCEED("dwgread absent; skipping VISUALSTYLE cross-tool gate");
-    return;
+    SKIP("dwgread absent; skipping VISUALSTYLE cross-tool gate");
   }
 
   INFO(result.output);
@@ -30671,8 +30652,7 @@ TEST_CASE("DWG cross-tool readback: libreDWG decodes native GEODATA",
   const ReadbackResult result = dwgReadbackMinJson(path);
   if (!result.found) {
     std::remove(path.c_str());
-    SUCCEED("dwgread absent; skipping GEODATA cross-tool gate");
-    return;
+    SKIP("dwgread absent; skipping GEODATA cross-tool gate");
   }
 
   INFO(result.output);
@@ -30724,8 +30704,7 @@ TEST_CASE("DWG typed class ordinals survive a GEODATA collision",
   const ReadbackResult result = dwgReadbackMinJson(path);
   if (!result.found) {
     std::remove(path.c_str());
-    SUCCEED("dwgread absent; skipping GEODATA collision readback gate");
-    return;
+    SKIP("dwgread absent; skipping GEODATA collision readback gate");
   }
 
   INFO(result.output);
@@ -30833,8 +30812,7 @@ TEST_CASE("DWG cross-tool: VIEWPORT raw carrier round-trips through dwgread",
           "[.dwg_readback][viewport]") {
   const std::string src = std::string(LIBRECAD_TEST_DIR) + "/tarch/t1.dwg";
   if (!std::filesystem::is_regular_file(src)) {
-    SUCCEED("t1.dwg fixture not found; skipping");
-    return;
+    SKIP("t1.dwg fixture not found; skipping");
   }
 
   // 1) Read t1.dwg (AC1027) and capture the 2 VIEWPORT (type 34) carriers.
@@ -30877,8 +30855,7 @@ TEST_CASE("DWG cross-tool: VIEWPORT raw carrier round-trips through dwgread",
   const std::string json = vpDwgreadJson(out);
   std::remove(out.c_str());
   if (json.empty()) {
-    SUCCEED("dev dwgread not available; skipping cross-tool assertion");
-    return;
+    SKIP("dev dwgread not available; skipping cross-tool assertion");
   }
   REQUIRE(json != "\x01"); // dwgread ran without fatal error
   CHECK(vpCountSubstr(json, "\"entity\": \"VIEWPORT\"") == 2u);

--- a/librecad/src/lib/filters/tests/dxf_corpus_tests.cpp
+++ b/librecad/src/lib/filters/tests/dxf_corpus_tests.cpp
@@ -308,14 +308,12 @@ TEST_CASE("DXF corpus: round-trip ~/dev/dwg_samples/*.dxf to a tmp dir",
   ensureSettings();
   const char *home = std::getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping DXF corpus round-trip");
-    return;
+    SKIP("HOME not set; skipping DXF corpus round-trip");
   }
   const std::filesystem::path src = std::filesystem::path(home) / "dev" / "dwg_samples";
   const auto files = listByExt(src, ".dxf");
   if (files.empty()) {
-    SUCCEED("no DXF samples at " << src.string() << "; skipping");
-    return;
+    SKIP("no DXF samples at " << src.string() << "; skipping");
   }
 
   const std::filesystem::path outDir =
@@ -352,8 +350,7 @@ TEST_CASE("DWG corpus: convert ~/doc/dwg{,2}/*.dwg to DXF in a tmp dir",
   ensureSettings();
   const char *home = std::getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set; skipping DWG corpus conversion");
-    return;
+    SKIP("HOME not set; skipping DWG corpus conversion");
   }
   std::vector<std::filesystem::path> files;
   for (const char *sub : {"doc/dwg", "doc/dwg2"}) {
@@ -361,8 +358,7 @@ TEST_CASE("DWG corpus: convert ~/doc/dwg{,2}/*.dwg to DXF in a tmp dir",
     files.insert(files.end(), found.begin(), found.end());
   }
   if (files.empty()) {
-    SUCCEED("no DWG samples at ~/doc/dwg{,2}; skipping");
-    return;
+    SKIP("no DWG samples at ~/doc/dwg{,2}; skipping");
   }
 
   const std::filesystem::path outDir =
@@ -409,8 +405,7 @@ TEST_CASE("[jsondump] libdxfrw JSON dump emits canonical entities", "[jsondump]"
                 "test-data" / "r11" / "entities-2d.dwg"
           : std::filesystem::path{};
   if (fixture.empty() || !std::filesystem::exists(fixture)) {
-    SUCCEED("entities-2d.dwg fixture absent; skipping [jsondump] self-test");
-    return;
+    SKIP("entities-2d.dwg fixture absent; skipping [jsondump] self-test");
   }
 
   std::ostringstream oss;

--- a/librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
+++ b/librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
@@ -1475,8 +1475,7 @@ TEST_CASE("DXF filter preserves fixture-backed BLOCK_RECORD preview chunks",
   std::filesystem::remove(out);
   std::filesystem::remove(out2);
   if (!std::filesystem::is_regular_file(src)) {
-    SUCCEED("block_record_preview_r2007.dxf fixture absent; skipping");
-    return;
+    SKIP("block_record_preview_r2007.dxf fixture absent; skipping");
   }
   CHECK(recordGroupValues(src, "BLOCK_RECORD", "310")
         == std::vector<std::string>{"414243", "DE"});
@@ -1522,8 +1521,7 @@ TEST_CASE("DXF filter preserves fixture-backed EED binary items",
   std::filesystem::remove(out);
   std::filesystem::remove(out2);
   if (!std::filesystem::is_regular_file(src)) {
-    SUCCEED("eed_binary_r2007.dxf fixture absent; skipping");
-    return;
+    SKIP("eed_binary_r2007.dxf fixture absent; skipping");
   }
   CHECK(recordGroupValues(src, "POINT", "1004")
         == std::vector<std::string>{"0102", "A0B1C2"});
@@ -1588,8 +1586,7 @@ TEST_CASE("DXF filter preserves fixture-backed CLASS and raw entity",
   std::filesystem::remove(out);
   std::filesystem::remove(out2);
   if (!std::filesystem::is_regular_file(src)) {
-    SUCCEED("classes_raw_entity_r2007.dxf fixture absent; skipping");
-    return;
+    SKIP("classes_raw_entity_r2007.dxf fixture absent; skipping");
   }
   CHECK(recordGroupValues(src, "CLASS", "91")
         == std::vector<std::string>{"7"});
@@ -1671,8 +1668,7 @@ TEST_CASE("DXF filter preserves fixture-backed raw control groups and remaps 481
   std::filesystem::remove(out);
   std::filesystem::remove(out2);
   if (!std::filesystem::is_regular_file(src)) {
-    SUCCEED("raw_control_groups_r2007.dxf fixture absent; skipping");
-    return;
+    SKIP("raw_control_groups_r2007.dxf fixture absent; skipping");
   }
 
   const auto values = [](const DxfRecordGroups& groups, const char* code) {

--- a/librecad/src/lib/filters/tests/dynblock_tests.cpp
+++ b/librecad/src/lib/filters/tests/dynblock_tests.cpp
@@ -176,8 +176,7 @@ TEST_CASE("DWG dynamic-block family decodes typed (makeall-plus / AC1032)",
           "[dwg][dynblock][parity][fixture]") {
   const std::string path = std::string(LIBRECAD_TEST_DIR) + "/dynblock_r2018.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("dynblock_r2018.dwg fixture not found; skipping");
-    return;
+    SKIP("dynblock_r2018.dwg fixture not found; skipping");
   }
 
   DynBlockCapture cap;

--- a/librecad/src/lib/filters/tests/evalgraph_tests.cpp
+++ b/librecad/src/lib/filters/tests/evalgraph_tests.cpp
@@ -143,8 +143,7 @@ TEST_CASE("DWG EVALUATION_GRAPH decodes on R2004 / AC1018 (<=AC1018 inline handl
           "[dwg][evalgraph][parity][fixture]") {
   const std::string path = std::string(LIBRECAD_TEST_DIR) + "/evalgraph_r2004.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("evalgraph_r2004.dwg fixture not found; skipping");
-    return;
+    SKIP("evalgraph_r2004.dwg fixture not found; skipping");
   }
 
   EvalGraphCapture cap;
@@ -186,8 +185,7 @@ TEST_CASE("DWG EVALUATION_GRAPH still decodes on R2018 / AC1032 (no >AC1018 regr
   // dynamic-block suite) as an R2018 EVALUATION_GRAPH carrier.
   const std::string path = std::string(LIBRECAD_TEST_DIR) + "/dynblock_r2018.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("dynblock_r2018.dwg fixture not found; skipping");
-    return;
+    SKIP("dynblock_r2018.dwg fixture not found; skipping");
   }
 
   EvalGraphCapture cap;

--- a/librecad/src/lib/filters/tests/helix_tests.cpp
+++ b/librecad/src/lib/filters/tests/helix_tests.cpp
@@ -339,8 +339,7 @@ TEST_CASE("LibreDWG 2007 HELIX DXF fixture reads through addHelix",
   const std::string path =
       "D:/data/dli/libredwg/test/test-data/2007/Helix.dxf";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("LibreDWG 2007 Helix.dxf fixture not found; skipping");
-    return;
+    SKIP("LibreDWG 2007 Helix.dxf fixture not found; skipping");
   }
 
   HelixCapture cap;

--- a/librecad/src/lib/filters/tests/large_radial_dim_dwg_tests.cpp
+++ b/librecad/src/lib/filters/tests/large_radial_dim_dwg_tests.cpp
@@ -182,8 +182,7 @@ TEST_CASE("DWG LARGE_RADIAL_DIMENSION decodes via parseDwg with DXF-consistent f
           "[dwg][dimension][large_radial]") {
   const std::string path = std::string(LIBRECAD_TEST_DIR) + "/large_radial.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("large_radial.dwg fixture not found; skipping");
-    return;
+    SKIP("large_radial.dwg fixture not found; skipping");
   }
 
   LargeRadialDwgCapture cap;

--- a/librecad/src/lib/filters/tests/mline_tests.cpp
+++ b/librecad/src/lib/filters/tests/mline_tests.cpp
@@ -455,13 +455,11 @@ TEST_CASE("DWG smoke: Multiline.dwg delivers >= 1 MLINE entity",
           "[.dwg_mline_probe]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set");
-    return;
+    SKIP("HOME not set");
   }
   const std::string path = std::string(home) + "/doc/dwg3/Multiline.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("~/doc/dwg3/Multiline.dwg not found");
-    return;
+    SKIP("~/doc/dwg3/Multiline.dwg not found");
   }
   MLineCapture capture;
   dwgR reader(path.c_str());

--- a/librecad/src/lib/filters/tests/mpolygon_dwg_tests.cpp
+++ b/librecad/src/lib/filters/tests/mpolygon_dwg_tests.cpp
@@ -138,8 +138,7 @@ TEST_CASE("DWG MPOLYGON is read into a DRW_MPolygon via parseDwg",
   const std::string path =
       std::string(LIBRECAD_TEST_DIR) + "/mpolygon_solid.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("mpolygon_solid.dwg fixture not found; skipping");
-    return;
+    SKIP("mpolygon_solid.dwg fixture not found; skipping");
   }
 
   MPolygonDwgCapture cap;

--- a/librecad/src/lib/filters/tests/objectcontext_leader_tests.cpp
+++ b/librecad/src/lib/filters/tests/objectcontext_leader_tests.cpp
@@ -146,7 +146,7 @@ bool approx(double a, double b, double eps = 1e-6) {
 // asserts a clean read with no stream desync.
 bool tryRead(const std::string &path, ContextCapture &cap) {
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("fixture not found; skipping: " << path);
+    SKIP("fixture not found; skipping: " << path);
     return false;
   }
   dwgR reader(path.c_str());

--- a/librecad/src/lib/filters/tests/rtext_arctext_tests.cpp
+++ b/librecad/src/lib/filters/tests/rtext_arctext_tests.cpp
@@ -440,8 +440,7 @@ TEST_CASE("DWG RTEXT + ARCALIGNEDTEXT are read as text via parseDwg",
   const std::string path =
       std::string(LIBRECAD_TEST_DIR) + "/rtext_arctext.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("rtext_arctext.dwg fixture not found; skipping");
-    return;
+    SKIP("rtext_arctext.dwg fixture not found; skipping");
   }
 
   TextCapture cap;
@@ -489,8 +488,7 @@ TEST_CASE("DWG BYDD00301 sample reads cleanly with RTEXT/ARCALIGNEDTEXT dispatch
           "[.rtext_bydd]") {
   const std::string dir = "d:/data/dli/doc/dwg4";
   if (!std::filesystem::is_directory(dir)) {
-    SUCCEED("BYDD corpus directory not present; skipping");
-    return;
+    SKIP("BYDD corpus directory not present; skipping");
   }
   std::string path;
   for (const auto &e : std::filesystem::directory_iterator(dir)) {
@@ -502,8 +500,7 @@ TEST_CASE("DWG BYDD00301 sample reads cleanly with RTEXT/ARCALIGNEDTEXT dispatch
     }
   }
   if (path.empty()) {
-    SUCCEED("BYDD00301*.dwg not found; skipping");
-    return;
+    SKIP("BYDD00301*.dwg not found; skipping");
   }
 
   TextCapture cap;

--- a/librecad/src/lib/filters/tests/section_object_tests.cpp
+++ b/librecad/src/lib/filters/tests/section_object_tests.cpp
@@ -143,8 +143,7 @@ TEST_CASE("DWG SECTIONOBJECT (AcDbSection) decodes to typed DRW_Section",
   const std::string path =
       std::string(LIBRECAD_TEST_DIR) + "/section_object_r2018.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("section_object_r2018.dwg fixture absent; skipping");
-    return;
+    SKIP("section_object_r2018.dwg fixture absent; skipping");
   }
 
   SectionCapture cap;
@@ -186,8 +185,7 @@ TEST_CASE("DWG SECTION_SETTINGS decodes type and geometry settings",
   const std::string path =
       std::string(LIBRECAD_TEST_DIR) + "/section_object_r2018.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("section_object_r2018.dwg fixture absent; skipping");
-    return;
+    SKIP("section_object_r2018.dwg fixture absent; skipping");
   }
 
   SectionCapture cap;
@@ -239,15 +237,13 @@ TEST_CASE("DWG SECTION_SETTINGS decodes type and geometry settings",
 TEST_CASE("LibreDWG recognizes the Section object family",
           "[section_object][external][.slow]") {
   if (std::system("command -v dwgread >/dev/null 2>&1") != 0) {
-    SUCCEED("dwgread is unavailable; external-reader gate skipped");
-    return;
+    SKIP("dwgread is unavailable; external-reader gate skipped");
   }
 
   const std::filesystem::path fixture =
       std::string(LIBRECAD_TEST_DIR) + "/section_object_r2018.dwg";
   if (!std::filesystem::is_regular_file(fixture)) {
-    SUCCEED("section_object_r2018.dwg fixture absent; skipping");
-    return;
+    SKIP("section_object_r2018.dwg fixture absent; skipping");
   }
 
   const auto output = std::filesystem::temp_directory_path()

--- a/librecad/src/lib/filters/tests/underlay_tests.cpp
+++ b/librecad/src/lib/filters/tests/underlay_tests.cpp
@@ -475,13 +475,11 @@ TEST_CASE("DWG smoke: Underlay.dwg delivers >= 3 PDFUNDERLAY entities",
           "[.dwg_underlay_probe]") {
   const char *home = getenv("HOME");
   if (!home) {
-    SUCCEED("HOME not set");
-    return;
+    SKIP("HOME not set");
   }
   const std::string path = std::string(home) + "/doc/dwg3/Underlay.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("~/doc/dwg3/Underlay.dwg not found");
-    return;
+    SKIP("~/doc/dwg3/Underlay.dwg not found");
   }
   UnderlayCounter capture;
   dwgR reader(path.c_str());

--- a/librecad/src/lib/filters/tests/visualstyle_dwg_tests.cpp
+++ b/librecad/src/lib/filters/tests/visualstyle_dwg_tests.cpp
@@ -141,8 +141,7 @@ TEST_CASE("DWG VISUALSTYLE r2010b+r2013b body decodes (Point.dwg / AC1027)",
           "[dwg][visualstyle][parity]") {
   const std::string path = std::string(LIBRECAD_TEST_DIR) + "/visualstyle_r2013.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("visualstyle_r2013.dwg fixture not found; skipping");
-    return;
+    SKIP("visualstyle_r2013.dwg fixture not found; skipping");
   }
 
   VisualStyleCapture cap;
@@ -209,8 +208,7 @@ TEST_CASE("DWG VISUALSTYLE legacy body decodes (Point_1.dwg / AC1021)",
           "[dwg][visualstyle][parity]") {
   const std::string path = std::string(LIBRECAD_TEST_DIR) + "/visualstyle_r2007.dwg";
   if (!std::filesystem::is_regular_file(path)) {
-    SUCCEED("visualstyle_r2007.dwg fixture not found; skipping");
-    return;
+    SKIP("visualstyle_r2007.dwg fixture not found; skipping");
   }
 
   VisualStyleCapture cap;
@@ -219,8 +217,7 @@ TEST_CASE("DWG VISUALSTYLE legacy body decodes (Point_1.dwg / AC1021)",
     // section-name UTF-16 decode bug in dwgReader21::readMetaData) is now
     // fixed, so this normally reads and asserts the legacy-body decode below;
     // this branch only guards a missing/unreadable fixture.
-    SUCCEED("visualstyle_r2007.dwg: fixture unavailable");
-    return;
+    SKIP("visualstyle_r2007.dwg: fixture unavailable");
   }
   REQUIRE(cap.m_styles.size() >= 1);
 


### PR DESCRIPTION
Section 5 of the DWG/DXF improvement plan: make the suite honest about what it actually ran.

### The problem

297 call sites answered a missing fixture, a missing external tool or an unset `HOME` with `SUCCEED()`. A test that asserted nothing was therefore counted as a pass, so the suite looked green whether or not the data it needs is present, which is exactly the situation a reader would want flagged.

This matters because the DWG/DXF tests reference **588 distinct `.dwg` fixture names while 8 exist in the tree**. Most of the rest live only in a developer's local corpus.

### The change

Catch2 3.3 added `SKIP` for this. Converting those sites makes the state visible in the summary:

```
before:  test cases: 2398 | 2370 passed | 28 failed
after:   test cases: 2398 | 2301 passed | 28 failed | 69 skipped
```

That is measured on a machine that **does** have the developer corpus. On a machine without it the skipped count is much larger, and it is now reported instead of being hidden among the passes.

Only sites whose message names an unavailable resource were converted. `SUCCEED()` calls that genuinely mean "this audit completed with nothing to report" are left alone. The bare `return;` that followed each converted call is dropped, since `SKIP` already leaves the test.

### Behaviour

Nothing changes about what is checked: the same 32 assertions fail, in the same five files, in the same counts (24 `dwg_write_smoke`, 3 `underlay`, 3 `acad_table`, 1 `rs_hatch`, 1 `dxf_layer0_declared`). Only the line numbers move, because the dead `return;` lines are gone. Those 32 failures are pre-existing on `origin/master` and are addressed in #2798.
