### PR TITLE
Add the PHANTOM linetype family so AutoCAD phantom lines survive a DXF round-trip

### DIFF
--- a/librecad/res/controls/controls.qrc
+++ b/librecad/res/controls/controls.qrc
@@ -20,6 +20,7 @@
         <file alias="linetype06.lci">linetype06.svg</file>
         <file alias="linetype07.lci">linetype07.svg</file>
         <file alias="linetype08.lci">linetype08.svg</file>
+        <file alias="linetype09.lci">linetype09.svg</file>
         <file alias="width00.lci">width00.svg</file>
         <file alias="width01.lci">width01.svg</file>
         <file alias="width02.lci">width02.svg</file>

--- a/librecad/res/controls/linetype09.svg
+++ b/librecad/res/controls/linetype09.svg
@@ -1,0 +1,1 @@
+<svg height="12" viewBox="0 0 8.4666665 3.175" width="32" xmlns="http://www.w3.org/2000/svg"><path d="m0 1.4597563h8.4949593" fill="#427bc3" stroke="#00000f" stroke-dasharray="1.8 .45 .6 .45 .6 .45" stroke-dashoffset="0" stroke-width=".9"/></svg>

--- a/librecad/src/lib/engine/rs.h
+++ b/librecad/src/lib/engine/rs.h
@@ -872,7 +872,12 @@ namespace RS2 {
         HiddenLine     = 28, /**< hidden line (acad.lin HIDDEN). */
         HiddenLineTiny = 29, /**< hidden line tiny */
         HiddenLine2    = 30, /**< hidden line small. */
-        HiddenLineX2   = 31  /**< hidden line large. */
+        HiddenLineX2   = 31, /**< hidden line large. */
+
+        PhantomLine     = 32, /**< long dash, dash, dash (acad.lin PHANTOM). */
+        PhantomLineTiny = 33, /**< long dash, dash, dash tiny */
+        PhantomLine2    = 34, /**< long dash, dash, dash small. */
+        PhantomLineX2   = 35  /**< long dash, dash, dash large. */
     };
 
     /**

--- a/librecad/src/lib/filters/rs_filterdxfrw.cpp
+++ b/librecad/src/lib/filters/rs_filterdxfrw.cpp
@@ -18422,6 +18422,16 @@ void RS_FilterDXFRW::writeLTypes() {
              28.575, {19.05, -3.175, 3.175, -3.175});
   writeLType("CENTERX2", "Center (2x) ________  __  ________  __  _____", 4,
              101.6, {63.5, -12.7, 12.7, -12.7});
+  // acad.lin: PHANTOM A,1.25,-.25,.25,-.25,.25,-.25; PHANTOM2 and PHANTOMX2
+  // are its .5x and 2x.
+  writeLType("PHANTOM", "Phantom ______  __  __  ______  __  __  ______", 6,
+             63.5, {31.75, -6.35, 6.35, -6.35, 6.35, -6.35});
+  writeLType("PHANTOMTINY", "Phantom (.15x) ___ _ _ ___ _ _ ___ _ _ ___ _ _", 6,
+             9.525, {4.7625, -0.9525, 0.9525, -0.9525, 0.9525, -0.9525});
+  writeLType("PHANTOM2", "Phantom (.5x) ___ _ _ ___ _ _ ___ _ _ ___ _ _", 6,
+             31.75, {15.875, -3.175, 3.175, -3.175, 3.175, -3.175});
+  writeLType("PHANTOMX2", "Phantom (2x) ____________    ____    ____   _", 6,
+             127.0, {63.5, -12.7, 12.7, -12.7, 12.7, -12.7});
   // Imported LTYPE records that are not part of the built-in table above are
   // re-emitted as they came in; writeLType() records the built-in names so a
   // new built-in type cannot end up written twice.
@@ -31759,6 +31769,20 @@ RS2::LineType RS_FilterDXFRW::nameToLineType(const QString &name) {
   if (uName == "CENTERX2") {
     return RS2::CenterLineX2;
   }
+  // ISO 128-20 type 09 "long-dashed double-short-dashed" (24,-3,6,-3,6,-3)
+  // is PHANTOM's shape at PHANTOM's scale, like the ISO04/ISO05 aliases.
+  if (uName == "ACAD_ISO09W100" || uName == "PHANTOM") {
+    return RS2::PhantomLine;
+  }
+  if (uName == "PHANTOMTINY") {
+    return RS2::PhantomLineTiny;
+  }
+  if (uName == "PHANTOM2") {
+    return RS2::PhantomLine2;
+  }
+  if (uName == "PHANTOMX2") {
+    return RS2::PhantomLineX2;
+  }
   if (uName == "BORDER") {
     return RS2::BorderLine;
   }
@@ -31831,6 +31855,14 @@ QString RS_FilterDXFRW::lineTypeToName(RS2::LineType lineType) {
     return "CENTER2";
   case RS2::CenterLineX2:
     return "CENTERX2";
+  case RS2::PhantomLine:
+    return "PHANTOM";
+  case RS2::PhantomLineTiny:
+    return "PHANTOMTINY";
+  case RS2::PhantomLine2:
+    return "PHANTOM2";
+  case RS2::PhantomLineX2:
+    return "PHANTOMX2";
   case RS2::BorderLine:
     return "BORDER";
   case RS2::BorderLineTiny:

--- a/librecad/src/lib/filters/rs_filterjww.cpp
+++ b/librecad/src/lib/filters/rs_filterjww.cpp
@@ -1287,7 +1287,7 @@ bool RS_FilterJWW::fileExport(RS_Graphic& g, const QString& file, RS2::FormatTyp
         // RS2::LineTypeUnchanged and RS2::LineSelected sit between the two
         // blocks and are UI-only, so the table is written as two ranges.
         int numLT = (int)RS2::BorderLineX2-(int)RS2::LineByBlock
-                  + (int)RS2::HiddenLineX2-(int)RS2::HiddenLine+1;
+                  + (int)RS2::PhantomLineX2-(int)RS2::HiddenLine+1;
         if (type==RS2::FormatJWC) {
                 numLT-=2;
         }
@@ -1297,7 +1297,7 @@ bool RS_FilterJWW::fileExport(RS_Graphic& g, const QString& file, RS2::FormatTyp
                         writeLineType(*dw, (RS2::LineType)t);
                 }
         }
-        for (int t=(int)RS2::HiddenLine; t<=(int)RS2::HiddenLineX2; ++t) {
+        for (int t=(int)RS2::HiddenLine; t<=(int)RS2::PhantomLineX2; ++t) {
                 writeLineType(*dw, (RS2::LineType)t);
         }
         dw->tableEnd();
@@ -2811,6 +2811,15 @@ RS2::LineType RS_FilterJWW::nameToLineType(const QString& name) {
         } else if (uName=="CENTERX2") {
                 return RS2::CenterLineX2;
 
+        } else if (uName=="ACAD_ISO09W100" || uName=="PHANTOM") {
+                return RS2::PhantomLine;
+
+        } else if (uName=="PHANTOM2") {
+                return RS2::PhantomLine2;
+
+        } else if (uName=="PHANTOMX2") {
+                return RS2::PhantomLineX2;
+
 
         } else if (uName=="BORDER") {
                 return RS2::BorderLine;
@@ -2897,6 +2906,16 @@ QString RS_FilterJWW::lineTypeToName(RS2::LineType lineType) {
                 break;
         case RS2::CenterLineX2:
                 return "CENTERX2";
+                break;
+
+        case RS2::PhantomLine:
+                return "PHANTOM";
+                break;
+        case RS2::PhantomLine2:
+                return "PHANTOM2";
+                break;
+        case RS2::PhantomLineX2:
+                return "PHANTOMX2";
                 break;
 
         case RS2::BorderLine:

--- a/librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
+++ b/librecad/src/lib/filters/tests/dxf_roundtrip_tests.cpp
@@ -54,6 +54,7 @@
 #include "rs_dimaligned.h"
 #include "rs_dimension.h"
 #include "rs_filterdxfrw.h"
+#include "rs_filterjww.h"
 #include "rs_graphic.h"
 #include "rs_entity.h"
 #include "rs_block.h"
@@ -4777,6 +4778,8 @@ TEST_CASE("Every DXF linetype name LibreCAD writes maps back to the same RS2::Li
            RS2::DashLine, RS2::DashLineTiny, RS2::DashLine2, RS2::DashLineX2,
            RS2::HiddenLine, RS2::HiddenLineTiny, RS2::HiddenLine2,
            RS2::HiddenLineX2,
+           RS2::PhantomLine, RS2::PhantomLineTiny, RS2::PhantomLine2,
+           RS2::PhantomLineX2,
            RS2::DashDotLine, RS2::DashDotLineTiny, RS2::DashDotLine2,
            RS2::DashDotLineX2,
            RS2::DivideLine, RS2::DivideLineTiny, RS2::DivideLine2,
@@ -4797,11 +4800,274 @@ TEST_CASE("Every DXF linetype name LibreCAD writes maps back to the same RS2::Li
   CHECK(RS_FilterDXFRW::lineTypeToName(RS2::HiddenLine2) == "HIDDEN2");
   CHECK(RS_FilterDXFRW::lineTypeToName(RS2::HiddenLineX2) == "HIDDENX2");
 
+  // The phantom family keeps its acad.lin names (PHANTOM* used to fall
+  // through to CONTINUOUS).
+  CHECK(RS_FilterDXFRW::lineTypeToName(RS2::PhantomLine) == "PHANTOM");
+  CHECK(RS_FilterDXFRW::lineTypeToName(RS2::PhantomLineTiny) == "PHANTOMTINY");
+  CHECK(RS_FilterDXFRW::lineTypeToName(RS2::PhantomLine2) == "PHANTOM2");
+  CHECK(RS_FilterDXFRW::lineTypeToName(RS2::PhantomLineX2) == "PHANTOMX2");
+  // ISO 128-20 type 09 (long-dashed double-short-dashed) imports as PHANTOM,
+  // the way ACAD_ISO04W100 / ACAD_ISO05W100 already alias DASHDOTX2 / DIVIDEX2.
+  CHECK(RS_FilterDXFRW::nameToLineType(QStringLiteral("ACAD_ISO09W100")) ==
+        RS2::PhantomLine);
+  CHECK(RS_FilterDXFRW::nameToLineType(QStringLiteral("acad_iso09w100")) ==
+        RS2::PhantomLine);
+
+  // The JWW filter carries its own name tables (without tiny variants); they
+  // must agree with the DXF ones.
+  for (const RS2::LineType type : {RS2::HiddenLine, RS2::HiddenLine2,
+                                   RS2::HiddenLineX2, RS2::PhantomLine,
+                                   RS2::PhantomLine2, RS2::PhantomLineX2}) {
+    INFO("linetype " << static_cast<int>(type));
+    const QString name = RS_FilterJWW::lineTypeToName(type);
+    CHECK(name == RS_FilterDXFRW::lineTypeToName(type));
+    CHECK(RS_FilterJWW::nameToLineType(name) == type);
+  }
+
+  // The values are persisted (QSettings, .lcp palettes, $DIMLTYPE) and the JWW
+  // export loop treats HiddenLine..PhantomLineX2 as one contiguous range.
+  CHECK(static_cast<int>(RS2::HiddenLine) == 28);
+  CHECK(static_cast<int>(RS2::HiddenLineX2) == 31);
+  CHECK(static_cast<int>(RS2::PhantomLine) == 32);
+  CHECK(static_cast<int>(RS2::PhantomLineX2) == 35);
+
   // Every drawable type must have a screen pattern: RS_Painter dereferences
   // getPattern() without a null check.
   for (const RS2::LineType type : {RS2::HiddenLine, RS2::HiddenLineTiny,
-                                   RS2::HiddenLine2, RS2::HiddenLineX2}) {
+                                   RS2::HiddenLine2, RS2::HiddenLineX2,
+                                   RS2::PhantomLine, RS2::PhantomLineTiny,
+                                   RS2::PhantomLine2, RS2::PhantomLineX2}) {
     INFO("linetype " << static_cast<int>(type));
     CHECK(RS_LineTypePattern::getPattern(type) != nullptr);
   }
+}
+
+TEST_CASE("DXF import keeps PHANTOM on a layer and on an entity",
+          "[dxf][filter][linetype]") {
+  ensureSettings();
+  const std::string src = tmpFile("phantom_src.dxf");
+  std::filesystem::remove(src);
+
+  // acad.lin: PHANTOM A,1.25,-.25,.25,-.25,.25,-.25 and PHANTOM2 at half
+  // that (inch values, as an imperial AutoCAD drawing carries them; acadiso.lin
+  // is the same x 25.4). Without the phantom family nameToLineType() fell
+  // through to SolidLine for both names.
+  writeText(src,
+            "0\nSECTION\n2\nHEADER\n9\n$ACADVER\n1\nAC1009\n0\nENDSEC\n"
+            "0\nSECTION\n2\nTABLES\n"
+            "0\nTABLE\n2\nLTYPE\n70\n2\n"
+            "0\nLTYPE\n2\nPHANTOM\n70\n0\n3\nPhantom ______  __  __  ______\n"
+            "72\n65\n73\n6\n40\n2.5\n"
+            "49\n1.25\n74\n0\n49\n-0.25\n74\n0\n49\n0.25\n74\n0\n"
+            "49\n-0.25\n74\n0\n49\n0.25\n74\n0\n49\n-0.25\n74\n0\n"
+            "0\nLTYPE\n2\nPHANTOM2\n70\n0\n3\nPhantom (.5x) ___ _ _ ___ _ _\n"
+            "72\n65\n73\n6\n40\n1.25\n"
+            "49\n0.625\n74\n0\n49\n-0.125\n74\n0\n49\n0.125\n74\n0\n"
+            "49\n-0.125\n74\n0\n49\n0.125\n74\n0\n49\n-0.125\n74\n0\n"
+            "0\nENDTAB\n0\nTABLE\n2\nLAYER\n70\n2\n"
+            "0\nLAYER\n2\n0\n70\n0\n62\n7\n6\nCONTINUOUS\n"
+            "0\nLAYER\n2\nPHANTOM_LAYER\n70\n0\n62\n7\n6\nPHANTOM\n"
+            "0\nENDTAB\n0\nENDSEC\n0\nSECTION\n2\nENTITIES\n"
+            "0\nLINE\n8\nPHANTOM_LAYER\n6\nPHANTOM\n"
+            "10\n0.0\n20\n0.0\n11\n10.0\n21\n0.0\n"
+            "0\nLINE\n8\n0\n6\nPHANTOM2\n"
+            "10\n0.0\n20\n5.0\n11\n10.0\n21\n5.0\n"
+            "0\nENDSEC\n0\nEOF\n");
+
+  RS_Graphic graphic;
+  {
+    RS_FilterDXFRW filter;
+    REQUIRE(filter.fileImport(graphic, QString::fromStdString(src),
+                              RS2::FormatDXFRW));
+  }
+  const auto *layer = graphic.findLayer(QStringLiteral("PHANTOM_LAYER"));
+  REQUIRE(layer != nullptr);
+  CHECK(layer->getPen().getLineType() == RS2::PhantomLine);
+
+  RS_Entity *line = graphic.firstEntity();
+  REQUIRE(line != nullptr);
+  CHECK(line->getPen(false).getLineType() == RS2::PhantomLine);
+
+  RS_Entity *half = graphic.nextEntity();
+  REQUIRE(half != nullptr);
+  CHECK(half->getPen(false).getLineType() == RS2::PhantomLine2);
+
+  std::filesystem::remove(src);
+}
+
+TEST_CASE("DXF round-trip preserves the PHANTOM linetype on an entity",
+          "[dxf][roundtrip][filter][linetype]") {
+  ensureSettings();
+  const std::string out = tmpFile("phantom_out.dxf");
+  const std::string dwg = tmpFile("phantom.dwg");
+  std::filesystem::remove(out);
+  std::filesystem::remove(dwg);
+
+  RS_Graphic graphic;
+  graphic.initForNewDocument();
+  auto *line = new RS_Line(&graphic, RS_LineData(RS_Vector(0.0, 0.0),
+                                                 RS_Vector(10.0, 10.0)));
+  line->setPen(RS_Pen(RS_Color(255, 0, 0), RS2::Width00, RS2::PhantomLine));
+  graphic.addEntity(line);
+
+  {
+    RS_FilterDXFRW filter;
+    REQUIRE(filter.fileExport(graphic, QString::fromStdString(out),
+                              RS2::FormatDXFRW));
+  }
+
+  // The entity references the linetype by its acad.lin name...
+  CHECK(recordGroupValues(out, "LINE", "6") ==
+        std::vector<std::string>{"PHANTOM"});
+  // ...and the LTYPE table carries acad.lin's PHANTOM
+  // (A,1.25,-.25,.25,-.25,.25,-.25) in mm.
+  const auto dashes = ltypeRecordGroupValues(out, "PHANTOM", "49");
+  REQUIRE(dashes.size() == 6);
+  CHECK(std::stod(dashes[0]) == Catch::Approx(31.75));
+  CHECK(std::stod(dashes[1]) == Catch::Approx(-6.35));
+  CHECK(std::stod(dashes[2]) == Catch::Approx(6.35));
+  CHECK(std::stod(dashes[3]) == Catch::Approx(-6.35));
+  CHECK(std::stod(dashes[4]) == Catch::Approx(6.35));
+  CHECK(std::stod(dashes[5]) == Catch::Approx(-6.35));
+  CHECK(ltypeRecordGroupValues(out, "PHANTOM", "73") ==
+        std::vector<std::string>{"6"});
+  const auto length = ltypeRecordGroupValues(out, "PHANTOM", "40");
+  REQUIRE(length.size() == 1);
+  CHECK(std::stod(length[0]) == Catch::Approx(63.5));
+
+  // The three scaled records are emitted alongside, at acad.lin's ratios.
+  struct ScaledRecord {
+    const char *name;
+    double length;
+    std::vector<double> dashes;
+  };
+  for (const ScaledRecord &record : {
+           ScaledRecord{"PHANTOMTINY", 9.525,
+                        {4.7625, -0.9525, 0.9525, -0.9525, 0.9525, -0.9525}},
+           ScaledRecord{"PHANTOM2", 31.75,
+                        {15.875, -3.175, 3.175, -3.175, 3.175, -3.175}},
+           ScaledRecord{"PHANTOMX2", 127.0,
+                        {63.5, -12.7, 12.7, -12.7, 12.7, -12.7}}}) {
+    INFO("LTYPE " << record.name);
+    CHECK(ltypeRecordGroupValues(out, record.name, "73") ==
+          std::vector<std::string>{"6"});
+    const auto scaledLength = ltypeRecordGroupValues(out, record.name, "40");
+    REQUIRE(scaledLength.size() == 1);
+    CHECK(std::stod(scaledLength[0]) == Catch::Approx(record.length));
+    const auto scaledDashes = ltypeRecordGroupValues(out, record.name, "49");
+    REQUIRE(scaledDashes.size() == record.dashes.size());
+    for (std::size_t i = 0; i < record.dashes.size(); ++i) {
+      CHECK(std::stod(scaledDashes[i]) == Catch::Approx(record.dashes[i]));
+    }
+  }
+
+  RS_Graphic reimported;
+  {
+    RS_FilterDXFRW filter;
+    REQUIRE(filter.fileImport(reimported, QString::fromStdString(out),
+                              RS2::FormatDXFRW));
+  }
+  RS_Entity *imported = reimported.firstEntity();
+  REQUIRE(imported != nullptr);
+  CHECK(imported->getPen(false).getLineType() == RS2::PhantomLine);
+
+  // The reimported drawing now carries PHANTOM in its raw LTYPE table copy
+  // as well; saving it again must write the record once, not once per
+  // source.
+  const std::string out2 = tmpFile("phantom_out2.dxf");
+  std::filesystem::remove(out2);
+  {
+    RS_FilterDXFRW filter;
+    REQUIRE(filter.fileExport(reimported, QString::fromStdString(out2),
+                              RS2::FormatDXFRW));
+  }
+  CHECK(ltypeRecordGroupValues(out2, "PHANTOM", "73") ==
+        std::vector<std::string>{"6"});
+  CHECK(recordGroupValues(out2, "LINE", "6") ==
+        std::vector<std::string>{"PHANTOM"});
+  std::filesystem::remove(out2);
+
+#ifdef DWGSUPPORT
+  // The DWG writer resolves entity linetypes by handle against the LTYPE
+  // table emitted by writeLTypes(), so a missing record would silently
+  // degrade the pen here.
+  {
+    RS_FilterDXFRW filter;
+    REQUIRE(filter.fileExport(graphic, QString::fromStdString(dwg),
+                              RS2::FormatDWG2004));
+  }
+  RS_Graphic fromDwg;
+  {
+    RS_FilterDXFRW filter;
+    REQUIRE(filter.fileImport(fromDwg, QString::fromStdString(dwg),
+                              RS2::FormatDWG));
+  }
+  RS_Entity *dwgLine = fromDwg.firstEntity();
+  REQUIRE(dwgLine != nullptr);
+  CHECK(dwgLine->getPen(false).getLineType() == RS2::PhantomLine);
+#endif
+
+  std::filesystem::remove(out);
+  std::filesystem::remove(dwg);
+}
+
+TEST_CASE("DXF import maps ACAD_ISO09W100 to PHANTOM and writes it back as PHANTOM",
+          "[dxf][roundtrip][filter][linetype]") {
+  ensureSettings();
+  const std::string src = tmpFile("iso09_src.dxf");
+  const std::string out = tmpFile("iso09_out.dxf");
+  std::filesystem::remove(src);
+  std::filesystem::remove(out);
+
+  // acadiso.lin: ACAD_ISO09W100 "ISO long-dash double-short-dash"
+  // A,24,-3,6,-3,6,-3. Like the other ACAD_ISO aliases it is an import
+  // mapping only: the entity is saved with the acad.lin name of the family
+  // it landed on, and the source record survives as raw metadata.
+  writeText(src,
+            "0\nSECTION\n2\nHEADER\n9\n$ACADVER\n1\nAC1009\n0\nENDSEC\n"
+            "0\nSECTION\n2\nTABLES\n"
+            "0\nTABLE\n2\nLTYPE\n70\n1\n"
+            "0\nLTYPE\n2\nACAD_ISO09W100\n70\n0\n"
+            "3\nISO long-dash double-short-dash\n"
+            "72\n65\n73\n6\n40\n45.0\n"
+            "49\n24.0\n74\n0\n49\n-3.0\n74\n0\n49\n6.0\n74\n0\n"
+            "49\n-3.0\n74\n0\n49\n6.0\n74\n0\n49\n-3.0\n74\n0\n"
+            "0\nENDTAB\n0\nTABLE\n2\nLAYER\n70\n2\n"
+            "0\nLAYER\n2\n0\n70\n0\n62\n7\n6\nCONTINUOUS\n"
+            "0\nLAYER\n2\nISO09_LAYER\n70\n0\n62\n7\n6\nACAD_ISO09W100\n"
+            "0\nENDTAB\n0\nENDSEC\n0\nSECTION\n2\nENTITIES\n"
+            "0\nLINE\n8\nISO09_LAYER\n6\nACAD_ISO09W100\n"
+            "10\n0.0\n20\n0.0\n11\n10.0\n21\n0.0\n"
+            "0\nENDSEC\n0\nEOF\n");
+
+  RS_Graphic graphic;
+  {
+    RS_FilterDXFRW filter;
+    REQUIRE(filter.fileImport(graphic, QString::fromStdString(src),
+                              RS2::FormatDXFRW));
+  }
+  const auto *layer = graphic.findLayer(QStringLiteral("ISO09_LAYER"));
+  REQUIRE(layer != nullptr);
+  CHECK(layer->getPen().getLineType() == RS2::PhantomLine);
+  RS_Entity *line = graphic.firstEntity();
+  REQUIRE(line != nullptr);
+  CHECK(line->getPen(false).getLineType() == RS2::PhantomLine);
+
+  {
+    RS_FilterDXFRW filter;
+    REQUIRE(filter.fileExport(graphic, QString::fromStdString(out),
+                              RS2::FormatDXFRW));
+  }
+  CHECK(recordGroupValues(out, "LINE", "6") ==
+        std::vector<std::string>{"PHANTOM"});
+  CHECK(namedRecordGroupValues(out, "LAYER", "ISO09_LAYER", "6") ==
+        std::vector<std::string>{"PHANTOM"});
+  CHECK(ltypeRecordGroupValues(out, "PHANTOM", "73") ==
+        std::vector<std::string>{"6"});
+  // The imported ISO09 record is re-emitted as it came in, once.
+  CHECK(ltypeRecordGroupValues(out, "ACAD_ISO09W100", "73") ==
+        std::vector<std::string>{"6"});
+
+  std::filesystem::remove(src);
+  std::filesystem::remove(out);
 }

--- a/librecad/src/lib/generators/makercamsvg/lc_makercamsvg.cpp
+++ b/librecad/src/lib/generators/makercamsvg/lc_makercamsvg.cpp
@@ -808,6 +808,7 @@ std::string LC_MakerCamSVG::svgPathAnyLineType(RS_Vector startpoint, RS_Vector e
     constexpr int divideFactor = 5; // --.. --.. --.. --..
     constexpr int centerFactor = 5; // -- - -- - -- -
     constexpr int borderFactor = 7; // -- -- . -- -- . -- -- .
+    constexpr int phantomFactor = 7; // -- - - -- - - -- - -
 
     constexpr double lineScaleTiny = 0.25;
     constexpr double lineScale2 = 0.5;
@@ -968,6 +969,27 @@ std::string LC_MakerCamSVG::svgPathAnyLineType(RS_Vector startpoint, RS_Vector e
             lineFactor = borderFactor;
             break;
         }
+
+        case RS2::PhantomLineTiny: {
+            lineScale = lineScaleTiny;
+            lineFactor = phantomFactor;
+            break;
+        }
+        case RS2::PhantomLine2: {
+            lineScale = lineScale2;
+            lineFactor = phantomFactor;
+            break;
+        }
+        case RS2::PhantomLine: {
+            lineScale = lineScaleOne;
+            lineFactor = phantomFactor;
+            break;
+        }
+        case RS2::PhantomLineX2: {
+            lineScale = lineScaleX2;
+            lineFactor = phantomFactor;
+            break;
+        }
         default: {
             lineScale = lineScaleOne;
             lineFactor = dotFactor;
@@ -1055,6 +1077,16 @@ std::string LC_MakerCamSVG::getLinePattern(RS_Vector* lastPos, RS_Vector step, R
             path += getLineSegment(lastPos, step, lineScale, true);
             path += getLineSegment(lastPos, step, lineScale, true);
             path += getPointSegment(lastPos, step, lineScale);
+            break;
+        }
+
+        case RS2::PhantomLineTiny:
+        case RS2::PhantomLine2:
+        case RS2::PhantomLine:
+        case RS2::PhantomLineX2: {
+            path += getLineSegment(lastPos, step, lineScale, true);
+            path += getLineSegment(lastPos, step, lineScale, false);
+            path += getLineSegment(lastPos, step, lineScale, false);
             break;
         }
 

--- a/librecad/src/lib/gui/rs_linetypepattern.cpp
+++ b/librecad/src/lib/gui/rs_linetypepattern.cpp
@@ -68,6 +68,11 @@ const RS_LineTypePattern PATTERN_HIDDEN_LINE_TINY{{1., -0.5}};
 const RS_LineTypePattern PATTERN_HIDDEN_LINE{{6.0, -3.0}};
 const RS_LineTypePattern PATTERN_HIDDEN_LINE2{{3.0, -1.5}};
 const RS_LineTypePattern PATTERN_HIDDEN_LINE_X2{{12.0, -6.0}};
+// acad.lin PHANTOM is CENTER with a second short dash (1.25,-.25,.25,-.25,.25,-.25)
+const RS_LineTypePattern PATTERN_PHANTOM_LINE_TINY{{5., -1., 1., -1., 1., -1.}};
+const RS_LineTypePattern PATTERN_PHANTOM_LINE{{32.0, -6.0, 6.0, -6.0, 6.0, -6.0}};
+const RS_LineTypePattern PATTERN_PHANTOM_LINE2{{16.0, -3.0, 3.0, -3.0, 3.0, -3.0}};
+const RS_LineTypePattern PATTERN_PHANTOM_LINE_X2{{64.0, -12.0, 12.0, -12.0, 12.0, -12.0}};
 
 const RS_LineTypePattern PATTERN_BLOCK_LINE{{0.5, -0.5}};
 const RS_LineTypePattern PATTERN_SELECTED{{1.0, -3.0}};
@@ -113,6 +118,10 @@ const RS_LineTypePattern* RS_LineTypePattern::getPattern(const RS2::LineType lin
             {RS2::HiddenLineTiny, &PATTERN_HIDDEN_LINE_TINY},
             {RS2::HiddenLine2, &PATTERN_HIDDEN_LINE2},
             {RS2::HiddenLineX2, &PATTERN_HIDDEN_LINE_X2},
+            {RS2::PhantomLine, &PATTERN_PHANTOM_LINE},
+            {RS2::PhantomLineTiny, &PATTERN_PHANTOM_LINE_TINY},
+            {RS2::PhantomLine2, &PATTERN_PHANTOM_LINE2},
+            {RS2::PhantomLineX2, &PATTERN_PHANTOM_LINE_X2},
             {RS2::LineByLayer, &PATTERN_BLOCK_LINE},
             {RS2::LineByBlock, &PATTERN_BLOCK_LINE},
             {RS2::LineSelected, &PATTERN_SELECTED}

--- a/librecad/src/main/doc_plugin_interface.cpp
+++ b/librecad/src/main/doc_plugin_interface.cpp
@@ -73,6 +73,9 @@ convLTW::convLTW() {
     lType.insert(RS2::HiddenLine, "HiddenLine");
     lType.insert(RS2::HiddenLine2, "HiddenLine2");
     lType.insert(RS2::HiddenLineX2, "HiddenLineX2");
+    lType.insert(RS2::PhantomLine, "PhantomLine");
+    lType.insert(RS2::PhantomLine2, "PhantomLine2");
+    lType.insert(RS2::PhantomLineX2, "PhantomLineX2");
     lType.insert(RS2::DashDotLine, "DashDotLine");
     lType.insert(RS2::DashDotLine2, "DashDotLine2");
     lType.insert(RS2::DashDotLineX2, "DashDotLineX2");

--- a/librecad/src/ui/components/comboboxes/qg_linetypebox.cpp
+++ b/librecad/src/ui/components/comboboxes/qg_linetypebox.cpp
@@ -111,6 +111,10 @@ void QG_LineTypeBox::init(const bool showByLayer, const bool showUnchanged, cons
     addItem(QIcon(":linetypes/linetype06.lci"), tr("Center (tiny)"), RS2::CenterLineTiny);
     addItem(QIcon(":linetypes/linetype06.lci"), tr("Center (small)"), RS2::CenterLine2);
     addItem(QIcon(":linetypes/linetype06.lci"), tr("Center (large)"), RS2::CenterLineX2);
+    addItem(QIcon(":linetypes/linetype09.lci"), tr("Phantom"), RS2::PhantomLine);
+    addItem(QIcon(":linetypes/linetype09.lci"), tr("Phantom (tiny)"), RS2::PhantomLineTiny);
+    addItem(QIcon(":linetypes/linetype09.lci"), tr("Phantom (small)"), RS2::PhantomLine2);
+    addItem(QIcon(":linetypes/linetype09.lci"), tr("Phantom (large)"), RS2::PhantomLineX2);
     addItem(QIcon(":linetypes/linetype07.lci"), tr("Border"), RS2::BorderLine);
     addItem(QIcon(":linetypes/linetype07.lci"), tr("Border (tiny)"), RS2::BorderLineTiny);
     addItem(QIcon(":linetypes/linetype07.lci"), tr("Border (small)"), RS2::BorderLine2);

--- a/librecad/src/ui/dock_widgets/pen_palette/lc_peninforegistry.cpp
+++ b/librecad/src/ui/dock_widgets/pen_palette/lc_peninforegistry.cpp
@@ -323,6 +323,10 @@ void LC_PenInfoRegistry::registerLineTypes(){
     doRegisterLineType(":linetypes/linetype06.lci", tr("Center (tiny)"), RS2::CenterLineTiny);
     doRegisterLineType(":linetypes/linetype06.lci", tr("Center (small)"), RS2::CenterLine2);
     doRegisterLineType(":linetypes/linetype06.lci", tr("Center (large)"), RS2::CenterLineX2);
+    doRegisterLineType(":linetypes/linetype09.lci", tr("Phantom"), RS2::PhantomLine);
+    doRegisterLineType(":linetypes/linetype09.lci", tr("Phantom (tiny)"), RS2::PhantomLineTiny);
+    doRegisterLineType(":linetypes/linetype09.lci", tr("Phantom (small)"), RS2::PhantomLine2);
+    doRegisterLineType(":linetypes/linetype09.lci", tr("Phantom (large)"), RS2::PhantomLineX2);
     doRegisterLineType(":linetypes/linetype07.lci", tr("Border"), RS2::BorderLine);
     doRegisterLineType(":linetypes/linetype07.lci", tr("Border (tiny)"), RS2::BorderLineTiny);
     doRegisterLineType(":linetypes/linetype07.lci", tr("Border (small)"), RS2::BorderLine2);


### PR DESCRIPTION
### The bug

LibreCAD has no PHANTOM linetype, the last of acad.lin's eight basic families (BORDER, CENTER, DASHDOT, DASHED, DIVIDE, DOT, HIDDEN since #2815, PHANTOM) it did not know. `RS_FilterDXFRW::nameToLineType()` has no entry for `PHANTOM` / `PHANTOM2` / `PHANTOMX2`, so they fall through to the final `return RS2::SolidLine`: a drawing that comes in from AutoCAD with phantom lines (alternate positions, adjacent parts, motion paths) shows them as continuous lines on every entity and layer that used them, and on the first save `lineTypeToName()` writes them back as `CONTINUOUS`. The substitution is silent. Since abd1f4a8e the raw LTYPE *records* survive in `LC_DwgAdvancedMetadata` and are re-emitted, so the saved file even carries orphaned `PHANTOM*` records that nothing references any more.

Reproduce: open a DXF with one `LINE` whose group 6 is `PHANTOM` (fixture `single_PHANTOM.dxf` below), select it: the Properties dock reads *Continuous*. Save as DXF: the `LINE` carries `6/CONTINUOUS`.

### Root cause

Same as #2813: `RS2::LineType` is a closed catalogue and the pen stores only the enum, so a name without an enum value cannot survive a round-trip. PHANTOM is not even an alias of another family; it is simply unknown.

### The fix

PHANTOM becomes a first-class family, exactly the way fc320c183 (#2815) added HIDDEN, following ca7c096e6 (2014, tiny variants for every family) and 4c77bc92a (2015, DXF persistence of the tiny variants):

- `RS2::PhantomLine`, `PhantomLineTiny`, `PhantomLine2`, `PhantomLineX2` = 32..35, **appended after `HiddenLineX2`** so 28..35 stays one contiguous block (the persisted values are never renumbered; the JWW export loop relies on the contiguity).
- LTYPE metrics straight from acad.lin × 25.4 (acadiso.lin carries the same numbers): `PHANTOM` A,1.25,−.25,.25,−.25,.25,−.25 → 31.75/−6.35/6.35/−6.35/6.35/−6.35 (length 63.5), `PHANTOM2` half of that, `PHANTOMX2` double, `PHANTOMTINY` .15×; descriptions are the acad.lin ones. PHANTOM is CENTER (A,1.25,−.25,.25,−.25) with a second short dash appended, at every scale.
- Screen patterns follow CENTER's rounding (31.75 → 32, 6.35 → 6): PHANTOM draws as 32/−6/6/−6/6/−6 next to CENTER's 32/−6/6/−6. `rs_painter.cpp` needs no change. **Visible change:** entities and layers carrying `PHANTOM` / `PHANTOM2` / `PHANTOMX2` were drawn solid and saved as `CONTINUOUS`; they now draw as phantom lines and keep their name.
- `nameToLineType()` also accepts `ACAD_ISO09W100`, ISO 128-20's type 09 *long-dashed double-short-dashed line* (24,−3,6,−3,6,−3 mm), which is PHANTOM's shape at PHANTOM's scale and until now imported as CONTINUOUS (listed as unsupported in the ISO table of #1738). This follows the existing `ACAD_ISO04W100 → DASHDOTX2` / `ACAD_ISO05W100 → DIVIDEX2` aliases: import only, written back as `PHANTOM`, the source record re-emitted once as raw metadata. Files using `ACAD_ISO09W100` now render phantom lines instead of solid ones. (`ACAD_ISO08W100` → CENTER would be the analogous alias for the Center family; deliberately not part of this change.)
- `writeLTypes()` emits the four records, which the DWG writer (`dwgWriter15`) and the DIMSTYLE writer resolve against; `writeLType()` records the built-in names (#2815), so an imported raw `PHANTOM` record is not written twice.
- JWW: the name tables gain the same three names CENTER has (no tiny variants there), and the second LTYPE range in `fileExport()` now ends at `PhantomLineX2`. JWW export is not reachable from the UI and `DL_Jww::writeLineType()` is an empty stub, so this is for consistency.
- MakerCAM SVG export gets the four cases with a phantom factor of 7 (long dash + short dash + short dash), the same approximation CENTER (5) and BORDER (7) use.
- Pen toolbar combobox and pen palette list *Phantom*, *Phantom (tiny)*, *Phantom (small)*, *Phantom (large)* right after the Center family, with their own icon (`linetype09.svg`, the Center icon with a second short dash). The property sheet and the quick selection dialog inherit both.
- The plugin string bridge (`convLTW` in `doc_plugin_interface.cpp`, the `DPI::LTYPE` property) gains the three names, like the CENTER entries next to it; without them a phantom entity would reach plugins as `BYLAYER`.

Left alone on purpose, as in #2815: the public `DPI::LineType` enum, `rs_filterdxf.cpp` (not in the CMake build), `rs_python_wrappers.cpp` (behind `RS_OPT_PYTHON`), translations. Compatibility note, as for every enumerator added before: a pen set to a phantom type in QSettings and then read by an older LibreCAD is not validated on the way in (the `FIXME` in `rs_settings.cpp`); `.lcp` palettes go through `LC_PenInfoRegistry::hasLineType()` and reject it cleanly; a drawing saved with PHANTOM opens in an older LibreCAD the way it does today (solid, `CONTINUOUS` on the next save). This does not implement `.lin` loading (#1738). With PHANTOM the built-in table covers acad.lin's basic families.

Fixes #2822.

### Verification

Built with `pixi` (conda-forge Qt 6.8.2, GCC 13.3, the recipe of `run_pixi.yml`) from `origin/master` with and without this change (unit tests and CI lanes re-run on the rebased head, 5e5628835; the GUI scenarios were taken at 3f50782a5, two commits earlier, none of which touches linetypes) (RelWithDebInfo, `-DBUILD_TESTS=ON`; no new warnings).

Unit (`dxf_roundtrip_tests.cpp`, part of `librecad_dxf_fast_tests`, the lane run by `dwg-dxf-verify.yml`), three new cases and the invariant test extended: a DXF whose LTYPE table, a layer and two `LINE`s use `PHANTOM` / `PHANTOM2` imports on the phantom family; a `LINE` with pen `PhantomLine` exported through `RS_FilterDXFRW` carries `6/PHANTOM`, the LTYPE table has `PHANTOM` with six dashes 31.75/−6.35/6.35/−6.35/6.35/−6.35 and length 63.5 plus the three scaled records at acad.lin's ratios, importing it back (DXF, and DWG under `DWGSUPPORT`) yields `PhantomLine`, and saving the reimported drawing writes the record once; a DXF using `ACAD_ISO09W100` on a layer and a `LINE` imports on `PhantomLine`, is written back as `PHANTOM`, and its source record is re-emitted once; every name `lineTypeToName()` writes maps back to the same enum, the JWW name tables agree with the DXF ones, the enum values 28..35 are pinned, and every phantom variant has a screen pattern. `librecad_dxf_fast_tests`: 521 cases passed; `librecad_dwg_fast_tests`: 909 passed, 37 skipped (fixtures), 0 failed.

GUI, Qt `vnc` platform driven by the harness in `tools/` (pen toolbar, command line, *File › Save as*, Properties dock; saved files checked with `check_dxf_linetype.py` / ezdxf):

| scenario | master (3f50782a5) | with this change |
|---|---|---|
| G1 pen toolbar line-type list, row after *Center (large)* | Border | Phantom, Phantom (tiny), Phantom (small), Phantom (large), then Border |
| G2 pick *Phantom*, draw a line, *Save as* → LTYPE table + group 6 | (no such entry; line saved ByLayer) | `PHANTOM` record 31.75/−6.35/6.35/−6.35/6.35/−6.35, `LINE` with `6/PHANTOM` |
| G3 reopen the G2 file, select, Properties dock | — | Phantom |
| G4 external `single_PHANTOM.dxf` / `single_PHANTOM2.dxf` / `single_PHANTOMX2.dxf`, Properties dock | Continuous / Continuous / Continuous | Phantom / Phantom (small) / Phantom (large) |
| G5 external `phantom_family.dxf` (3 lines + a layer using PHANTOM), *Save as* → group 6 of the lines, layer linetype, LTYPE records | `CONTINUOUS` ×3, layer `CONTINUOUS`; orphaned `PHANTOM*` records kept (34 records) | `PHANTOM` / `PHANTOM2` / `PHANTOMX2`, layer `PHANTOM`; 35 records, no duplicates |
| canvas with `phantom_family.dxf` | four solid lines | long-short-short pattern at the three scales |

![pen toolbar line-type list, base vs fix](https://raw.githubusercontent.com/ROMPEFUEGOS/LibreCAD/pr-assets-phantom-linetype/test-results/phantom/combobox_base_vs_fix.png)

![Properties dock on the single-line fixtures, base vs fix](https://raw.githubusercontent.com/ROMPEFUEGOS/LibreCAD/pr-assets-phantom-linetype/test-results/phantom/properties_fixtures_base_vs_fix.png)

![canvas with the family fixture, base vs fix](https://raw.githubusercontent.com/ROMPEFUEGOS/LibreCAD/pr-assets-phantom-linetype/test-results/phantom/canvas_family_base_vs_fix.png)

Full set — `results.json`, all screenshots, the fixtures, the saved DXF files and the harness: [branch `pr-assets-phantom-linetype`](https://github.com/ROMPEFUEGOS/LibreCAD/tree/pr-assets-phantom-linetype/test-results/phantom) of the fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjRUbZuYYZLuxhXB8HFDRo
