### PR TITLE
Release the entities the preview paths do not adopt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2468,6 +2468,7 @@ if (BUILD_TESTS)
         librecad/src/lib/engine/document/entities/tests/lc_textbidi_tests.cpp
         librecad/src/lib/engine/document/entities/tests/rs_mtext_bidi_tests.cpp
         librecad/src/lib/engine/document/entities/tests/rs_text_bidi_tests.cpp
+        librecad/src/actions/drawing/modify/tests/lc_action_modify_round_tests.cpp
         librecad/src/lib/math/tests/rs_math_tests.cpp
         librecad/src/lib/math/tests/lc_quadratic_tests.cpp
         librecad/src/lib/creation/tests/rs_creation_null_entity_tests.cpp

--- a/librecad/src/actions/drawing/modify/lc_action_modify_round.cpp
+++ b/librecad/src/actions/drawing/modify/lc_action_modify_round.cpp
@@ -207,16 +207,14 @@ void LC_ActionModifyRound::onMouseMoveEvent(const int status, const LC_MouseEven
                                 previewEntityModifications(se, roundResult.trimmed2, roundResult.trimmingPoint2, roundResult.trim2Mode);
                             }
                         }
-                        if (m_actionData->data.trim && !roundResult.isPolyline){
-                            m_preview->removeEntity(roundResult.trimmed1);
-                            m_preview->removeEntity(roundResult.trimmed2);
-                        }
+                        bool previewOwnsArc = false;
 
                         const auto *arc = roundResult.round;
                         if (arc != nullptr){
                             if (m_showRefEntitiesOnPreview) {
                                 if (!roundResult.isPolyline) {
                                     previewEntity(arc);
+                                    previewOwnsArc = true;
                                 }
                             }
                             if (isInfoCursorForModificationEnabled()){
@@ -229,7 +227,19 @@ void LC_ActionModifyRound::onMouseMoveEvent(const int status, const LC_MouseEven
                             }
                         }
                         if (roundResult.isPolyline) {
+                            // The clone owns the arc and both trimmed segments,
+                            // so handing it to the preview hands over all three.
                             previewEntity(roundResult.polyline);
+                        }
+                        else {
+                            // round() hands back raw ownership and the batch it
+                            // filled in is a local that frees nothing, so what
+                            // the preview did not take is ours to release.
+                            delete roundResult.trimmed1;
+                            delete roundResult.trimmed2;
+                            if (!previewOwnsArc) {
+                                delete roundResult.round;
+                            }
                         }
                     }
 

