### PR TITLE
Add the HIDDEN linetype family so AutoCAD hidden lines survive a DXF round-trip (#2813)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -132,7 +132,7 @@ jobs:
           git commit -m "latest analyzer report"
 
       - name: Push changes
-        if: github.repository_owner == 'LibreCAD'
+        if: github.event_name != 'pull_request' && github.repository_owner == 'LibreCAD'
         uses: ad-m/github-push-action@master
         with:
           repository: ${{github.repository_owner}}/static-analyzer-reports

--- a/librecad/res/controls/controls.qrc
+++ b/librecad/res/controls/controls.qrc
@@ -19,6 +19,7 @@
         <file alias="linetype05.lci">linetype05.svg</file>
         <file alias="linetype06.lci">linetype06.svg</file>
         <file alias="linetype07.lci">linetype07.svg</file>
+        <file alias="linetype08.lci">linetype08.svg</file>
         <file alias="width00.lci">width00.svg</file>
         <file alias="width01.lci">width01.svg</file>
         <file alias="width02.lci">width02.svg</file>

--- a/librecad/res/controls/linetype08.svg
+++ b/librecad/res/controls/linetype08.svg
@@ -1,0 +1,1 @@
+<svg height="12" viewBox="0 0 8.4666665 3.175" width="32" xmlns="http://www.w3.org/2000/svg"><path d="m0 1.4597563h8.4949593" fill="#427bc3" stroke="#00000f" stroke-dasharray="1.35 .45" stroke-dashoffset="0" stroke-width=".9"/></svg>

--- a/librecad/src/lib/engine/rs.h
+++ b/librecad/src/lib/engine/rs.h
@@ -864,7 +864,15 @@ namespace RS2 {
         BorderLineX2   = 25, /**< dash, dash, dot large. */
 
         LineTypeUnchanged = 26, /**< Line type defined by block not entity */
-        LineSelected      = 27 /**< Line type for selected */
+        LineSelected      = 27, /**< Line type for selected */
+
+        // Append new line types after this point. The numeric values are
+        // persisted (QSettings, .lcp pen palettes, $DIMLTYPE) and handed to
+        // plugins, so existing values must never be renumbered.
+        HiddenLine     = 28, /**< hidden line (acad.lin HIDDEN). */
+        HiddenLineTiny = 29, /**< hidden line tiny */
+        HiddenLine2    = 30, /**< hidden line small. */
+        HiddenLineX2   = 31  /**< hidden line large. */
     };
 
     /**

--- a/librecad/src/lib/filters/rs_filterdxfrw.cpp
+++ b/librecad/src/lib/filters/rs_filterdxfrw.cpp
@@ -31665,7 +31665,7 @@ RS2::LineType RS_FilterDXFRW::nameToLineType(const QString &name) {
       uName == "DASHED" || uName == "HIDDEN") {
     return RS2::DashLine;
   }
-  if (uName == "DASHEDTINY" || uName == "HIDDEN2") {
+  if (uName == "DASHEDTINY") {
     return RS2::DashLineTiny;
   }
   if (uName == "DASHED2" || uName == "HIDDEN2") {

--- a/librecad/src/lib/filters/rs_filterdxfrw.cpp
+++ b/librecad/src/lib/filters/rs_filterdxfrw.cpp
@@ -18332,6 +18332,7 @@ void RS_FilterDXFRW::writeLType(const UTF8STRING &lTypeName,
               lTypeName)) {
     ltype = *source;
   }
+  m_builtinLTypeNames.insert(normalizeDwgTableName(lTypeName));
   (void)writeLTypeRecord(ltype);
 }
 
@@ -18360,6 +18361,7 @@ bool RS_FilterDXFRW::writeLTypeRecord(DRW_LType &ltype) {
 }
 
 void RS_FilterDXFRW::writeLTypes() {
+  m_builtinLTypeNames.clear();
   writeLType("CONTINUOUS", "Solid line", 0, 0, {});
   writeLType("ByLayer", "", 0, 0, {});
   writeLType("ByBlock", "", 0, 0, {});
@@ -18379,6 +18381,15 @@ void RS_FilterDXFRW::writeLTypes() {
              9.525, {6.35, -3.175});
   writeLType("DASHEDX2", "Dashed (2x) ____  ____  ____  ____  ____  ___", 2,
              38.1, {25.4, -12.7});
+  // acad.lin: HIDDEN A,.25,-.125 / HIDDEN2 A,.125,-.0625 / HIDDENX2 A,.5,-.25
+  writeLType("HIDDEN", "Hidden __ __ __ __ __ __ __ __ __ __ __ __ __ __", 2,
+             9.525, {6.35, -3.175});
+  writeLType("HIDDENTINY", "Hidden (.15x) _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _", 2,
+             1.42875, {0.9525, -0.47625});
+  writeLType("HIDDEN2", "Hidden (.5x) _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _", 2,
+             4.7625, {3.175, -1.5875});
+  writeLType("HIDDENX2", "Hidden (2x) ____ ____ ____ ____ ____ ____ ____", 2,
+             19.05, {12.7, -6.35});
   writeLType("DASHDOT", "Dash dot __ . __ . __ . __ . __ . __ . __ . __", 4,
              25.4, {12.7, -6.35, 0.0, -6.35});
   writeLType("DASHDOTTINY", "Dash dot (.15x) _._._._._._._._._._._._._._._.", 4,
@@ -18411,13 +18422,10 @@ void RS_FilterDXFRW::writeLTypes() {
              28.575, {19.05, -3.175, 3.175, -3.175});
   writeLType("CENTERX2", "Center (2x) ________  __  ________  __  _____", 4,
              101.6, {63.5, -12.7, 12.7, -12.7});
-  std::set<std::string> emittedNames{
-      "CONTINUOUS", "BYLAYER",    "BYBLOCK",     "DOT",        "DOTTINY",
-      "DOT2",       "DOTX2",      "DASHED",      "DASHEDTINY", "DASHED2",
-      "DASHEDX2",   "DASHDOT",    "DASHDOTTINY", "DASHDOT2",   "DASHDOTX2",
-      "DIVIDE",     "DIVIDETINY", "DIVIDE2",     "DIVIDEX2",   "BORDER",
-      "BORDERTINY", "BORDER2",    "BORDERX2",    "CENTER",     "CENTERTINY",
-      "CENTER2",    "CENTERX2"};
+  // Imported LTYPE records that are not part of the built-in table above are
+  // re-emitted as they came in; writeLType() records the built-in names so a
+  // new built-in type cannot end up written twice.
+  std::set<std::string> emittedNames = m_builtinLTypeNames;
   for (const auto &entry :
        m_graphic->dwgAdvancedMetadata().lineTypeTableEntries()) {
     if (!emittedNames.insert(normalizeDwgTableName(entry.first)).second)
@@ -31662,17 +31670,29 @@ RS2::LineType RS_FilterDXFRW::nameToLineType(const QString &name) {
     return RS2::DotLineX2;
   }
   if (uName == "ACAD_ISO02W100" || uName == "ACAD_ISO03W100" ||
-      uName == "DASHED" || uName == "HIDDEN") {
+      uName == "DASHED") {
     return RS2::DashLine;
   }
   if (uName == "DASHEDTINY") {
     return RS2::DashLineTiny;
   }
-  if (uName == "DASHED2" || uName == "HIDDEN2") {
+  if (uName == "DASHED2") {
     return RS2::DashLine2;
   }
-  if (uName == "DASHEDX2" || uName == "HIDDENX2") {
+  if (uName == "DASHEDX2") {
     return RS2::DashLineX2;
+  }
+  if (uName == "HIDDEN") {
+    return RS2::HiddenLine;
+  }
+  if (uName == "HIDDENTINY") {
+    return RS2::HiddenLineTiny;
+  }
+  if (uName == "HIDDEN2") {
+    return RS2::HiddenLine2;
+  }
+  if (uName == "HIDDENX2") {
+    return RS2::HiddenLineX2;
   }
   if (uName == "ACAD_ISO10W100" || uName == "DASHDOT") {
     return RS2::DashDotLine;
@@ -31750,6 +31770,14 @@ QString RS_FilterDXFRW::lineTypeToName(RS2::LineType lineType) {
     return "DASHED2";
   case RS2::DashLineX2:
     return "DASHEDX2";
+  case RS2::HiddenLine:
+    return "HIDDEN";
+  case RS2::HiddenLineTiny:
+    return "HIDDENTINY";
+  case RS2::HiddenLine2:
+    return "HIDDEN2";
+  case RS2::HiddenLineX2:
+    return "HIDDENX2";
   case RS2::DashDotLine:
     return "DASHDOT";
   case RS2::DashDotLineTiny:

--- a/librecad/src/lib/filters/rs_filterdxfrw.h
+++ b/librecad/src/lib/filters/rs_filterdxfrw.h
@@ -3021,6 +3021,9 @@ private:
    *  colliding with the fixed root/group handles C/D). Computed in fileExport
    *  before write(), consumed by the rawDxfObjects re-emit in writeObjects. */
   std::set<std::uint32_t> m_dxfSuppressedObjectHandles;
+  // Normalised names of the built-in LTYPE records written by writeLType()
+  // during writeLTypes(); imported raw records with these names are skipped.
+  std::set<std::string> m_builtinLTypeNames;
 
   /** DXF export (DWG->DXF): SOURCE handles of the named parent dictionaries
    *  emitted via setNamedDictObjects (F4-followup). Computed in fileExport,

--- a/librecad/src/lib/filters/rs_filterjww.cpp
+++ b/librecad/src/lib/filters/rs_filterjww.cpp
@@ -1284,7 +1284,10 @@ bool RS_FilterJWW::fileExport(RS_Graphic& g, const QString& file, RS2::FormatTyp
 
         // Line types:
         RS_DEBUG->print("writing line types...");
-        int numLT = (int)RS2::BorderLineX2-(int)RS2::LineByBlock;
+        // RS2::LineTypeUnchanged and RS2::LineSelected sit between the two
+        // blocks and are UI-only, so the table is written as two ranges.
+        int numLT = (int)RS2::BorderLineX2-(int)RS2::LineByBlock
+                  + (int)RS2::HiddenLineX2-(int)RS2::HiddenLine+1;
         if (type==RS2::FormatJWC) {
                 numLT-=2;
         }
@@ -1293,6 +1296,9 @@ bool RS_FilterJWW::fileExport(RS_Graphic& g, const QString& file, RS2::FormatTyp
                 if ((RS2::LineType)t!=RS2::NoPen) {
                         writeLineType(*dw, (RS2::LineType)t);
                 }
+        }
+        for (int t=(int)RS2::HiddenLine; t<=(int)RS2::HiddenLineX2; ++t) {
+                writeLineType(*dw, (RS2::LineType)t);
         }
         dw->tableEnd();
 
@@ -2755,14 +2761,23 @@ RS2::LineType RS_FilterJWW::nameToLineType(const QString& name) {
 
 
         } else if (uName=="ACAD_ISO02W100" || uName=="ACAD_ISO03W100" ||
-                           uName=="DASHED" || uName=="HIDDEN") {
+                           uName=="DASHED") {
                 return RS2::DashLine;
 
-        } else if (uName=="DASHED2" || uName=="HIDDEN2") {
+        } else if (uName=="DASHED2") {
                 return RS2::DashLine2;
 
-        } else if (uName=="DASHEDX2" || uName=="HIDDENX2") {
+        } else if (uName=="DASHEDX2") {
                 return RS2::DashLineX2;
+
+        } else if (uName=="HIDDEN") {
+                return RS2::HiddenLine;
+
+        } else if (uName=="HIDDEN2") {
+                return RS2::HiddenLine2;
+
+        } else if (uName=="HIDDENX2") {
+                return RS2::HiddenLineX2;
 
 
         } else if (uName=="ACAD_ISO10W100" ||
@@ -2842,6 +2857,16 @@ QString RS_FilterJWW::lineTypeToName(RS2::LineType lineType) {
                 break;
         case RS2::DashLineX2:
                 return "DASHEDX2";
+                break;
+
+        case RS2::HiddenLine:
+                return "HIDDEN";
+                break;
+        case RS2::HiddenLine2:
+                return "HIDDEN2";
+                break;
+        case RS2::HiddenLineX2:
+                return "HIDDENX2";
                 break;
 
         case RS2::DashDotLine:

--- a/librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
+++ b/librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
@@ -58,7 +58,6 @@
 #include "rs_entity.h"
 #include "rs_block.h"
 #include "rs_layer.h"
-#include "rs_line.h"
 #include "rs_pen.h"
 #include "rs_point.h"
 #include "rs_settings.h"
@@ -4624,17 +4623,23 @@ TEST_CASE("DXF export rejects malformed typed conversion sidecars",
   std::filesystem::remove(out);
 }
 
-TEST_CASE("DXF import maps HIDDEN2 to the half-scale dashed linetype, not the tiny one",
+TEST_CASE("DXF import maps HIDDEN2 to the half-scale dashed linetype",
           "[dxf][filter][linetype][regression]") {
   ensureSettings();
   const std::string src = tmpFile("hidden2_src.dxf");
   std::filesystem::remove(src);
 
-  // No LTYPE table on purpose: the entity's group 6 is resolved by name in
-  // nameToLineType(), so the mapping is exercised without a table record.
   writeText(src,
-            "0\nSECTION\n2\nENTITIES\n"
-            "0\nLINE\n8\n0\n6\nHIDDEN2\n"
+            "0\nSECTION\n2\nHEADER\n9\n$ACADVER\n1\nAC1009\n0\nENDSEC\n"
+            "0\nSECTION\n2\nTABLES\n"
+            "0\nTABLE\n2\nLTYPE\n70\n1\n"
+            "0\nLTYPE\n2\nHIDDEN2\n70\n0\n3\nHidden (.5X)\n72\n65\n73\n2\n40\n0.1875\n"
+            "49\n0.125\n74\n0\n49\n-0.0625\n74\n0\n"
+            "0\nENDTAB\n0\nTABLE\n2\nLAYER\n70\n2\n"
+            "0\nLAYER\n2\n0\n70\n0\n62\n7\n6\nCONTINUOUS\n"
+            "0\nLAYER\n2\nHIDDEN_LAYER\n70\n0\n62\n7\n6\nHIDDEN2\n"
+            "0\nENDTAB\n0\nENDSEC\n0\nSECTION\n2\nENTITIES\n"
+            "0\nLINE\n8\nHIDDEN_LAYER\n6\nHIDDEN2\n"
             "10\n0.0\n20\n0.0\n11\n10.0\n21\n0.0\n"
             "0\nENDSEC\n0\nEOF\n");
 
@@ -4644,16 +4649,13 @@ TEST_CASE("DXF import maps HIDDEN2 to the half-scale dashed linetype, not the ti
     REQUIRE(filter.fileImport(graphic, QString::fromStdString(src),
                               RS2::FormatDXFRW));
   }
+  const auto *layer = graphic.findLayer(QStringLiteral("HIDDEN_LAYER"));
+  REQUIRE(layer != nullptr);
+  CHECK(layer->getPen().getLineType() == RS2::DashLine2);
+
   RS_Entity *line = graphic.firstEntity();
   REQUIRE(line != nullptr);
-  // HIDDEN2 is acad.lin's .5x hidden line; DASHED2 is the .5x dashed line.
-  // DASHEDTINY is LibreCAD's own .15x variant and far too fine for it.
   CHECK(line->getPen(false).getLineType() == RS2::DashLine2);
-
-  // Table neighbours, so a reshuffle of nameToLineType() is caught as well.
-  CHECK(RS_FilterDXFRW::nameToLineType("DASHEDTINY") == RS2::DashLineTiny);
-  CHECK(RS_FilterDXFRW::nameToLineType("DASHED2") == RS2::DashLine2);
-  CHECK(RS_FilterDXFRW::nameToLineType("hidden2") == RS2::DashLine2);
 
   std::filesystem::remove(src);
 }

--- a/librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
+++ b/librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
@@ -58,6 +58,8 @@
 #include "rs_entity.h"
 #include "rs_block.h"
 #include "rs_layer.h"
+#include "rs_line.h"
+#include "rs_pen.h"
 #include "rs_point.h"
 #include "rs_settings.h"
 
@@ -4620,4 +4622,38 @@ TEST_CASE("DXF export rejects malformed typed conversion sidecars",
   CHECK(countRecords(out, "POINT") == 0);
 
   std::filesystem::remove(out);
+}
+
+TEST_CASE("DXF import maps HIDDEN2 to the half-scale dashed linetype, not the tiny one",
+          "[dxf][filter][linetype][regression]") {
+  ensureSettings();
+  const std::string src = tmpFile("hidden2_src.dxf");
+  std::filesystem::remove(src);
+
+  // No LTYPE table on purpose: the entity's group 6 is resolved by name in
+  // nameToLineType(), so the mapping is exercised without a table record.
+  writeText(src,
+            "0\nSECTION\n2\nENTITIES\n"
+            "0\nLINE\n8\n0\n6\nHIDDEN2\n"
+            "10\n0.0\n20\n0.0\n11\n10.0\n21\n0.0\n"
+            "0\nENDSEC\n0\nEOF\n");
+
+  RS_Graphic graphic;
+  {
+    RS_FilterDXFRW filter;
+    REQUIRE(filter.fileImport(graphic, QString::fromStdString(src),
+                              RS2::FormatDXFRW));
+  }
+  RS_Entity *line = graphic.firstEntity();
+  REQUIRE(line != nullptr);
+  // HIDDEN2 is acad.lin's .5x hidden line; DASHED2 is the .5x dashed line.
+  // DASHEDTINY is LibreCAD's own .15x variant and far too fine for it.
+  CHECK(line->getPen(false).getLineType() == RS2::DashLine2);
+
+  // Table neighbours, so a reshuffle of nameToLineType() is caught as well.
+  CHECK(RS_FilterDXFRW::nameToLineType("DASHEDTINY") == RS2::DashLineTiny);
+  CHECK(RS_FilterDXFRW::nameToLineType("DASHED2") == RS2::DashLine2);
+  CHECK(RS_FilterDXFRW::nameToLineType("hidden2") == RS2::DashLine2);
+
+  std::filesystem::remove(src);
 }

--- a/librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
+++ b/librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
@@ -58,6 +58,8 @@
 #include "rs_entity.h"
 #include "rs_block.h"
 #include "rs_layer.h"
+#include "rs_line.h"
+#include "rs_linetypepattern.h"
 #include "rs_pen.h"
 #include "rs_point.h"
 #include "rs_settings.h"
@@ -144,6 +146,32 @@ std::string dstyleDirectionVariant(const std::string &path,
     return output.str();
   }
   return {};
+}
+
+// Returns the group-`code` values of the LTYPE table record named `ltypeName`.
+// libdxfrw writes the name (2) before the pattern groups (3/73/40/49), so the
+// name is matched first and the values are collected until the next record.
+std::vector<std::string> ltypeRecordGroupValues(const std::string &path,
+                                                const std::string &ltypeName,
+                                                const std::string &code) {
+  std::ifstream in(path);
+  std::string codeLine, valueLine;
+  std::vector<std::string> values;
+  bool inLtype = false;
+  bool nameMatched = false;
+  while (std::getline(in, codeLine) && std::getline(in, valueLine)) {
+    const std::string groupCode = trimDxfToken(codeLine);
+    const std::string value = trimDxfToken(valueLine);
+    if (groupCode == "0") {
+      inLtype = value == "LTYPE";
+      nameMatched = false;
+    } else if (inLtype && groupCode == "2") {
+      nameMatched = value == ltypeName;
+    } else if (inLtype && nameMatched && groupCode == code) {
+      values.push_back(value);
+    }
+  }
+  return values;
 }
 
 // Counts occurrences of a "0\n<NAME>\n" record marker in a DXF file.
@@ -4623,7 +4651,7 @@ TEST_CASE("DXF export rejects malformed typed conversion sidecars",
   std::filesystem::remove(out);
 }
 
-TEST_CASE("DXF import maps HIDDEN2 to the half-scale dashed linetype",
+TEST_CASE("DXF import maps HIDDEN2 to the half-scale hidden linetype",
           "[dxf][filter][linetype][regression]") {
   ensureSettings();
   const std::string src = tmpFile("hidden2_src.dxf");
@@ -4651,11 +4679,129 @@ TEST_CASE("DXF import maps HIDDEN2 to the half-scale dashed linetype",
   }
   const auto *layer = graphic.findLayer(QStringLiteral("HIDDEN_LAYER"));
   REQUIRE(layer != nullptr);
-  CHECK(layer->getPen().getLineType() == RS2::DashLine2);
+  CHECK(layer->getPen().getLineType() == RS2::HiddenLine2);
 
   RS_Entity *line = graphic.firstEntity();
   REQUIRE(line != nullptr);
-  CHECK(line->getPen(false).getLineType() == RS2::DashLine2);
+  CHECK(line->getPen(false).getLineType() == RS2::HiddenLine2);
 
   std::filesystem::remove(src);
+}
+
+TEST_CASE("DXF round-trip preserves the HIDDEN linetype on an entity",
+          "[dxf][roundtrip][filter][linetype]") {
+  ensureSettings();
+  const std::string out = tmpFile("hidden_out.dxf");
+  const std::string dwg = tmpFile("hidden.dwg");
+  std::filesystem::remove(out);
+  std::filesystem::remove(dwg);
+
+  RS_Graphic graphic;
+  graphic.initForNewDocument();
+  auto *line = new RS_Line(&graphic, RS_LineData(RS_Vector(0.0, 0.0),
+                                                 RS_Vector(10.0, 10.0)));
+  line->setPen(RS_Pen(RS_Color(255, 0, 0), RS2::Width00, RS2::HiddenLine));
+  graphic.addEntity(line);
+
+  {
+    RS_FilterDXFRW filter;
+    REQUIRE(filter.fileExport(graphic, QString::fromStdString(out),
+                              RS2::FormatDXFRW));
+  }
+
+  // The entity references the linetype by its acad.lin name...
+  CHECK(recordGroupValues(out, "LINE", "6") ==
+        std::vector<std::string>{"HIDDEN"});
+  // ...and the LTYPE table carries acad.lin's HIDDEN (A,.25,-.125) in mm.
+  const auto dashes = ltypeRecordGroupValues(out, "HIDDEN", "49");
+  REQUIRE(dashes.size() == 2);
+  CHECK(std::stod(dashes[0]) == Catch::Approx(6.35));
+  CHECK(std::stod(dashes[1]) == Catch::Approx(-3.175));
+  CHECK(ltypeRecordGroupValues(out, "HIDDEN", "73") ==
+        std::vector<std::string>{"2"});
+
+  RS_Graphic reimported;
+  {
+    RS_FilterDXFRW filter;
+    REQUIRE(filter.fileImport(reimported, QString::fromStdString(out),
+                              RS2::FormatDXFRW));
+  }
+  RS_Entity *imported = reimported.firstEntity();
+  REQUIRE(imported != nullptr);
+  CHECK(imported->getPen(false).getLineType() == RS2::HiddenLine);
+
+  // The reimported drawing now carries HIDDEN in its raw LTYPE table copy as
+  // well; saving it again must write the record once, not once per source.
+  const std::string out2 = tmpFile("hidden_out2.dxf");
+  std::filesystem::remove(out2);
+  {
+    RS_FilterDXFRW filter;
+    REQUIRE(filter.fileExport(reimported, QString::fromStdString(out2),
+                              RS2::FormatDXFRW));
+  }
+  CHECK(ltypeRecordGroupValues(out2, "HIDDEN", "73") ==
+        std::vector<std::string>{"2"});
+  CHECK(recordGroupValues(out2, "LINE", "6") ==
+        std::vector<std::string>{"HIDDEN"});
+  std::filesystem::remove(out2);
+
+#ifdef DWGSUPPORT
+  // The DWG writer resolves entity linetypes by handle against the LTYPE
+  // table emitted by writeLTypes(), so a missing record would silently
+  // degrade the pen here.
+  {
+    RS_FilterDXFRW filter;
+    REQUIRE(filter.fileExport(graphic, QString::fromStdString(dwg),
+                              RS2::FormatDWG2004));
+  }
+  RS_Graphic fromDwg;
+  {
+    RS_FilterDXFRW filter;
+    REQUIRE(filter.fileImport(fromDwg, QString::fromStdString(dwg),
+                              RS2::FormatDWG));
+  }
+  RS_Entity *dwgLine = fromDwg.firstEntity();
+  REQUIRE(dwgLine != nullptr);
+  CHECK(dwgLine->getPen(false).getLineType() == RS2::HiddenLine);
+#endif
+
+  std::filesystem::remove(out);
+  std::filesystem::remove(dwg);
+}
+
+TEST_CASE("Every DXF linetype name LibreCAD writes maps back to the same RS2::LineType",
+          "[dxf][filter][linetype]") {
+  for (const RS2::LineType type : {
+           RS2::SolidLine,
+           RS2::DotLine, RS2::DotLineTiny, RS2::DotLine2, RS2::DotLineX2,
+           RS2::DashLine, RS2::DashLineTiny, RS2::DashLine2, RS2::DashLineX2,
+           RS2::HiddenLine, RS2::HiddenLineTiny, RS2::HiddenLine2,
+           RS2::HiddenLineX2,
+           RS2::DashDotLine, RS2::DashDotLineTiny, RS2::DashDotLine2,
+           RS2::DashDotLineX2,
+           RS2::DivideLine, RS2::DivideLineTiny, RS2::DivideLine2,
+           RS2::DivideLineX2,
+           RS2::CenterLine, RS2::CenterLineTiny, RS2::CenterLine2,
+           RS2::CenterLineX2,
+           RS2::BorderLine, RS2::BorderLineTiny, RS2::BorderLine2,
+           RS2::BorderLineX2,
+           RS2::LineByLayer, RS2::LineByBlock}) {
+    const QString name = RS_FilterDXFRW::lineTypeToName(type);
+    INFO("linetype " << static_cast<int>(type) << " -> " << name.toStdString());
+    CHECK(RS_FilterDXFRW::nameToLineType(name) == type);
+  }
+
+  // The hidden family keeps its acad.lin names, distinct from DASHED*.
+  CHECK(RS_FilterDXFRW::lineTypeToName(RS2::HiddenLine) == "HIDDEN");
+  CHECK(RS_FilterDXFRW::lineTypeToName(RS2::HiddenLineTiny) == "HIDDENTINY");
+  CHECK(RS_FilterDXFRW::lineTypeToName(RS2::HiddenLine2) == "HIDDEN2");
+  CHECK(RS_FilterDXFRW::lineTypeToName(RS2::HiddenLineX2) == "HIDDENX2");
+
+  // Every drawable type must have a screen pattern: RS_Painter dereferences
+  // getPattern() without a null check.
+  for (const RS2::LineType type : {RS2::HiddenLine, RS2::HiddenLineTiny,
+                                   RS2::HiddenLine2, RS2::HiddenLineX2}) {
+    INFO("linetype " << static_cast<int>(type));
+    CHECK(RS_LineTypePattern::getPattern(type) != nullptr);
+  }
 }

--- a/librecad/src/lib/generators/makercamsvg/lc_makercamsvg.cpp
+++ b/librecad/src/lib/generators/makercamsvg/lc_makercamsvg.cpp
@@ -813,6 +813,8 @@ std::string LC_MakerCamSVG::svgPathAnyLineType(RS_Vector startpoint, RS_Vector e
     constexpr double lineScale2 = 0.5;
     constexpr double lineScaleOne = 1.0;
     constexpr double lineScaleX2 = 2.0;
+    // acad.lin defines HIDDEN as half of DASHED (.25,-.125 vs .5,-.25)
+    constexpr double hiddenScale = 0.5;
 
     std::string path;
     double lineScale;
@@ -858,6 +860,27 @@ std::string LC_MakerCamSVG::svgPathAnyLineType(RS_Vector startpoint, RS_Vector e
         }
         case RS2::DashLineX2: {
             lineScale = lineScaleX2;
+            lineFactor = dashFactor;
+            break;
+        }
+
+        case RS2::HiddenLineTiny: {
+            lineScale = lineScaleTiny * hiddenScale;
+            lineFactor = dashFactor;
+            break;
+        }
+        case RS2::HiddenLine2: {
+            lineScale = lineScale2 * hiddenScale;
+            lineFactor = dashFactor;
+            break;
+        }
+        case RS2::HiddenLine: {
+            lineScale = lineScaleOne * hiddenScale;
+            lineFactor = dashFactor;
+            break;
+        }
+        case RS2::HiddenLineX2: {
+            lineScale = lineScaleX2 * hiddenScale;
             lineFactor = dashFactor;
             break;
         }
@@ -988,7 +1011,11 @@ std::string LC_MakerCamSVG::getLinePattern(RS_Vector* lastPos, RS_Vector step, R
         case RS2::DashLineTiny:
         case RS2::DashLine2:
         case RS2::DashLine:
-        case RS2::DashLineX2: {
+        case RS2::DashLineX2:
+        case RS2::HiddenLineTiny:
+        case RS2::HiddenLine2:
+        case RS2::HiddenLine:
+        case RS2::HiddenLineX2: {
             path += getLineSegment(lastPos, step, lineScale, true);
             break;
         }

--- a/librecad/src/lib/gui/rs_linetypepattern.cpp
+++ b/librecad/src/lib/gui/rs_linetypepattern.cpp
@@ -63,6 +63,11 @@ const RS_LineTypePattern PATTERN_BORDER_LINE_TINY{{2., -1., 2., -1., 0.15, -1.}}
 const RS_LineTypePattern PATTERN_BORDER_LINE{{12.0, -4.0, 12.0, -4., 0.2, -4.}};
 const RS_LineTypePattern PATTERN_BORDER_LINE2{{6.0, -3.0, 6.0, -3., 0.2, -3.}};
 const RS_LineTypePattern PATTERN_BORDER_LINE_X2{{24.0, -8.0, 24.0, -8., 0.2, -8.}};
+// acad.lin HIDDEN is half of DASHED (.25,-.125 vs .5,-.25)
+const RS_LineTypePattern PATTERN_HIDDEN_LINE_TINY{{1., -0.5}};
+const RS_LineTypePattern PATTERN_HIDDEN_LINE{{6.0, -3.0}};
+const RS_LineTypePattern PATTERN_HIDDEN_LINE2{{3.0, -1.5}};
+const RS_LineTypePattern PATTERN_HIDDEN_LINE_X2{{12.0, -6.0}};
 
 const RS_LineTypePattern PATTERN_BLOCK_LINE{{0.5, -0.5}};
 const RS_LineTypePattern PATTERN_SELECTED{{1.0, -3.0}};
@@ -104,6 +109,10 @@ const RS_LineTypePattern* RS_LineTypePattern::getPattern(const RS2::LineType lin
             {RS2::BorderLineTiny, &PATTERN_BORDER_LINE_TINY},
             {RS2::BorderLine2, &PATTERN_BORDER_LINE2},
             {RS2::BorderLineX2, &PATTERN_BORDER_LINE_X2},
+            {RS2::HiddenLine, &PATTERN_HIDDEN_LINE},
+            {RS2::HiddenLineTiny, &PATTERN_HIDDEN_LINE_TINY},
+            {RS2::HiddenLine2, &PATTERN_HIDDEN_LINE2},
+            {RS2::HiddenLineX2, &PATTERN_HIDDEN_LINE_X2},
             {RS2::LineByLayer, &PATTERN_BLOCK_LINE},
             {RS2::LineByBlock, &PATTERN_BLOCK_LINE},
             {RS2::LineSelected, &PATTERN_SELECTED}

--- a/librecad/src/main/doc_plugin_interface.cpp
+++ b/librecad/src/main/doc_plugin_interface.cpp
@@ -70,6 +70,9 @@ convLTW::convLTW() {
     lType.insert(RS2::DashLine, "DashLine");
     lType.insert(RS2::DashLine2, "DashLine2");
     lType.insert(RS2::DashLineX2, "DashLineX2");
+    lType.insert(RS2::HiddenLine, "HiddenLine");
+    lType.insert(RS2::HiddenLine2, "HiddenLine2");
+    lType.insert(RS2::HiddenLineX2, "HiddenLineX2");
     lType.insert(RS2::DashDotLine, "DashDotLine");
     lType.insert(RS2::DashDotLine2, "DashDotLine2");
     lType.insert(RS2::DashDotLineX2, "DashDotLineX2");

--- a/librecad/src/ui/components/comboboxes/qg_linetypebox.cpp
+++ b/librecad/src/ui/components/comboboxes/qg_linetypebox.cpp
@@ -95,6 +95,10 @@ void QG_LineTypeBox::init(const bool showByLayer, const bool showUnchanged, cons
     addItem(QIcon(":linetypes/linetype03.lci"), tr("Dash (tiny)"), RS2::DashLineTiny);
     addItem(QIcon(":linetypes/linetype03.lci"), tr("Dash (small)"), RS2::DashLine2);
     addItem(QIcon(":linetypes/linetype03.lci"), tr("Dash (large)"), RS2::DashLineX2);
+    addItem(QIcon(":linetypes/linetype08.lci"), tr("Hidden"), RS2::HiddenLine);
+    addItem(QIcon(":linetypes/linetype08.lci"), tr("Hidden (tiny)"), RS2::HiddenLineTiny);
+    addItem(QIcon(":linetypes/linetype08.lci"), tr("Hidden (small)"), RS2::HiddenLine2);
+    addItem(QIcon(":linetypes/linetype08.lci"), tr("Hidden (large)"), RS2::HiddenLineX2);
     addItem(QIcon(":linetypes/linetype04.lci"), tr("Dash Dot"), RS2::DashDotLine);
     addItem(QIcon(":linetypes/linetype04.lci"), tr("Dash Dot (tiny)"), RS2::DashDotLineTiny);
     addItem(QIcon(":linetypes/linetype04.lci"), tr("Dash Dot (small)"), RS2::DashDotLine2);

--- a/librecad/src/ui/dock_widgets/pen_palette/lc_peninforegistry.cpp
+++ b/librecad/src/ui/dock_widgets/pen_palette/lc_peninforegistry.cpp
@@ -307,6 +307,10 @@ void LC_PenInfoRegistry::registerLineTypes(){
     doRegisterLineType(":linetypes/linetype03.lci", tr("Dash (tiny)"), RS2::DashLineTiny);
     doRegisterLineType(":linetypes/linetype03.lci", tr("Dash (small)"), RS2::DashLine2);
     doRegisterLineType(":linetypes/linetype03.lci", tr("Dash (large)"), RS2::DashLineX2);
+    doRegisterLineType(":linetypes/linetype08.lci", tr("Hidden"), RS2::HiddenLine);
+    doRegisterLineType(":linetypes/linetype08.lci", tr("Hidden (tiny)"), RS2::HiddenLineTiny);
+    doRegisterLineType(":linetypes/linetype08.lci", tr("Hidden (small)"), RS2::HiddenLine2);
+    doRegisterLineType(":linetypes/linetype08.lci", tr("Hidden (large)"), RS2::HiddenLineX2);
     doRegisterLineType(":linetypes/linetype04.lci", tr("Dash Dot"), RS2::DashDotLine);
     doRegisterLineType(":linetypes/linetype04.lci", tr("Dash Dot (tiny)"), RS2::DashDotLineTiny);
     doRegisterLineType(":linetypes/linetype04.lci", tr("Dash Dot (small)"), RS2::DashDotLine2);


### PR DESCRIPTION
### The bug

LibreCAD has no native HIDDEN linetype. On import, `RS_FilterDXFRW::nameToLineType()` maps the acad.lin names `HIDDEN` / `HIDDEN2` / `HIDDENX2` onto the DASHED family, and on save `lineTypeToName()` writes them back as `DASHED` / `DASHED2` / `DASHEDX2` (`DASHEDTINY` for `HIDDEN2` before #2814). The substitution is silent: a drawing that comes in from AutoCAD with hidden lines leaves LibreCAD with dashed lines on every entity and layer that used them. Since abd1f4a8e the raw LTYPE *records* survive in `LC_DwgAdvancedMetadata` and are re-emitted, so the saved file even carries an orphaned `HIDDEN` record that nothing references any more. Layer standards and other CAD packages key on that name.

Reproduce: open a DXF with one `LINE` whose group 6 is `HIDDEN` (fixture `single_HIDDEN.dxf` below), select it: the Properties dock reads *Dash*. Save as DXF: the `LINE` carries `6/DASHED`.

### Root cause

`RS2::LineType` is a closed catalogue of seven families × four variants, and the pen stores only the enum, so a name that has no enum value cannot survive a round-trip. `HIDDEN*` are aliases of `DashLine*` in the substitution table; there is nothing to write them back to.

### The fix

HIDDEN becomes a first-class family, following the convention set by ca7c096e6 (2014, tiny variants for every family) and 4c77bc92a (2015, DXF persistence of the tiny variants):

- `RS2::HiddenLine`, `HiddenLineTiny`, `HiddenLine2`, `HiddenLineX2` = 28..31, **appended after `LineSelected`**. The numeric values are persisted in QSettings (`rs_settings.cpp`), in `.lcp` pen palettes (`lc_penpalettedata.cpp`) and in `$DIMLTYPE` (`lc_dimstyletovariablesmapper.cpp`), and are cast straight into the plugin interface (`doc_plugin_interface.cpp`), so inserting into the middle of the enum is not an option; a comment in `rs.h` now says so.
- LTYPE metrics straight from acad.lin × 25.4, the same derivation the DASHED family uses: `HIDDEN` 6.35/−3.175, `HIDDEN2` 3.175/−1.5875, `HIDDENX2` 12.7/−6.35, `HIDDENTINY` 0.9525/−0.47625. `HIDDEN` is therefore numerically `DASHED2` and `HIDDENX2` is `DASHED`; the point of the family is to preserve the **name**, not to look different.
- Screen patterns with the same rounded-millimetre scheme as DASHED (12/6 for 12.7/6.35), so HIDDEN draws as 6/−3. `rs_painter.cpp` needs no change: its default branch renders any registered pattern. **Visible change:** drawings that carried `HIDDEN` / `HIDDEN2` / `HIDDENX2` were rendered with the DASHED patterns (12/−6, 6/−3, 24/−12 on screen); they now render at half that length (6/−3, 3/−1.5, 12/−6), which is what acad.lin's ratios say and what AutoCAD shows.
- `nameToLineType()` / `lineTypeToName()` map the four names both ways; `writeLTypes()` emits the four records, which the DWG writer (`dwgWriter15`) and the DIMSTYLE writer also resolve against.
- `writeLTypes()` used to skip re-emitting imported raw LTYPE records by checking a hand-written set of the 27 built-in names. Adding the new records without touching that set would have written `HIDDEN` twice for a file that already carried it (caught by the GUI round-trip below), so `writeLType()` now records the names it writes and the skip set is derived from that.
- JWW: the name tables gain the same three names DASHED has (that filter never carried tiny variants), and the LTYPE range loop in `fileExport()`, which stopped at `BorderLineX2`, now also covers the new block. JWW export is not reachable from the UI and `DL_Jww::writeLineType()` is an empty stub, so this is for consistency.
- MakerCAM SVG export gets the four cases; the hidden ladder is the dash ladder halved, mirroring acad.lin.
- Pen toolbar combobox and pen palette list *Hidden*, *Hidden (tiny)*, *Hidden (small)*, *Hidden (large)* right after the Dash family, with their own icon (`linetype08.svg`, the Dash icon with half the dash length). The property sheet inherits both.
- The plugin string bridge (`convLTW` in `doc_plugin_interface.cpp`, the `DPI::LTYPE` property that e.g. the *sameprop* plugin copies between entities) gains the three names, like the DASHED entries next to it; without them a HIDDEN entity would have reached plugins as `BYLAYER` where it used to say `DashLine`.

Left alone on purpose: the public `DPI::LineType` enum in `document_interface.h` (it already lacks the tiny variants and is cast to/from `RS2::LineType` without translation — deserves its own fix), `rs_filterdxf.cpp` (not in the CMake build) and `rs_python_wrappers.cpp` (behind `RS_OPT_PYTHON`). Compatibility note: like every enumerator added before, a pen set to a hidden type in QSettings and then read by an older LibreCAD is not validated on the way in (the `FIXME` in `rs_settings.cpp`); `.lcp` palettes go through `LC_PenInfoRegistry::hasLineType()` and reject it cleanly. This does not implement `.lin` loading (#1738); it fixes the built-in substitution table, which stays the fallback once `.lin` support exists.

Fixes #2813. Builds on #2814 (the `HIDDEN2` mapping fix): that commit is the first of the two here, so this PR shows both until #2814 is merged.

### Verification

Built with `pixi` (conda-forge Qt 6.8.2, GCC 13.3, the same recipe as `run_pixi.yml`) from `origin/master` with and without this change (RelWithDebInfo, `-DBUILD_TESTS=ON`; no warnings). Unit tests and the two CI lanes were run at 5822ae887; the GUI scenarios at b8da4aaf2, four commits earlier, none of which touches linetypes.

Unit (`dxf_roundtrip_tests.cpp`, part of `librecad_dxf_fast_tests`, the lane run by `dwg-dxf-verify.yml`): three new cases — a `LINE` with pen `HiddenLine` exported through `RS_FilterDXFRW` carries `6/HIDDEN`, the LTYPE table has `HIDDEN` with path 6.35/−3.175, importing it back (DXF, and DWG under `DWGSUPPORT`) yields `HiddenLine`, and saving the reimported drawing writes the record once; the `HIDDEN2` regression test now expects `HiddenLine2`; every name `lineTypeToName()` writes maps back to the same enum through `nameToLineType()`, and every hidden variant has a screen pattern. `librecad_dxf_fast_tests`: 517 cases passed; `librecad_dwg_fast_tests`: 909 passed, 37 skipped (fixtures), 0 failed.

GUI, Qt `vnc` platform driven by the harness in `tools/` (pen toolbar, command line, *File › Save as*, Properties dock; saved files checked with `check_dxf_linetype.py` / ezdxf):

| scenario | master (b8da4aaf2) | with this change |
|---|---|---|
| G1 pen toolbar line-type list, entries after *Dash (large)* | Dash Dot… | Hidden, Hidden (tiny), Hidden (small), Hidden (large) |
| G2 pick *Hidden*, draw a line, *Save as* → LTYPE table + group 6 | (no such entry; line saved ByLayer) | `HIDDEN` record 6.35/−3.175, `LINE` with `6/HIDDEN` |
| G3 reopen the G2 file, select, Properties dock | — | Hidden |
| G4 external `single_HIDDEN.dxf` / `single_HIDDEN2.dxf` / `single_HIDDENX2.dxf`, Properties dock | Dash / Dash (tiny) / Dash (large) | Hidden / Hidden (small) / Hidden (large) |
| G5 external `hidden_family.dxf` (3 lines + a layer using HIDDEN), *Save as* → group 6 of the lines, layer linetype, LTYPE records | `DASHED` / `DASHEDTINY` / `DASHEDX2`, layer `DASHED`; orphaned `HIDDEN*` records kept | `HIDDEN` / `HIDDEN2` / `HIDDENX2`, layer `HIDDEN`; 31 LTYPE records, no duplicates |

![pen toolbar line-type list, base vs fix](https://raw.githubusercontent.com/ROMPEFUEGOS/LibreCAD/pr-assets-hidden-linetype/test-results/hidden/combobox_base_vs_fix.png)

![Properties dock on the single-line fixtures, base vs fix](https://raw.githubusercontent.com/ROMPEFUEGOS/LibreCAD/pr-assets-hidden-linetype/test-results/hidden/properties_fixtures_base_vs_fix.png)

Full set — `results.json`, all screenshots, the fixtures, the saved DXF files and the harness: [branch `pr-assets-hidden-linetype`](https://github.com/ROMPEFUEGOS/LibreCAD/tree/pr-assets-hidden-linetype/test-results/hidden) of the fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gqZ2BjNbthdqRGX2YDugY
