### PR TITLE
Fix spline close command on 2.2.1

### DIFF
--- a/librecad/src/actions/rs_actiondrawspline.cpp
+++ b/librecad/src/actions/rs_actiondrawspline.cpp
@@ -228,11 +228,11 @@ void RS_ActionDrawSpline::commandEvent(RS_CommandEvent* e) {
         break;
 
     case SetNextPoint:
-        /*if (checkCommand("close", c)) {
+        if (checkCommand("close", c)) {
             close();
             updateMouseButtonHints();
             return;
-        }*/
+        }
 
         if (checkCommand("undo", c)) {
             undo();
@@ -257,7 +257,8 @@ QStringList RS_ActionDrawSpline::getAvailableCommands() {
     case SetNextPoint:
 		if (pPoints->history.size()>=2) {
             cmd += command("undo");
-		}else if (pPoints->history.size()>=3) {
+        }
+		if (pPoints->history.size()>=3) {
             cmd += command("close");
         }
         break;
@@ -321,25 +322,18 @@ void RS_ActionDrawSpline::updateMouseCursor() {
     graphicView->setMouseCursor(RS2::CadCursor);
 }
 
-/*
 void RS_ActionDrawSpline::close() {
-    if (history.count()>2 && start.valid) {
-        //data.endpoint = start;
-        //trigger();
-                if (spline) {
-                        RS_CoordinateEvent e(spline->getStartpoint());
-                        coordinateEvent(&e);
-                }
-                trigger();
+    if (pPoints->spline && pPoints->history.size()>2) {
+        pPoints->spline->setClosed(true);
+        trigger();
+        reset();
         setStatus(SetStartpoint);
-        graphicView->moveRelativeZero(start);
     } else {
         RS_DIALOGFACTORY->commandMessage(
             tr("Cannot close sequence of lines: "
                "Not enough entities defined yet."));
     }
 }
-*/
 
 void RS_ActionDrawSpline::undo() {
 	if (pPoints->history.size()>1) {

--- a/librecad/src/actions/rs_actiondrawspline.h
+++ b/librecad/src/actions/rs_actiondrawspline.h
@@ -71,7 +71,7 @@ public:
 	void updateMouseCursor() override;
 //    void updateToolBar() override;
 
-	//void close();
+	void close();
 	virtual void undo();
 	virtual void setDegree(int deg);
 	int getDegree();

--- a/librecad/src/lib/engine/rs_spline.cpp
+++ b/librecad/src/lib/engine/rs_spline.cpp
@@ -187,7 +187,7 @@ void RS_Spline::update() {
 
     // wrap control points, if it's not wrapped yet
     std::vector<RS_Vector>& tControlPoints = data.controlPoints;
-    if (data.closed && (data.degree == 2 || !hasWrappedControlPoints())) {
+    if (data.closed && !hasWrappedControlPoints()) {
         std::vector<RS_Vector> wrappedPoints{data.controlPoints.cbegin(), data.controlPoints.cbegin() + data.degree};
         tControlPoints.insert(tControlPoints.end(), wrappedPoints.cbegin(), wrappedPoints.cend());
         RS_DEBUG->print(RS_Debug::D_NOTICE, "%s: controlPoints: size=%llu\n", __func__, data.controlPoints.size());
@@ -493,13 +493,12 @@ void RS_Spline::removeLastControlPoint() {
 
 /**
  * @brief hasWrappedControlPoints whether the control points are wrapped, needed for a closed spline.
- *          only implemented for cubic splines
  * @return bool - true, if the control points are already wrapped.
- *          for a cubic spline with wrapped splines, the last three control points are the same as the first three.
+ *          the last degree control points are the same as the first degree control points.
  */
 bool RS_Spline::hasWrappedControlPoints() const {
     const std::vector<RS_Vector>& controlPoints = data.controlPoints;
-    if (!data.closed || data.degree < 3 || controlPoints.size() < size_t(2 * data.degree) + 1)
+    if (!data.closed || data.degree < 1 || controlPoints.size() < size_t(2 * data.degree))
         return false;
 
     return std::equal(controlPoints.cbegin(), controlPoints.cbegin() + data.degree,


### PR DESCRIPTION
## Summary
- Restore the advertised `close` command for control-point splines.
- Keep closed spline control points wrapped exactly once across repeated updates.
- Preserve the selected Closed option for the next spline.

## Verification
- `git diff --check`
- qmake6-generated compilation of `rs_spline.cpp` and `rs_actiondrawspline.cpp`

A complete local qmake6 build is currently blocked before linking by the existing 2.2.1 Qt 6 compatibility error in `rs_debug.cpp` (`QBaseIODevice` is not defined by Qt 6). This backport does not alter that unrelated code.