### PR TITLE
Format a QString length with QString, not with printf

### DIFF
--- a/librecad/src/ui/qg_recentfiles.cpp
+++ b/librecad/src/ui/qg_recentfiles.cpp
@@ -73,9 +73,10 @@ void QG_RecentFiles::add(const QString &filename)
 {
     RS_DEBUG->print("QG_RecentFiles::add");
     if (filename.size() > 2048) {
-        RS_DEBUG->print(RS_Debug::D_ERROR,
-                        "QG_RecentFiles::add filename too long at %d\n",
-                        filename.size());
+        RS_DEBUG->print(RS_Debug::D_ERROR, "%s",
+                        qPrintable(QStringLiteral(
+                                       "QG_RecentFiles::add filename too long "
+                                       "at %1\n").arg(filename.size())));
         return;
     }
 


### PR DESCRIPTION
Backport of the formatting half of #2820 to `2.2.1`. The glyph-rendering half
of that PR is **not** needed here — `transformCapability()` does not exist on
this branch and `RS_Insert::update()` still clones every child unconditionally,
so the regression it fixes (introduced by #2680 on master) never reached 2.2.1.

`QG_RecentFiles::add()` passes `QString::size()` to a `%d` conversion:

```cpp
RS_DEBUG->print(RS_Debug::D_ERROR,
                "QG_RecentFiles::add filename too long at %d\n",
                filename.size());
```

`size()` returns `qsizetype`, which is as wide as a pointer, so on a 64-bit
build printf is told to read 32 bits of a 64-bit variadic argument. That is
undefined behaviour, even though the value survives on the common 64-bit ABIs
for any length below 2^31 — so this is latent rather than currently visible.

### Why no compiler catches it here

`RS_Debug::print()` on `2.2.1` is declared without a `format(printf, ...)`
attribute:

```cpp
void print(RS_DebugLevel level, const char* format ...);   // 2.2.1
```

master added the attribute, which is why the same call there produces
`warning: format specifies type 'size_t' … but the argument has type
'qsizetype' [-Wformat]` and nothing is reported on this branch. Compiling the
2.2.1 expression on its own with `-Wall -Wextra` does warn
(`format specifies type 'int' but the argument has type 'qsizetype'
(aka 'long long')`), confirming the mismatch is real and only the missing
attribute hides it.

Backporting that attribute would surface any other mismatches on this branch,
but it is a wider change than a release branch wants and is better considered
on its own.

### The change

Building the message with `QString::arg()` removes the class of bug rather
than the instance: `arg()` takes the length through an overload the compiler
picks, so no conversion specifier has to agree with `qsizetype` on any
platform, and the `%s` that remains carries an already-complete string. Same
edit as on master, at this branch's path for the file.

### Verification

A full cmake build of this branch links clean with the change, 0 errors and no
warning on the file. Note that cmake resolves **Qt 5** for `2.2.1` on my
machine (`Qt5_DIR=/opt/homebrew/opt/qt@5/...`), so I also compiled the exact
changed expression against Qt 6.11.2 and ran it: a 3000-character name prints
`QG_RecentFiles::add filename too long at 3000`.

Unrelated, but found while checking: a qmake build of `2.2.1` against Qt 6.11
fails before it reaches this file, at `librecad/src/lib/debug/rs_debug.cpp:47` —
`use of undeclared identifier 'QBaseIODevice'`. That line has been there since
`d72fa0a47` (2024-07-13) and is taken only on the Qt 6 side of the version
check, so the branch's qmake build appears to be Qt 5 only. Worth a separate
look; it is independent of this change.
