### PR TITLE
Restore /EHsc in the Windows DWG/DXF test configure

### DIFF
--- a/.github/workflows/dwg-dxf-verify.yml
+++ b/.github/workflows/dwg-dxf-verify.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Configure bounded DWG/DXF test lanes
         run: |
-          cmake.exe -S . -B generated-tests -G "Visual Studio 17 2022" -A "${{ matrix.cmake_arch }}" -DBOOST_ROOT="%CD%\boost" -DCMAKE_CXX_FLAGS="/MP8" -DBUILD_TESTS=ON -DLIBRECAD_REGISTER_INTEGRATION_TESTS=ON -DLIBRECAD_REGISTER_FULL_TESTS=OFF -DLIBRECAD_REGISTER_FORMAT_TESTS=OFF -DLIBRECAD_REGISTER_CROSS_READ_SMOKE=OFF
+          cmake.exe -S . -B generated-tests -G "Visual Studio 17 2022" -A "${{ matrix.cmake_arch }}" -DBOOST_ROOT="%CD%\boost" -DCMAKE_CXX_FLAGS="/MP8 /EHsc" -DBUILD_TESTS=ON -DLIBRECAD_REGISTER_INTEGRATION_TESTS=ON -DLIBRECAD_REGISTER_FULL_TESTS=OFF -DLIBRECAD_REGISTER_FORMAT_TESTS=OFF -DLIBRECAD_REGISTER_CROSS_READ_SMOKE=OFF
         shell: cmd
 
       - name: Build bounded DWG/DXF test lanes


### PR DESCRIPTION
The **DWG/DXF verification** workflow has failed on `master` since 8bf62ddc1 ("tests: report unavailable-fixture cases as skipped, not passed", #2800) — not only on PRs. `librecad_dwg_fast_tests` aborts with `0xc0000409`:

```
datastorage_tests.cpp(2855): skipped: 'no DataStorage fixture available; linkage is optional'
Catch will terminate because it needed to throw an exception.
The message was: Explicitly skipping tests during runtime requires exceptions
...
1 - librecad_dwg_fast_tests (Exit code 0xc0000409)
```

## Why

Catch2 implements the runtime `SKIP()` macro by throwing, so it requires C++ exception handling. That lane has none.

The configure step passes `-DCMAKE_CXX_FLAGS="/MP8"`. Setting `CMAKE_CXX_FLAGS` **replaces** CMake's MSVC default of `/DWIN32 /D_WINDOWS /W3 /GR /EHsc` rather than adding to it, so `/EHsc` is dropped. Every translation unit in the job says so:

```
warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
```

That was survivable while these tests only reported `SUCCEED()`. #2800 converted 297 of them to `SKIP()` across 26 files, and the first one reached now terminates the process.

## The fix

Append `/EHsc` instead of letting the override drop it — one token:

```diff
--DCMAKE_CXX_FLAGS="/MP8"
+-DCMAKE_CXX_FLAGS="/MP8 /EHsc"
```

This also clears the C4530 warnings, which were not cosmetic: without unwind semantics MSVC does not run destructors while an exception propagates.

`dwg-dxf-verify.yml` is the only workflow that overrides `CMAKE_CXX_FLAGS`, so no other lane is affected.

## Verification

I have no Windows toolchain available, so this is verified by reading the failing job rather than by a local build — CI on this PR is the check. The causal chain is exact: the log shows both the missing-`/EHsc` warnings and Catch2's own message naming exceptions as the requirement.

An alternative, more defensive fix would be to put `/EHsc` on the Catch2 test targets in `CMakeLists.txt` next to the existing `/bigobj`, so the requirement travels with the targets rather than depending on the caller's flags. I went with the one-token workflow fix since the override is what broke the contract, but happy to switch if maintainers prefer the target-level guarantee.