--- a/librecad/src/actions/drawing/modify/tests/lc_action_modify_round_tests.cpp
+++ b/librecad/src/actions/drawing/modify/tests/lc_action_modify_round_tests.cpp
@@ -1,0 +1,215 @@
+/****************************************************************************
+**
+** This file is part of the LibreCAD project, a 2D CAD program
+**
+** Copyright (C) 2026 LibreCAD.org
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+**********************************************************************/
+
+// Ownership of what RS_Modification::round() builds during the fillet hover
+// preview (issue #2804).
+//
+// round() returns raw pointers to a new arc and to clones of both picked
+// entities, and registers them in the LC_DocumentModificationBatch it is
+// handed. On the hover path that batch is a local whose destructor frees
+// nothing, so every entity the preview does not adopt has to be released by
+// the action - otherwise each mouse move over a fillet target leaks. The two
+// m_preview->removeEntity() calls that used to stand in for this were no-ops:
+// the trimmed clones are never added to the preview, and removeEntity() only
+// deletes what the container actually holds.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+
+#include <QApplication>
+#include <QMouseEvent>
+
+#include "lc_action_modify_round.h"
+#include "lc_actioncontext.h"
+#include "rs_graphic.h"
+#include "rs_graphicview.h"
+#include "rs_line.h"
+#include "rs_settings.h"
+#include "rs_vector.h"
+
+namespace {
+
+/**
+ * Returns a QApplication, reusing the process-wide one if another test built it
+ * first. The pointer is deliberately leaked: only one QApplication may exist at
+ * a time and only one ~QApplication may run at exit.
+ */
+QApplication* application() {
+    static int argc = 1;
+    static char name[] = "librecad_tests";
+    static char* argv[] = {name, nullptr};
+    static QApplication* app = [] {
+        auto* existing = qobject_cast<QApplication*>(QCoreApplication::instance());
+        return existing != nullptr ? existing : new QApplication(argc, argv);
+    }();
+    static bool settingsReady = [] {
+        QCoreApplication::setOrganizationName("LibreCAD");
+        QCoreApplication::setApplicationName("LibreCAD-tests");
+        RS_Settings::init("LibreCAD", "LibreCAD-tests");
+        return true;
+    }();
+    (void)settingsReady;
+    return app;
+}
+
+/**
+ * A line that keeps count of how many of its clones are alive. round() clones
+ * the picked entities through RS_Entity::clone(), so overriding it here makes
+ * the clones the fillet preview produces observable: if the action drops one,
+ * the count never comes back down.
+ */
+class CountingLine : public RS_Line {
+public:
+    static int s_liveClones;
+
+    CountingLine(RS_EntityContainer* parent, const RS_LineData& d) : RS_Line(parent, d) {}
+
+    RS_Entity* clone() const override {
+        auto* copy = new CountingLine(*this);
+        copy->m_isClone = true;
+        ++s_liveClones;
+        return copy;
+    }
+
+    ~CountingLine() override {
+        if (m_isClone) {
+            --s_liveClones;
+        }
+    }
+
+private:
+    bool m_isClone{false};
+};
+
+int CountingLine::s_liveClones = 0;
+
+class RoundTestView final : public RS_GraphicView {
+public:
+    RoundTestView() : RS_GraphicView(nullptr) {}
+
+    int getWidth() const override { return 640; }
+    int getHeight() const override { return 480; }
+    void redraw([[maybe_unused]] RS2::RedrawMethod method = RS2::RedrawAll,
+                [[maybe_unused]] bool immediately = false) override {}
+    void adjustOffsetControls() override {}
+    void adjustZoomControls() override {}
+    void setMouseCursor([[maybe_unused]] RS2::CursorType cursor) override {}
+    void updateGridStatusWidget([[maybe_unused]] QString status) override {}
+};
+
+/**
+ * The action caches the first picked entity and acts on it in the mouse move
+ * handler, so the probe exposes that field plus the two framework halves that
+ * bracket every mouse move.
+ */
+class RoundProbe final : public LC_ActionModifyRound {
+public:
+    explicit RoundProbe(LC_ActionContext* actionContext) : LC_ActionModifyRound(actionContext) {}
+
+    using LC_ActionModifyRound::onMouseMoveEvent;
+    using LC_ActionModifyRound::m_entity1;
+    using LC_ActionModifyRound::SetEntity2;
+    using RS_ActionInterface::setStatus;
+    using RS_PreviewActionInterface::deletePreviewAndHighlights;
+    using RS_PreviewActionInterface::drawPreviewAndHighlights;
+};
+
+LC_MouseEvent eventAt(const double x, const double y) {
+    LC_MouseEvent e;
+    e.graphPoint = RS_Vector{x, y};
+    e.snapPoint = RS_Vector{x, y};
+    return e;
+}
+
+/**
+ * Member order matters: the action is destroyed before the view, because
+ * ~RS_PreviewActionInterface reaches into overlay containers the view owns.
+ */
+struct RoundFixture {
+    const bool m_qtReady{application() != nullptr};
+    RS_Graphic m_graphic;
+    RoundTestView m_view;
+    LC_ActionContext m_context;
+    std::unique_ptr<RoundProbe> m_action;
+
+    RoundFixture() {
+        m_graphic.initForNewDocument();
+        m_view.setDocument(&m_graphic);
+        m_context.setDocumentAndView(&m_graphic, &m_view);
+        m_action = std::make_unique<RoundProbe>(&m_context);
+    }
+
+    CountingLine* addLine(const RS_Vector& from, const RS_Vector& to) {
+        auto* line = new CountingLine(&m_graphic, RS_LineData{from, to});
+        m_graphic.addEntity(line);
+        return line;
+    }
+
+    /// One mouse move, in the order RS_PreviewActionInterface dispatches it.
+    void hover(const double x, const double y) {
+        m_action->deletePreviewAndHighlights();
+        LC_MouseEvent e = eventAt(x, y);
+        m_action->onMouseMoveEvent(RoundProbe::SetEntity2, &e);
+        m_action->drawPreviewAndHighlights();
+    }
+};
+
+} // namespace
+
+TEST_CASE("fillet hover preview releases the entities round() hands back",
+          "[modify][round][fillet]") {
+    RoundFixture f;
+    auto* first = f.addLine({0.0, 0.0}, {100.0, 0.0});
+    f.addLine({100.0, 0.0}, {100.0, 100.0});
+
+    f.m_action->setRadius(10.0);
+    f.m_action->setTrim(true);              // the shipped default
+    f.m_action->m_entity1 = first;
+    f.m_action->setStatus(RoundProbe::SetEntity2);
+
+    // Hover the second line, where round() produces a preview.
+    f.hover(100.0, 50.0);
+    const int afterFirstHover = CountingLine::s_liveClones;
+
+    for (int i = 0; i < 50; ++i) {
+        f.hover(100.0, 50.0);
+    }
+
+    // Each move clones both picked lines. Whatever the preview does not adopt
+    // is the action's to release, so the count must not grow with the number of
+    // mouse moves.
+    INFO("clones still alive after 50 further hover moves");
+    CHECK(CountingLine::s_liveClones == afterFirstHover);
+}
+
+TEST_CASE("a mouse move on a view without a relative point widget does not crash",
+          "[actions][graphicview]") {
+    // RS_GraphicView::isInRelativePointInput() is the first statement of every
+    // mouse move, and only QG_GraphicView ever creates the holder it reads.
+    RoundFixture f;
+    f.addLine({0.0, 0.0}, {100.0, 0.0});
+
+    QMouseEvent move(QEvent::MouseMove, QPointF(10.0, 10.0), QPointF(10.0, 10.0),
+                     Qt::NoButton, Qt::NoButton, Qt::NoModifier);
+    f.m_action->mouseMoveEvent(&move);
+    SUCCEED("dispatched a mouse move through a view with no relative point widget");
+}

