### PR TITLE
Draw the letters an LFF font builds from another letter

### DIFF
--- a/librecad/src/lib/engine/document/entities/rs_insert.cpp
+++ b/librecad/src/lib/engine/document/entities/rs_insert.cpp
@@ -129,10 +129,17 @@ InsertTransformCapability transformCapability(const RS_Entity& entity) {
     case RS2::EntitySpline:
     case RS2::EntitySplinePoints:
     case RS2::EntityParabola:
+    // An LFF glyph may be assembled from another glyph: "[0051] Q" is the
+    // line "C004f" - clone the block of 'O' - followed by its own stroke, so
+    // RS_Font::generateLffFont() nests that clone inside the letter block.
+    // RS_Block::clone() always returns an RS_Block, which is why the child
+    // arrives here as EntityBlock rather than EntityFontChar.
+    // RS_EntityContainer implements scale/rotate/move by recursing into its
+    // children, so such a child transforms natively like any other entity.
+    case RS2::EntityBlock:
         return InsertTransformCapability::NativeOrthogonal;
     case RS2::EntityUnknown:
     case RS2::EntityContainer:
-    case RS2::EntityBlock:
     case RS2::EntityFontChar:
     case RS2::EntityGraphic:
     case RS2::EntityVertex:

--- a/librecad/src/ui/main/support/qg_recentfiles.cpp
+++ b/librecad/src/ui/main/support/qg_recentfiles.cpp
@@ -69,9 +69,10 @@ void QG_RecentFiles::saveToSettings() const {
 void QG_RecentFiles::add(const QString& filename) {
     RS_DEBUG->print("QG_RecentFiles::add");
     if (filename.size() > 2048) {
-        RS_DEBUG->print(RS_Debug::D_ERROR,
-                        "QG_RecentFiles::add filename too long at %zu\n",
-                        filename.size());
+        RS_DEBUG->print(RS_Debug::D_ERROR, "%s",
+                        qPrintable(QStringLiteral(
+                                       "QG_RecentFiles::add filename too long "
+                                       "at %1\n").arg(filename.size())));
         return;
     }
 


### PR DESCRIPTION
Fixes #2817.

An LFF font may assemble a glyph from a glyph it already has. `standard.lff`
writes `Q` as a reference to `O` plus its own tail stroke, and `R` the same way
from `P`:

```
[0051] Q                    [0052] R
C004f                       C0050
6,0;4,2                     5,0;2.97871,4.04626
```

`RS_Font::generateLffFont()` honours that by nesting a clone of the referenced
block inside the new letter block. `transformCapability()` listed `EntityBlock`
among the types `RS_Insert` cannot transform, so `cloneForTransform()` returned
`nullptr` for that child — and since a rejected child fails the whole expansion,
the letter was not drawn partially, it was discarded:

```
RS_Insert::update: unsupported derived entity transform
RS_Insert::update: expansion rejected without partial children
```

### Wider than the report

Q and R are the only two **ASCII** letters `standard.lff` builds this way, which
is why plain-English typists noticed exactly those. The same mechanism carries
every accented Latin letter. Measured by expanding each glyph through
`RS_Insert` the way `RS_MText::addLetter()` does and counting the geometry that
reaches the drawing:

| | before | after |
| --- | --- | --- |
| `O` (strokes only) | 4 entities, 5.56 × 10.00 | unchanged |
| `Q` | **0 entities, 0.00 × 0.00** | 5 entities, 6.67 × 10.00 |
| `R` | **0 entities, 0.00 × 0.00** | 5 entities, 5.56 × 10.00 |
| `Ä Ö Ü` | **0 entities, 0.00 × 0.00** | 5–6 entities, 13.33 tall |
| `é à ñ ç` | **0 entities, 0.00 × 0.00** | 6–9 entities |

Q comes out wider than O (6.67 vs 5.56) because of the tail, and accented
capitals taller (13.33 vs 10.00) because of the diacritic — the geometry is
right, not merely present.

Share of glyphs affected: **81 of 226 in `standard.lff`**, 81 of 225 in
`iso.lff`, 49 of 152 in `cursive.lff`, 200 of 6543 in `unicode.lff`.

### Origin

`git blame` puts the whole `transformCapability()` switch on `430d423af`
("DWG support: round 8 (#2680)", 2026-07-23), which replaced a walker that
cloned any child unconditionally with an explicit allow-list. The font data is
not involved: `Q` has been `C004f` since long before #2773 touched the fonts,
and `RS_Font` still resolves it correctly — `findLetter("Q")` returns a
two-entity block. Only the insert expansion drops it.

### The change

One case label moves into the `NativeOrthogonal` group.
`RS_EntityContainer` implements scale, rotate and move by recursing into its
children, so an `RS_Block` child transforms natively like any other entity.
`EntityFontChar` deliberately stays where it was: `RS_FontChar` has no
`clone()` of its own, so `RS_Block::clone()` returns an `RS_Block` and a child
never arrives with that type.

### Verification

The measurements above come from a local harness rather than a committed test —
this PR is the fix alone, and a regression test for reference-built glyphs is
worth adding separately.

Suite before and after are identical, so nothing else moves:

| | cases | assertions |
| --- | --- | --- |
| `be5e75db7` (master) | 2428 / 2337 passed / 22 failed / 69 skipped | 72813 / 26 failed |
| this branch | 2428 / 2337 passed / 22 failed / 69 skipped | 72813 / 26 failed |

Built locally both ways at this branch's tip: cmake/Ninja RelWithDebInfo links
`LibreCAD.app` clean, and a from-scratch `qmake6 -spec macx-clang
CONFIG+=release` build of `librecad.pro` compiles with **0 errors**.

### Also here: the build's only -Wformat warning

`QG_RecentFiles::add()` passes `QString::size()` to a `%zu` conversion.
That returns `qsizetype` — signed, pointer-wide — so the call had a
format/argument mismatch and printf did not read the value the compiler was
asked to pass:

```
qg_recentfiles.cpp:74:25: warning: format specifies type 'size_t'
   (aka 'unsigned long') but the argument has type 'qsizetype'
   (aka 'long long') [-Wformat]
```

Building the message with `QString::arg()` removes the class of bug rather
than the instance: `arg()` takes the length through an overload the compiler
picks, so no conversion specifier has to agree with `qsizetype` on any
platform, and the `%s` that remains carries an already-complete string.

It was the **only** `-Wformat` warning in the qmake build (1 → 0). It is
unrelated to the glyph fix, so it is a separate commit and can be dropped on
its own.


