### PR TITLE
Fix dxf2png/dxf2svg --outfile handling to match dxf2pdf and master

### DIFF
--- a/librecad/src/main/console_dxf2png.cpp
+++ b/librecad/src/main/console_dxf2png.cpp
@@ -129,7 +129,8 @@ int console_dxf2png(int argc, char* argv[])
     parser.addVersionOption();
 
     QCommandLineOption outFileOpt(QStringList() << "o" << "outfile",
-        "Output PNG file.", "file");
+        "Output file. Used as given; a relative path is resolved against the "
+        "current working directory.", "file");
     parser.addOption(outFileOpt);
 
     QCommandLineOption pngSizeOpt(QStringList() << "r" << "resolution",
@@ -168,12 +169,16 @@ int console_dxf2png(int argc, char* argv[])
     if(fn.isEmpty())
         fn = "unnamed";
 
-    // Set output filename from user input if present
+    // Set output filename from user input if present.
+    //
+    // --outfile is used as given, as dxf2pdf and master do: an absolute path
+    // lands where it says, a relative one resolves against the working
+    // directory. It used to be prefixed with the input file's directory,
+    // which turned an absolute path into an uncreatable
+    // "/input/dir/C:/tmp/out.png".
     QString outFile = parser.value(outFileOpt);
     if (outFile.isEmpty()) {
         outFile = dxfFileInfo.path() + "/" + fn + "." + args[0].mid(args[0].size()-3);
-    } else {
-        outFile = dxfFileInfo.path() + "/" + outFile;
     }
 
     // Open the file and process the graphics
@@ -215,7 +220,14 @@ int console_dxf2png(int argc, char* argv[])
                        black, bw);
     }
 
-    qDebug() << "Printing" << dxfFile << "to" << outFile << (ret ? "Done" : "Failed");
+    if (!ret) {
+        // Returning 0 here made a conversion that wrote nothing look like a
+        // success to any caller checking the exit status.
+        qCritical("ERROR: failed to write %s", qPrintable(outFile));
+        return 1;
+    }
+
+    qDebug() << "Printing" << dxfFile << "to" << outFile << "Done";
     return 0;
 }
 


### PR DESCRIPTION
Fixes #2801, on the `2.2.1` branch. Master already behaves correctly, as the reporter suspected; this brings the released line's two image converters in line with it and with `dxf2pdf`.

### The bug

`console_dxf2png()` serves both `dxf2png` and `dxf2svg`. It prefixed `--outfile` with the input file's directory unconditionally, so an absolute path became something like `/path/to/input/C:/tmp/out.png`. That cannot be created, the export failed, and the exit status ignored the failure and returned 0 regardless. The run reported success while writing nothing.

That second half is what makes it expensive to diagnose. `dxf2pdf`, in the same binary, uses `--outfile` as given, so a caller who validates their pipeline with PDF concludes absolute paths work and then gets empty results from PNG/SVG with a zero exit and nothing on stderr.

### The fix

- Use `--outfile` exactly as given. An absolute path lands where it says; a relative one resolves against the working directory, as `dxf2pdf` and master already do.
- Return a non-zero exit and report to stderr when the export fails, instead of always returning 0.

With no `--outfile`, the output keeps the input's base name beside the input file, which matches master's `defaultOutputPath()` when no output directory is given.

### Behaviour change on this branch

A relative `--outfile` used to resolve against the **input file's directory** and now resolves against the **working directory**. That is a deliberate alignment with master rather than an accident of the fix, so a 2.2.1.x script that passes a bare filename and then reads the result from beside the input will need to look in the working directory instead. The option's help text now states where the file goes.

### Verification

Built `2.2.1` with Qt 5 on macOS and ran the issue's reproduction, including its second measurement where the working directory differs from the input's directory. "Before" is the same binary built from the unmodified branch.

| case | before | after |
| --- | --- | --- |
| relative `--outfile` | beside the input | **working directory** |
| relative `sub/out.ext` | beside the input | working directory, under `sub/` |
| absolute `--outfile` | nothing written, exit 0 | file written, exit 0 |
| unwritable path | nothing written, exit 0 | `ERROR: failed to write …`, exit 1 |
| no `--outfile` | default name beside the input | unchanged |

Checked for both `dxf2svg` and `dxf2png`.

One note for the reporter: on this build `dxf2png` does write a real file (11 kB here), so the empty-output symptom was the path bug rather than anything specific to PNG encoding.
