### PR TITLE
Fix HIDDEN2 DXF import mapping

### DIFF
--- a/librecad/src/lib/filters/rs_filterdxfrw.cpp
+++ b/librecad/src/lib/filters/rs_filterdxfrw.cpp
@@ -3317,7 +3317,7 @@ RS2::LineType RS_FilterDXFRW::nameToLineType(const QString& name) {
                uName=="DASHED" || uName=="HIDDEN") {
         return RS2::DashLine;
 
-    } else if (uName=="DASHEDTINY" || uName=="HIDDEN2") {
+    } else if (uName=="DASHEDTINY") {
         return RS2::DashLineTiny;
 
     } else if (uName=="DASHED2" || uName=="HIDDEN2") {


### PR DESCRIPTION
Backports the `HIDDEN2` DXFRW linetype mapping fix from #2814.

`HIDDEN2` was matched by the earlier `DASHEDTINY` condition, so it never reached its intended `DASHED2` / `DashLine2` mapping. Remove the duplicate alias from the tiny-line condition.

Verification:
- CMake Debug build of the `librecad` target completed successfully on macOS.

This intentionally contains only the release-branch-compatible production fix; `2.2.1` does not include master's focused DXF test target.