### PR TITLE
Stop redefining LC_VERSION for librecad_lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2197,11 +2197,13 @@ qt_add_library (librecad_lib STATIC
                 ${MUPARSER_SOURCES}
                 ${SHARED_SOURCES}
 )
+# MUPARSER_STATIC, LC_VERSION and LC_PRERELEASE are already set for every
+# target by the add_compile_definitions() calls near the top of this file.
+# Repeating them here only gave them room to drift apart, and they did: this
+# block pinned LC_VERSION a release behind the global one, so every object in
+# the target was compiled with both -D's and a -Wmacro-redefined warning.
 target_compile_definitions (librecad_lib PRIVATE
                             DWGSUPPORT
-                            MUPARSER_STATIC
-                            LC_VERSION=2.2.2.5-alpha
-                            LC_PRERELEASE=true
 )
 target_include_directories(librecad_lib PRIVATE
     ${SHARED_INCLUDES}


### PR DESCRIPTION
### Problem

`librecad_lib` repeated three definitions that the directory-level
`add_compile_definitions()` calls at the top of `CMakeLists.txt` already make
for every target — `MUPARSER_STATIC`, `LC_VERSION` and `LC_PRERELEASE` — and
the copy had drifted a release behind:

```
DEFINES = -DDWGSUPPORT -DLC_PRERELEASE=true -DLC_VERSION=2.2.2.5-alpha -DLC_VERSION=2.2.2.6-alpha ...
```

Both reach the command line, so all 925 objects in that target compile with

```
<command line>: warning: 'LC_VERSION' macro redefined [-Wmacro-redefined]
```

### Why it is worth fixing rather than ignoring

Which definition survives is decided by string order, not intent: CMake sorts
the definitions, `2.2.2.6-alpha` happens to sort after `2.2.2.5-alpha` and
wins, which is why the version has been right and only the warning showed. A
bump to `2.2.2.10-alpha` would sort *before* `2.2.2.5-alpha` and silently
stamp the shared library with the stale version.

### Fix

Drop the three redundant entries, keep `DWGSUPPORT` — the only definition
this target actually adds.

### Verification

- After reconfiguring, `-DLC_VERSION=2.2.2.5-alpha` appears 0 times (was 925)
  and every object gets exactly one `-DLC_VERSION=2.2.2.6-alpha`. All other
  flags are unchanged.
- `librecad_lib` rebuilt from scratch: 929 objects, 0 errors, 0
  macro-redefined warnings. The ~20 remaining warnings are pre-existing and of
  other kinds.
- `strings` on the built archive shows `2.2.2.6-alpha` and no
  `2.2.2.5-alpha`, so the effective version is unchanged.
- Swept the whole generated build for any other macro defined twice with
  differing values: none. This was the only instance.
- The qmake path defines `LC_VERSION` once, so it never had the problem.