--- a/librecad/src/actions/drawing/modify/tests/lc_action_modify_round_tests.cpp
+++ b/librecad/src/actions/drawing/modify/tests/lc_action_modify_round_tests.cpp
@@ -40,6 +40,7 @@
 
 #include "lc_action_modify_round.h"
 #include "lc_actioncontext.h"
+#include "rs_preview.h"
 #include "rs_graphic.h"
 #include "rs_graphicview.h"
 #include "rs_line.h"
@@ -72,35 +73,24 @@ QApplication* application() {
 }
 
 /**
- * A line that keeps count of how many of its clones are alive. round() clones
- * the picked entities through RS_Entity::clone(), so overriding it here makes
- * the clones the fillet preview produces observable: if the action drops one,
- * the count never comes back down.
+ * A line that keeps count of how many of its instances are alive, clones
+ * included. Entities reach these code paths either by RS_Entity::clone(), which
+ * this overrides, or by being built directly, and in both cases a dropped
+ * entity shows up as a count that never comes back down.
  */
 class CountingLine : public RS_Line {
 public:
-    static int s_liveClones;
+    static int s_live;
 
-    CountingLine(RS_EntityContainer* parent, const RS_LineData& d) : RS_Line(parent, d) {}
+    CountingLine(RS_EntityContainer* parent, const RS_LineData& d) : RS_Line(parent, d) { ++s_live; }
+    CountingLine(const CountingLine& other) : RS_Line(other) { ++s_live; }
 
-    RS_Entity* clone() const override {
-        auto* copy = new CountingLine(*this);
-        copy->m_isClone = true;
-        ++s_liveClones;
-        return copy;
-    }
+    RS_Entity* clone() const override { return new CountingLine(*this); }
 
-    ~CountingLine() override {
-        if (m_isClone) {
-            --s_liveClones;
-        }
-    }
-
-private:
-    bool m_isClone{false};
+    ~CountingLine() override { --s_live; }
 };
 
