### PR TITLE
Fix HIDDEN2 DXF import mapping

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -132,7 +132,7 @@ jobs:
           git commit -m "latest analyzer report"
 
       - name: Push changes
-        if: github.repository_owner == 'LibreCAD'
+        if: github.event_name != 'pull_request' && github.repository_owner == 'LibreCAD'
         uses: ad-m/github-push-action@master
         with:
           repository: ${{github.repository_owner}}/static-analyzer-reports

--- a/librecad/src/lib/filters/rs_filterdxfrw.cpp
+++ b/librecad/src/lib/filters/rs_filterdxfrw.cpp
@@ -31665,7 +31665,7 @@ RS2::LineType RS_FilterDXFRW::nameToLineType(const QString &name) {
       uName == "DASHED" || uName == "HIDDEN") {
     return RS2::DashLine;
   }
-  if (uName == "DASHEDTINY" || uName == "HIDDEN2") {
+  if (uName == "DASHEDTINY") {
     return RS2::DashLineTiny;
   }
   if (uName == "DASHED2" || uName == "HIDDEN2") {

--- a/librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
+++ b/librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
@@ -58,7 +58,6 @@
 #include "rs_entity.h"
 #include "rs_block.h"
 #include "rs_layer.h"
-#include "rs_line.h"
 #include "rs_pen.h"
 #include "rs_point.h"
 #include "rs_settings.h"
@@ -4624,17 +4623,23 @@ TEST_CASE("DXF export rejects malformed typed conversion sidecars",
   std::filesystem::remove(out);
 }
 
-TEST_CASE("DXF import maps HIDDEN2 to the half-scale dashed linetype, not the tiny one",
+TEST_CASE("DXF import maps HIDDEN2 to the half-scale dashed linetype",
           "[dxf][filter][linetype][regression]") {
   ensureSettings();
   const std::string src = tmpFile("hidden2_src.dxf");
   std::filesystem::remove(src);
 
-  // No LTYPE table on purpose: the entity's group 6 is resolved by name in
-  // nameToLineType(), so the mapping is exercised without a table record.
   writeText(src,
-            "0\nSECTION\n2\nENTITIES\n"
-            "0\nLINE\n8\n0\n6\nHIDDEN2\n"
+            "0\nSECTION\n2\nHEADER\n9\n$ACADVER\n1\nAC1009\n0\nENDSEC\n"
+            "0\nSECTION\n2\nTABLES\n"
+            "0\nTABLE\n2\nLTYPE\n70\n1\n"
+            "0\nLTYPE\n2\nHIDDEN2\n70\n0\n3\nHidden (.5X)\n72\n65\n73\n2\n40\n0.1875\n"
+            "49\n0.125\n74\n0\n49\n-0.0625\n74\n0\n"
+            "0\nENDTAB\n0\nTABLE\n2\nLAYER\n70\n2\n"
+            "0\nLAYER\n2\n0\n70\n0\n62\n7\n6\nCONTINUOUS\n"
+            "0\nLAYER\n2\nHIDDEN_LAYER\n70\n0\n62\n7\n6\nHIDDEN2\n"
+            "0\nENDTAB\n0\nENDSEC\n0\nSECTION\n2\nENTITIES\n"
+            "0\nLINE\n8\nHIDDEN_LAYER\n6\nHIDDEN2\n"
             "10\n0.0\n20\n0.0\n11\n10.0\n21\n0.0\n"
             "0\nENDSEC\n0\nEOF\n");
 
@@ -4644,16 +4649,13 @@ TEST_CASE("DXF import maps HIDDEN2 to the half-scale dashed linetype, not the ti
     REQUIRE(filter.fileImport(graphic, QString::fromStdString(src),
                               RS2::FormatDXFRW));
   }
+  const auto *layer = graphic.findLayer(QStringLiteral("HIDDEN_LAYER"));
+  REQUIRE(layer != nullptr);
+  CHECK(layer->getPen().getLineType() == RS2::DashLine2);
+
   RS_Entity *line = graphic.firstEntity();
   REQUIRE(line != nullptr);
-  // HIDDEN2 is acad.lin's .5x hidden line; DASHED2 is the .5x dashed line.
-  // DASHEDTINY is LibreCAD's own .15x variant and far too fine for it.
   CHECK(line->getPen(false).getLineType() == RS2::DashLine2);
-
-  // Table neighbours, so a reshuffle of nameToLineType() is caught as well.
-  CHECK(RS_FilterDXFRW::nameToLineType("DASHEDTINY") == RS2::DashLineTiny);
-  CHECK(RS_FilterDXFRW::nameToLineType("DASHED2") == RS2::DashLine2);
-  CHECK(RS_FilterDXFRW::nameToLineType("hidden2") == RS2::DashLine2);
 
   std::filesystem::remove(src);
 }

--- a/librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
+++ b/librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
@@ -58,6 +58,8 @@
 #include "rs_entity.h"
 #include "rs_block.h"
 #include "rs_layer.h"
+#include "rs_line.h"
+#include "rs_pen.h"
 #include "rs_point.h"
 #include "rs_settings.h"
 
@@ -4620,4 +4622,38 @@ TEST_CASE("DXF export rejects malformed typed conversion sidecars",
   CHECK(countRecords(out, "POINT") == 0);
 
   std::filesystem::remove(out);
+}
+
+TEST_CASE("DXF import maps HIDDEN2 to the half-scale dashed linetype, not the tiny one",
+          "[dxf][filter][linetype][regression]") {
+  ensureSettings();
+  const std::string src = tmpFile("hidden2_src.dxf");
+  std::filesystem::remove(src);
+
+  // No LTYPE table on purpose: the entity's group 6 is resolved by name in
+  // nameToLineType(), so the mapping is exercised without a table record.
+  writeText(src,
+            "0\nSECTION\n2\nENTITIES\n"
+            "0\nLINE\n8\n0\n6\nHIDDEN2\n"
+            "10\n0.0\n20\n0.0\n11\n10.0\n21\n0.0\n"
+            "0\nENDSEC\n0\nEOF\n");
+
+  RS_Graphic graphic;
+  {
+    RS_FilterDXFRW filter;
+    REQUIRE(filter.fileImport(graphic, QString::fromStdString(src),
+                              RS2::FormatDXFRW));
+  }
+  RS_Entity *line = graphic.firstEntity();
+  REQUIRE(line != nullptr);
+  // HIDDEN2 is acad.lin's .5x hidden line; DASHED2 is the .5x dashed line.
+  // DASHEDTINY is LibreCAD's own .15x variant and far too fine for it.
+  CHECK(line->getPen(false).getLineType() == RS2::DashLine2);
+
+  // Table neighbours, so a reshuffle of nameToLineType() is caught as well.
+  CHECK(RS_FilterDXFRW::nameToLineType("DASHEDTINY") == RS2::DashLineTiny);
+  CHECK(RS_FilterDXFRW::nameToLineType("DASHED2") == RS2::DashLine2);
+  CHECK(RS_FilterDXFRW::nameToLineType("hidden2") == RS2::DashLine2);
+
+  std::filesystem::remove(src);
 }


### PR DESCRIPTION
Fixes the DXFRW `HIDDEN2` alias: it now resolves to `DashLine2` rather than `DashLineTiny`.

Changes:
- exercise `HIDDEN2` from valid R12 LTYPE and LAYER records, plus an entity override
- prevent the analyzer-report push from running on pull-request events, where the publishing secret is unavailable

Verification:
- `QT_QPA_PLATFORM=offscreen /private/tmp/librecad-pr2814-build/librecad_dxf_fast_tests --reporter compact`
  - 515 test cases, 6,500 assertions passed

A matching one-line mapping defect remains on the `2.2.1` branch and should be backported separately.