### PR TITLE
Decode pre-R13 table names with the file codepage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2469,6 +2469,7 @@ if (BUILD_TESTS)
         librecad/src/lib/engine/document/entities/tests/rs_mtext_bidi_tests.cpp
         librecad/src/lib/engine/document/entities/tests/rs_text_bidi_tests.cpp
         librecad/src/actions/drawing/modify/tests/lc_action_modify_round_tests.cpp
+        librecad/src/lib/filters/tests/dwg_pre_r13_codepage_tests.cpp
         librecad/src/lib/math/tests/rs_math_tests.cpp
         librecad/src/lib/math/tests/lc_quadratic_tests.cpp
         librecad/src/lib/creation/tests/rs_creation_null_entity_tests.cpp

--- a/libraries/libdxfrw/src/intern/drw_textcodec.cpp
+++ b/libraries/libdxfrw/src/intern/drw_textcodec.cpp
@@ -435,6 +435,11 @@ std::string DRW_ConvDBCSTable::toUtf8(std::string_view s) {
         } else if(c == 0x80 ){//1 byte table
             notFound = false;
             res += encodeNum(0x20AC);//euro sign
+        } else if (it + 1 == s.end()) {
+            // Trailing lead byte with no trail byte. Fixed-width DWG fields are
+            // NUL-padded and can cut a double-byte character in half, so this is
+            // reachable; fall through to the not-found replacement rather than
+            // stepping past the end.
         } else {//2 bytes
             ++it;
             int code = (c << 8) | static_cast<unsigned char >(*it);
@@ -533,6 +538,8 @@ std::string DRW_Conv932Table::toUtf8(std::string_view s) {
         } else if(c > 0xA0 && c < 0xE0 ){//1 byte table
             notFound = false;
             res += encodeNum(c + CPOFFSET932); //translate from table
+        } else if (it + 1 == s.end()) {
+            // Trailing lead byte with no trail byte; see DRW_ConvDBCSTable.
         } else {//2 bytes
             ++it;
             int code = (c << 8) | static_cast<unsigned char>(*it);

--- a/libraries/libdxfrw/src/intern/dwgreaderR11.cpp
+++ b/libraries/libdxfrw/src/intern/dwgreaderR11.cpp
@@ -101,6 +101,17 @@ const char* preR13CodePageName(std::uint16_t numHeaderVars, std::uint16_t cp) {
     return dwgCodePageName(cp);
 }
 
+std::string preR13FixedText(dwgBuffer& buf, const int width, DRW_TextCodec& codec) {
+    std::string raw;
+    bool ended = false;
+    for (int j = 0; j < width; ++j) {
+        const char c = static_cast<char>(buf.getRawChar8());
+        if (c == '\0') ended = true;
+        if (!ended) raw.push_back(c);
+    }
+    return codec.toUtf8(raw);
+}
+
 bool dwgReaderR11::readMetaData() {
     // Identify the precise pre-R13 version from the 6-byte magic. Both AC1006
     // (R10) and AC1009 (R11) are validatable against dwgread; their containers
@@ -377,13 +388,7 @@ bool dwgReaderR11::readNameTable(std::uint32_t hdrPos, std::vector<std::string>&
                 || !dwgSafety::add(recordOffset, 1, nameOffset)
                 || !fileBuf->setPosition(nameOffset))
                 return false;
-            std::string name;
-            bool ended = false;
-            for (int j = 0; j < 32; ++j) {
-                const char c = static_cast<char>(fileBuf->getRawChar8());
-                if (c == '\0') ended = true;
-                if (!ended) name.push_back(c);
-            }
+            std::string name = preR13FixedText(*fileBuf, 32, decoder);
             if (!fileBuf->isGood())
                 return false;
             names.push_back(std::move(name));
@@ -475,24 +480,13 @@ bool dwgReaderR11::readLTypeTable(std::uint32_t hdrPos) {
             || !fileBuf->setPosition(offset))
             return false;
         const std::uint8_t flag = fileBuf->getRawChar8();
-        std::string name;
-        bool ended = false;
-        for (int j = 0; j < 32; ++j) {
-            const char c = static_cast<char>(fileBuf->getRawChar8());
-            if (c == '\0') ended = true;
-            if (!ended) name.push_back(c);
-        }
+        std::string name = preR13FixedText(*fileBuf, 32, decoder);
         // off 33: used (signed RS, ignored — header lists "used count"
         // sentinel; libreDWG keeps it for debugging only). R11 only; R10 omits.
         if (hasUsed) static_cast<void>(fileBuf->getRawShort16());
         // description (48 FIXED null-padded bytes).
         std::string desc;
-        ended = false;
-        for (int j = 0; j < 48; ++j) {
-            const char c = static_cast<char>(fileBuf->getRawChar8());
-            if (c == '\0') ended = true;
-            if (!ended) desc.push_back(c);
-        }
+        desc = preR13FixedText(*fileBuf, 48, decoder);
         // off 83: alignment (always 'A' for AutoCAD ltypes); off 84: numdashes.
         const std::uint8_t alignment = fileBuf->getRawChar8();
         const std::uint8_t numdashes = fileBuf->getRawChar8();
@@ -572,13 +566,7 @@ bool dwgReaderR11::readLayerTable(std::uint32_t hdrPos) {
             || !fileBuf->setPosition(offset))
             return false;
         const std::uint8_t flag = fileBuf->getRawChar8();
-        std::string name;
-        bool ended = false;
-        for (int j = 0; j < 32; ++j) {
-            const char c = static_cast<char>(fileBuf->getRawChar8());
-            if (c == '\0') ended = true;
-            if (!ended) name.push_back(c);
-        }
+        std::string name = preR13FixedText(*fileBuf, 32, decoder);
         if (hasUsed) static_cast<void>(fileBuf->getRawShort16()); // off33 used (R11)
         const std::int16_t color =
             static_cast<std::int16_t>(fileBuf->getRawShort16());
@@ -638,13 +626,7 @@ bool dwgReaderR11::readStyleTable(std::uint32_t hdrPos) {
             || !fileBuf->setPosition(offset))
             return false;
         const std::uint8_t flag = fileBuf->getRawChar8();
-        std::string name;
-        bool ended = false;
-        for (int j = 0; j < 32; ++j) {
-            const char c = static_cast<char>(fileBuf->getRawChar8());
-            if (c == '\0') ended = true;
-            if (!ended) name.push_back(c);
-        }
+        std::string name = preR13FixedText(*fileBuf, 32, decoder);
         if (hasUsed) static_cast<void>(fileBuf->getRawShort16()); // off33 used (R11)
         const double textSize = fileBuf->getRawDouble();
         const double widthFactor = fileBuf->getRawDouble();   // off43
@@ -652,18 +634,8 @@ bool dwgReaderR11::readStyleTable(std::uint32_t hdrPos) {
         const std::uint8_t generation = fileBuf->getRawChar8(); // off59
         const double lastHeight = fileBuf->getRawDouble();    // off60
         std::string font, bigFont;
-        ended = false;
-        for (int j = 0; j < 64; ++j) {
-            const char c = static_cast<char>(fileBuf->getRawChar8());
-            if (c == '\0') ended = true;
-            if (!ended) font.push_back(c);
-        }
-        ended = false;
-        for (int j = 0; j < 64; ++j) {
-            const char c = static_cast<char>(fileBuf->getRawChar8());
-            if (c == '\0') ended = true;
-            if (!ended) bigFont.push_back(c);
-        }
+        font = preR13FixedText(*fileBuf, 64, decoder);
+        bigFont = preR13FixedText(*fileBuf, 64, decoder);
         auto st = std::make_unique<DRW_Textstyle>();
         st->name = name;
         st->height = textSize;
@@ -751,13 +723,7 @@ bool dwgReaderR11::readExtendedNameTable(std::uint32_t hdrPos, bool isDimstyle) 
                 || !fileBuf->setPosition(offset))
                 return false;
             const std::uint8_t flag = fileBuf->getRawChar8();
-            std::string name;
-            bool ended = false;
-            for (int j = 0; j < 32; ++j) {
-                const char c = static_cast<char>(fileBuf->getRawChar8());
-                if (c == '\0') ended = true;
-                if (!ended) name.push_back(c);
-            }
+            std::string name = preR13FixedText(*fileBuf, 32, decoder);
             if (!fileBuf->isGood())
                 return false;
             auto ds = std::make_unique<DRW_Dimstyle>();
@@ -780,13 +746,7 @@ bool dwgReaderR11::readExtendedNameTable(std::uint32_t hdrPos, bool isDimstyle) 
             || !fileBuf->setPosition(offset))
             return false;
         const std::uint8_t flag = fileBuf->getRawChar8();
-        std::string name;
-        bool ended = false;
-        for (int j = 0; j < 32; ++j) {
-            const char c = static_cast<char>(fileBuf->getRawChar8());
-            if (c == '\0') ended = true;
-            if (!ended) name.push_back(c);
-        }
+        std::string name = preR13FixedText(*fileBuf, 32, decoder);
         if (!fileBuf->isGood())
             return false;
         auto ai = std::make_unique<DRW_AppId>();

--- a/libraries/libdxfrw/src/intern/dwgreaderR11.h
+++ b/libraries/libdxfrw/src/intern/dwgreaderR11.h
@@ -29,6 +29,13 @@
 */
 const char* preR13CodePageName(std::uint16_t numHeaderVars, std::uint16_t cp);
 
+/// Read a pre-R13 fixed-width, NUL-padded text field. Always consumes @p width
+/// bytes so the sequential record layout stays aligned, keeps only the bytes
+/// before the first NUL, and decodes them with @p codec ($DWGCODEPAGE). Table
+/// records store names as raw codepage bytes, so without this they reach the
+/// document undecoded. Declared here so it can be unit tested.
+std::string preR13FixedText(dwgBuffer& buf, int width, DRW_TextCodec& codec);
+
 //! Class to read pre-R13 (R10/R11) DWG files
 /*!
 *  Reads the fixed pre-R13 container: file header section pointers, then the

--- a/librecad/src/lib/filters/tests/dwg_pre_r13_codepage_tests.cpp
+++ b/librecad/src/lib/filters/tests/dwg_pre_r13_codepage_tests.cpp
@@ -1,0 +1,133 @@
+/****************************************************************************
+**
+** This file is part of the LibreCAD project, a 2D CAD program
+**
+** Copyright (C) 2026 LibreCAD.org
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+**********************************************************************/
+
+// $DWGCODEPAGE handling for pre-R13 (R2.10/R9/R10/R11/R12) table records.
+//
+// Those records store names in fixed-width, NUL-padded fields of raw codepage
+// bytes. The reader resolved the codepage correctly but assembled the fields
+// byte by byte and never decoded them, so a GBK layer name reached the document
+// as raw bytes and QString::fromUtf8() turned it into U+FFFD. preR13FixedText()
+// is the single place that now reads and decodes those fields.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "drw_textcodec.h"
+#include "dwgbuffer.h"
+#include "dwgreaderR11.h"
+
+namespace {
+
+/// A fixed-width DWG name field: `bytes`, NUL-padded out to `width`.
+std::vector<std::uint8_t> field(const std::string& bytes, const std::size_t width) {
+    std::vector<std::uint8_t> raw(width, 0);
+    for (std::size_t i = 0; i < bytes.size() && i < width; ++i) {
+        raw[i] = static_cast<std::uint8_t>(bytes[i]);
+    }
+    return raw;
+}
+
+std::string readField(std::vector<std::uint8_t>& raw, const int width, DRW_TextCodec& codec,
+                      std::uint64_t* endPos = nullptr) {
+    dwgBuffer buf(raw.data(), raw.size());
+    const std::string text = preR13FixedText(buf, width, codec);
+    if (endPos != nullptr) {
+        *endPos = buf.getPosition();
+    }
+    return text;
+}
+
+void useGbk(DRW_TextCodec& codec) {
+    codec.setCodePage("ANSI_936", /*dxfFormat=*/false);
+}
+
+} // namespace
+
+TEST_CASE("pre-R13 fixed name fields are decoded with the file codepage",
+          "[dwg][pre_r13][codepage]") {
+    DRW_TextCodec codec;
+    useGbk(codec);
+
+    SECTION("GBK bytes become UTF-8") {
+        // "\xbd\xa8\xd6\xfe" is GBK for the two characters of the layer name
+        // prefix seen on real drawings; U+5EFA U+7B51.
+        auto raw = field("\xbd\xa8\xd6\xfe" "_1", 32);
+        CHECK(readField(raw, 32, codec) == "\xe5\xbb\xba\xe7\xad\x91" "_1");
+    }
+
+    SECTION("ASCII is unchanged") {
+        auto raw = field("LAYER_0", 32);
+        CHECK(readField(raw, 32, codec) == "LAYER_0");
+    }
+
+    SECTION("the field stops at the first NUL but still consumes its full width") {
+        // The pre-R13 record layout is strictly sequential: reading fewer bytes
+        // than the field is wide desyncs every field after it.
+        auto raw = field("AB", 32);
+        std::uint64_t endPos = 0;
+        CHECK(readField(raw, 32, codec, &endPos) == "AB");
+        CHECK(endPos == 32);
+    }
+
+    SECTION("a field with no NUL uses its whole width") {
+        auto raw = field(std::string(32, 'X'), 32);
+        CHECK(readField(raw, 32, codec) == std::string(32, 'X'));
+    }
+}
+
+TEST_CASE("a double-byte character truncated by the field width is not read past",
+          "[dwg][pre_r13][codepage]") {
+    // A fixed-width field can cut a double-byte character in half. Each case
+    // keeps a valid trail byte in the backing buffer just past the end of the
+    // view: if the decoder steps past the end to find one, it forms the whole
+    // character and the check below sees it.
+
+    SECTION("GBK") {
+        DRW_TextCodec codec;
+        useGbk(codec);
+        const char backing[] = "\xbd\xa8";              // whole char: U+5EFA
+        const std::string_view leadOnly(backing, 1);   // view stops after the lead
+        INFO("decoding a lone lead byte must not consume the byte after the view");
+        CHECK(codec.toUtf8(leadOnly) != "\xe5\xbb\xba");
+    }
+
+    SECTION("Shift-JIS") {
+        DRW_TextCodec codec;
+        codec.setCodePage("ANSI_932", /*dxfFormat=*/false);
+        const char backing[] = "\x81\x40";              // whole char: U+3000
+        const std::string_view leadOnly(backing, 1);
+        CHECK(codec.toUtf8(leadOnly) != "\xe3\x80\x80");
+    }
+
+    SECTION("through a fixed-width field") {
+        DRW_TextCodec codec;
+        useGbk(codec);
+        auto raw = field(std::string(31, 'A') + "\xbd", 32);
+        std::uint64_t endPos = 0;
+        const std::string out = readField(raw, 32, codec, &endPos);
+        CHECK(endPos == 32);
+        CHECK(out.compare(0, 31, std::string(31, 'A')) == 0);
+    }
+}


### PR DESCRIPTION
Layer, linetype, text style, block, appid and dimstyle names come out of pre-R13 drawings (R2.10/R9/R10/R11/R12) as mojibake whenever they are not pure ASCII:

```
建筑_建筑基底_1___住宅_14_0_3_0_     shown as     ?õ?_?滮???õ?_238_0_0_V2_2
```

A GBK layer name arrives as raw codepage bytes, and `QString::fromUtf8()` turns the byte pairs that happen to be valid UTF-8 into the wrong characters (`d7 a1` → U+05E1 Hebrew, where GBK says 住) and everything else into U+FFFD. At that point the original bytes are gone, so nothing downstream can recover them.

## The codepage resolution was never the problem

`readFileHeader()` reads the pre-R13 `$DWGCODEPAGE` id at offset `0x3f9`, gates it on `numheader_vars > 129`, maps it via `dwgCodePageName()` and calls `setCodePage()`. For the file that prompted this, id **39 resolves to `ANSI_936`** exactly as it should, and `DRW_TextCodec` implements ANSI_936 with a full DBCS table.

**The decoder is simply never used.** Every fixed-width name field is assembled byte by byte straight into the record:

```cpp
for (int j = 0; j < 32; ++j) {
    const char c = static_cast<char>(fileBuf->getRawChar8());
    if (c == '\0') ended = true;
    if (!ended) name.push_back(c);
}
ly->name = name;            // raw codepage bytes
```

Eleven fields across five table readers did this — the 32-byte name in `readNameTable`, `readLTypeTable`, `readLayerTable`, `readStyleTable` and `readExtendedNameTable`, plus the **48-byte LTYPE description** and the **two 64-byte STYLE font-file fields**. The entity reader already routes its text through `decoder.toUtf8()`; the table readers were missed.

## The fix

One `preR13FixedText()` helper replaces all eleven loops. It reads the field, keeps the bytes before the first NUL, and decodes them — always consuming the full width, because the pre-R13 record layout is strictly sequential and a short read desyncs every field after it. **The reader loses 40 lines.**

## Measured

Over the 87 pre-R13 drawings I have on hand, 41 of which carry non-ASCII layer names:

| | layer names containing U+FFFD or invalid UTF-8 | files imported |
|---|---|---|
| before | **1113** | 67 |
| after | **0** | 67 |

## An out-of-bounds read this would otherwise have exposed

`DRW_ConvDBCSTable::toUtf8()` and `DRW_Conv932Table::toUtf8()` advance the iterator to fetch the trail byte of a double-byte character without checking for the end of input, so a string ending in a lead byte **dereferences the end iterator**. A fixed-width field can cut a double-byte character in half, so routing those fields through the decoder makes this reachable. Both now fall through to the not-found replacement.

The test catches it precisely rather than relying on a sanitizer: it keeps a valid trail byte in the backing buffer just past the end of the `string_view`, so a decoder that steps past the end forms the whole character. Without the fix:

```
CHECK( codec.toUtf8(leadOnly) != "\xe3\x80\x80" )
with expansion:  "　" != "　"
```

Both the GBK and Shift-JIS cases fail without it.

## Why the codepage id table is left alone

Deliberately, on evidence. Of the 87 pre-R13 files here:

| id | count | status |
|---|---|---|
| 39 (GBK) | 60 | already mapped |
| 0 (undefined) | 20 | correctly keeps the default |
| 30 (ANSI_1252) | 3 | already mapped |
| 26988 | 3 | AC2.10 files whose `numheader_vars` of 83 fails the `> 129` gate — already rejected |
| 12 | 1 | unmapped |

Ids below 28 are the DOS OEM and ISO-8859 range, and libdxfrw has no conversion tables for them, so adding speculative mappings would trade a known-safe ANSI_1252 fallback for guesses I cannot verify against a real file. That belongs in its own change with its own evidence.

## Tests

The helper is covered directly rather than through a synthetic DWG (no pre-R13 fixtures exist in the tree): GBK decoding, ASCII passthrough, NUL padding, and that the full field width is consumed. The helper's own test cannot go red against master since the helper is new API — it pins the behaviour going forward. The codec truncation tests do go red, as shown above.

Full suite, Qt 6.11, `RelWithDebInfo`: **2400 cases / 2303 passed / 28 failed / 32 assertions failed**, against a measured master baseline of 2398 / 2301 / 28 / 32 — exactly +2 cases for the two new tests, with the pre-existing failures unchanged despite this touching the shared DWG read path.

Related: LibreDWG cannot decode the file that prompted this at all (`DWG_SENTINEL_R11_LAYER_BEGIN not found`), so there is no external oracle for it here.