-int CountingLine::s_liveClones = 0;
+int CountingLine::s_live = 0;
 
 class RoundTestView final : public RS_GraphicView {
 public:
@@ -131,6 +121,7 @@ public:
     using RS_ActionInterface::setStatus;
     using RS_PreviewActionInterface::deletePreviewAndHighlights;
     using RS_PreviewActionInterface::drawPreviewAndHighlights;
+    using RS_PreviewActionInterface::m_preview;
 };
 
 LC_MouseEvent eventAt(const double x, const double y) {
@@ -188,7 +179,7 @@ TEST_CASE("fillet hover preview releases the entities round() hands back",
 
     // Hover the second line, where round() produces a preview.
     f.hover(100.0, 50.0);
-    const int afterFirstHover = CountingLine::s_liveClones;
+    const int afterFirstHover = CountingLine::s_live;
 
     for (int i = 0; i < 50; ++i) {
         f.hover(100.0, 50.0);
@@ -197,8 +188,8 @@ TEST_CASE("fillet hover preview releases the entities round() hands back",
     // Each move clones both picked lines. Whatever the preview does not adopt
     // is the action's to release, so the count must not grow with the number of
     // mouse moves.
-    INFO("clones still alive after 50 further hover moves");
-    CHECK(CountingLine::s_liveClones == afterFirstHover);
+    INFO("lines still alive after 50 further hover moves");
+    CHECK(CountingLine::s_live == afterFirstHover);
 }
 
 TEST_CASE("a mouse move on a view without a relative point widget does not crash",
@@ -212,4 +203,30 @@ TEST_CASE("a mouse move on a view without a relative point widget does not crash
                      Qt::NoButton, Qt::NoButton, Qt::NoModifier);
     f.m_action->mouseMoveEvent(&move);
     SUCCEED("dispatched a mouse move through a view with no relative point widget");
+}
+
+TEST_CASE("the preview releases entities it does not adopt past its cap",
+          "[preview][overlay]") {
+    // addAllFromList() is handed entities the caller has already built and
+    // expects the preview to take. It stops adding at m_maxEntities, so
+    // everything past the cap has to be released rather than dropped.
+    RoundFixture f;
+    RS_Preview* preview = f.m_action->m_preview.get();
+    const int cap = preview->getMaxAllowedEntities();
+    REQUIRE(cap > 0);
+
+    const int baseline = CountingLine::s_live;
+    const int count = cap + 50;
+
+    QList<RS_Entity*> handedOver;
+    for (int i = 0; i < count; ++i) {
+        handedOver.append(new CountingLine(nullptr, RS_LineData{{0.0, double(i)}, {1.0, double(i)}}));
+    }
+    REQUIRE(CountingLine::s_live == baseline + count);
+
+    preview->addAllFromList(handedOver);
+    preview->clear();
+
+    INFO("entities past the preview cap were neither adopted nor released");
+    CHECK(CountingLine::s_live == baseline);
 }

--- a/librecad/src/lib/engine/overlays/preview/rs_preview.cpp
+++ b/librecad/src/lib/engine/overlays/preview/rs_preview.cpp
@@ -207,26 +207,30 @@ void RS_Preview::addClonesFromList(const QList<RS_Entity*>& list) {
 void RS_Preview::addAllFromList(const QList<RS_Entity*>& list) {
     unsigned int c = 0;
     for (const auto e: list) {
+        if (e == nullptr) {
+            continue;
+        }
         if (c > m_maxEntities) {
-            break;
+            delete e;                       // adopted or released, never dropped
+            continue;
         }
-        if (e != nullptr) {
-            c += e->countDeep();
-            addEntity(e);
-        }
+        c += e->countDeep();
+        addEntity(e);
     }
 }
 
 void RS_Preview::addAllFromList(const std::list<RS_Entity*>& list) {
     unsigned int c = 0;
     for (const auto e: list) {
+        if (e == nullptr) {
+            continue;
+        }
         if (c > m_maxEntities) {
-            break;
+            delete e;
+            continue;
         }
-        if (e != nullptr) {
-            c += e->countDeep();
-            addEntity(e);
-        }
+        c += e->countDeep();
+        addEntity(e);
     }
 }
 

--- a/librecad/src/lib/engine/overlays/preview/rs_preview.h
+++ b/librecad/src/lib/engine/overlays/preview/rs_preview.h
@@ -63,6 +63,8 @@ public:
                          RS_Vector& worldCorner4) const;
     void addAllFrom(RS_EntityContainer& container, LC_GraphicViewport* view);
     void addClonesFromList(const QList<RS_Entity*>& list);
+    // Take ownership of every entity in the list. Entities past the preview
+    // limit are released rather than shown, so the caller must not reuse them.
     void addAllFromList(const QList<RS_Entity*>& list);
     void addAllFromList(const std::list<RS_Entity*>& list);
     void addStretchablesFrom(RS_EntityContainer& container, LC_GraphicViewport* view,

--- a/librecad/src/lib/gui/rs_graphicview.cpp
+++ b/librecad/src/lib/gui/rs_graphicview.cpp
@@ -453,5 +453,7 @@ void RS_GraphicView::restoreRelativeInputWidget() const {
 }
 
 bool RS_GraphicView::isInRelativePointInput() const {
-    return m_relativePointWidgetHolder->isVisible();
+    // Only QG_GraphicView creates the holder, so the base class cannot assume
+    // it exists. This is the first statement of every mouse move event.
+    return m_relativePointWidgetHolder != nullptr && m_relativePointWidgetHolder->isVisible();
 }

--- a/librecad/src/lib/modification/rs_modification.cpp
+++ b/librecad/src/lib/modification/rs_modification.cpp
@@ -1531,7 +1531,10 @@ bool RS_Modification::cut(const RS_Vector& cutCoord, RS_AtomicEntity* cutEntity,
             // interpolation spline can be closed
             // so we cannot use the default implementation
             // fixme - review cutting for spline points!!!!
-            cut2 = static_cast<LC_SplinePoints*>(cutEntity->clone())->cut(cutCoord);
+            // cut() returns a freshly allocated spline, never the receiver,
+            // so the clone it is called on has to be owned here.
+            const std::unique_ptr<RS_Entity> spline{cutEntity->clone()};
+            cut2 = static_cast<LC_SplinePoints*>(spline.get())->cut(cutCoord);
             cut1 = static_cast<RS_AtomicEntity*>(cutEntity->clone());
             break;
         }

--- a/librecad/src/lib/modification/tests/rs_modification_trim_tests.cpp
+++ b/librecad/src/lib/modification/tests/rs_modification_trim_tests.cpp
@@ -61,6 +61,10 @@ TEST_CASE("RS_Modification::trim does not cast a container limit entity",
     // The trim of the atomic entity is still allowed; only the container side is
     // declined, so nothing is produced for it.
     CHECK(result.trimmed2 == nullptr);
+
+    // trim() hands the clones it makes to the batch, whose destructor frees
+    // nothing, so a test that never applies the batch has to release them.
+    qDeleteAll(ctx.entitiesToAdd);
 }
 
 TEST_CASE("RS_Modification::trim still trims against an atomic limit entity",
@@ -76,4 +80,6 @@ TEST_CASE("RS_Modification::trim still trims against an atomic limit entity",
                                                        true, ctx);
     CHECK(result.trimmed1 != nullptr);
     CHECK(result.trimmed2 != nullptr);
+
+    qDeleteAll(ctx.entitiesToAdd);
 }


### PR DESCRIPTION
Found while investigating #2804, then widened by auditing `rs_creation.cpp` and `rs_modification.cpp` for the same ownership mistake. Three leaks, all on preview paths that run per mouse move. This does not claim to be that report's freeze — see the note near the end.

| # | where | leaked | reach |
|---|---|---|---|
| 1 | `LC_ActionModifyRound::onMouseMoveEvent` | 896 B/move | fillet hover |
| 2 | `RS_Preview::addAllFromList` | everything past the cap | **five preview paths, incl. the move tool** |
| 3 | `RS_Modification::cut` | one spline clone per cut | spline-points cut |

## The leak

`LC_ActionModifyRound::onMouseMoveEvent` calls `RS_Modification::round()` with a local `LC_DocumentModificationBatch` to build the fillet preview. `round()` returns raw ownership of a new arc and of clones of both picked entities, and registers them in that batch — whose destructor is `= default` and frees nothing.

The action then called:

```cpp
if (m_actionData->data.trim && !roundResult.isPolyline){
    m_preview->removeEntity(roundResult.trimmed1);
    m_preview->removeEntity(roundResult.trimmed2);
}
```

Both calls are no-ops. The trimmed clones are never *added* to the preview, and `RS_EntityContainer::removeEntity()` only deletes what the container actually holds:

```cpp
const bool ret = m_entities.removeOne(entity);
if (ret) { ... if (m_autoDelete) { delete entity; } }
return ret;
```

So every mouse move over a valid fillet target leaked.

## Measurements

Driving `RS_PreviewActionInterface::mouseMoveEvent` on a two-line corner, live heap bytes leaked per mouse move:

| Trim | Reference entities | leaked |
|---|---|---|
| off | on | 0 |
| off | off | 512 — the arc |
| **on** | **on** | **896 — both clones** (shipped default) |
| on | off | 1408 — both clones and the arc |

With the defaults it is linear and unbounded — **1.5 MB → 106 MB over 120k mouse moves**, no plateau. `leaks(1)` attributes it exactly:

```
2002 leaks for 448192 total leaked bytes        (500 hover moves)
STACK OF 500 INSTANCES OF 'ROOT LEAK: <RS_Line>':
  LC_ActionModifyRound::onMouseMoveEvent   lc_action_modify_round.cpp
  RS_Modification::round(...)              rs_modification.cpp
  RS_Line::clone() const                   rs_line.cpp:64
  operator new
```

After the fix the heap is flat over 120k moves in all four configurations, and `leaks(1)` is clean.

## The fix

Release whatever the preview did not adopt. `LC_ActionModifyBevel` already carries the same `delete`, so this brings fillet in line with its sibling:

```cpp
if (!bevelResult.isPolyline) {
    delete bevelResult.trimmed1;
    delete bevelResult.trimmed2;
}
```

## The other two paths, measured rather than assumed

Both are already correct, so the fix stays confined to the one branch that needed it:

- **Polyline branch** — the clone owns the arc and both trimmed segments, so handing it to the preview hands over all three. Measured **0 bytes per mouse move**.
- **Click / commit path** — every error return in `round()` precedes its first allocation, and on success the document takes the entities. `leaks(1)` over 120 full pick-pick gestures reports only the 192-byte `RS_Graphic::initForNewDocument` baseline that every run of the suite carries. The two clones retained per committed fillet are document-resident, not leaked.

## Leak 2: the preview drops what it will not adopt

`RS_Preview::addAllFromList()` is handed entities the caller has already built and expects the preview to take over. It stops at `m_maxEntities` and **breaks**, so the tail is neither adopted nor released:

```cpp
for (const auto e: list) {
    if (c > m_maxEntities) {
        break;                  // the rest of the list is dropped
    }
    ...
    addEntity(e);
}
```

Its three neighbours are safe for the opposite reason — `addAllFrom()`, `addClonesFromList()` and `addStretchablesFrom()` clone *inside* the loop, so stopping early just means they never allocate. Only the two `addAllFromList()` overloads take ownership of entities that already exist.

The cap defaults to **100**, and all five callers are preview paths, so the drop repeats every mouse move:

| caller | list |
|---|---|
| `LC_ActionModifyMove` | `ctx.entitiesToAdd` from `RS_Modification::move` |
| `LC_ActionPolylineFromSegment` | `ctx.entitiesToAdd` |
| `LC_ActionDrawLineParallel` | `RS_Creation::createParallel` output |
| `LC_ActionDrawLineParallelThrough` | same |
| `LC_ActionDrawLineBisector` | `RS_Creation::createBisector` output |

**Dragging a selection of more than a hundred entities with the move tool leaks the whole tail on every mouse move.** None of the five callers touches the list afterwards except to read `front()`, which is always adopted, so releasing the remainder is safe for all of them.

## Leak 3: a temporary clone in RS_Modification::cut

```cpp
cut2 = static_cast<LC_SplinePoints*>(cutEntity->clone())->cut(cutCoord);
```

`LC_SplinePoints::cut()` returns a freshly allocated spline and never the receiver, so the clone it is called on is never stored and never freed — including on the two of its three returns that hand back `nullptr`. Held in a `unique_ptr` now. This is the only instance of the pattern in the tree; grepping for a `clone()` that is immediately dereferenced finds no other.

## Leak 4: the trim tests never release what the batch holds

Found by running `leaks(1)` over the whole test suite. `RS_Modification::trim()` itself is correct — `trimmed2` is allocated and handed to the batch under the same `trimBoth` guard, and `trimmed1` always reaches it. The leak is test-side: both cases in `rs_modification_trim_tests.cpp` build a local `LC_DocumentModificationBatch`, call `trim()`, assert and return, and the batch destructor frees nothing. Three leaked `RS_Line` per run, now zero.

## What the audit found clean

Checked rather than assumed, by two independent methods.

**Empirically.** A `leaks(1)` sweep of the full suite under `MallocStackLogging` found **no production leak** in either file. Every genuine `ROOT LEAK` stack touching them came from the trim tests above. The remaining 106,186 entries are all `ROOT CYCLE` rather than `ROOT LEAK` — entity graphs whose children carry parent back-pointers, which `leaks(1)` cannot prove reachable and which are not defects.

**By inspection.** Every allocation in `rs_creation.cpp` and `rs_modification.cpp` was traced to a transfer into the modification batch, a container, or a return value, and every early return was checked against the allocations preceding it.

- `bevel()` — all three error returns precede its first allocation, and its caller already deletes the trimmed clones the preview does not take.
- The three `acceptedInsertSourceEdit()` rejection paths in `move`, `scale` and `mirror` all delete their clone.
- `splitPolyline`, `addPolylineNode`, `deletePolylineNode`, `deletePolylineNodesBetween`, `polylineTrim` — allocations all follow the early returns and all reach `ctx`.
- `trim`, `trimAmount`, `libraryInsert`, `explode`, `doExplodeTextIntoLetters`, `createBisector`, `createTangent1`, `createLineRelAngle`, `createBlock` — clean.
- No caller of `createParallel()` requests the symmetric pair, so the second entity that would produce is never dropped.
- The functions that hand back sole ownership without registering in `ctx` — `createTangent1`, `createLineRelAngle`, `createBlock` — were checked at every call site. `RS_ActionDrawLineTangent1` adopts each result into a `unique_ptr` immediately (so its reassignment frees the first) and previews a clone; the visual-snap solver deletes its tangent; `LC_ActionDrawLineRelAngle` hands its line to the preview.

### The underlying hazard

All four leaks share one root: `LC_DocumentModificationBatch` holds raw pointers and its destructor is `= default`, so "registered in the batch" and "owned by someone" are not the same thing. Giving the batch real ownership semantics would remove the whole class of bug, but it changes the contract for every caller and belongs in its own change rather than here.

## Second fix: a null dereference in RS_GraphicView

`RS_GraphicView::isInRelativePointInput()` dereferences `m_relativePointWidgetHolder` unconditionally, but only `QG_GraphicView` ever creates it. It is the **first statement of every mouse move**, so any `RS_GraphicView` that is not the widget subclass — including the ones the test suite builds — segfaults on the first move. Guarding it is what lets an action test drive the real mouse move path.

## Tests

The tests pin the ownership contract rather than measuring bytes. A counting `RS_Line` subclass overrides `clone()`, which makes the clones `round()` produces observable: a dropped clone shows up as a live count that grows with the number of mouse moves.

Verified red/green — reverting only the `lc_action_modify_round.cpp` hunk and rebuilding:

```
CHECK( CountingLine::s_liveClones == afterFirstHover )
with expansion:
  104 == 4
with message:
  clones still alive after 50 further hover moves
```

106 − 6 = 100, exactly two leaked clones per move over fifty moves. Reverting only the `rs_preview.cpp` hunk gives `49 == 0` — the tail past a cap of 100 with 150 entities handed over. With the fixes, all three tests pass.

The counting line now counts every instance rather than only clones, so the same probe covers entities the preview is handed directly.

The spline-cut fix has no test of its own: it needs a valid `LC_SplinePoints` with enough control points for `cut()` to succeed, which is more scaffolding than the two-line fix warrants. It is verified by reading — `cut()` allocates its return and never yields `this`.

No existing test references `LC_ActionModifyRound` or `isInRelativePointInput`, so nothing else exercises the changed code.

## What this does not claim

I could not reproduce the freeze reported in #2804 on a small drawing. The whole fillet mouse-move path costs **8.8 µs** per move on the drawing that issue's `-d 6` log describes (39 lines, 9 arcs, 5 circles), with no loop and no unbounded container growth — 120k synthetic mouse moves ran clean. This leak degrades a long session rather than freezing one in seconds, and it only accrues while hovering after the first entity is picked.

Worth noting separately for that report: at `-d 6` the same path emits **182 lines per mouse move**, each individually `fflush`ed by `RS_Debug::print`. Measured 21× slower to `/dev/null`, 27× to a pipe, 61× to a file — and a terminal is far more expensive still, blocking the main thread on `write()` once the pty buffer fills. So the session documented in that issue looks throughput-bound rather than hung.

Built and tested locally with Qt 6.11 (cmake + ninja, `RelWithDebInfo`).

## Full suite, before and after

Same build, Qt 6.11, `RelWithDebInfo`. The baseline is pristine `origin/master`
with both source hunks reverted and the new tests excluded by tag:

| | cases | passed | failed | assertions failed |
|---|---|---|---|---|
| `origin/master` | 2398 | 2301 | 28 | 32 |
| this PR | 2401 | 2304 | 28 | 32 |

Exactly +3 cases and +3 assertions — the three new tests — with the 28
pre-existing failures unchanged.
