### PR TITLE
Show the snap indicator while a dimension picks its points

### DIFF
--- a/librecad/src/actions/drawing/draw/dimensions/lc_actioncircledimbase.cpp
+++ b/librecad/src/actions/drawing/draw/dimensions/lc_actioncircledimbase.cpp
@@ -54,6 +54,12 @@ void LC_ActionCircleDimBase::doTriggerCompletion([[maybe_unused]]bool success) {
     RS_Snapper::finish();
 }
 
+// SetEntity picks a circle or arc and SetText reads from the command line;
+// only SetPos takes a point through the snapper (LibreCAD#2824).
+bool LC_ActionCircleDimBase::isInVisualSnapStatus(int status) {
+    return status == SetPos;
+}
+
 void LC_ActionCircleDimBase::onMouseMoveEvent(const int status, const LC_MouseEvent* e) {
     RS_Vector snap = e->snapPoint;
     switch (status) {

--- a/librecad/src/actions/drawing/draw/dimensions/lc_actioncircledimbase.h
+++ b/librecad/src/actions/drawing/draw/dimensions/lc_actioncircledimbase.h
@@ -63,6 +63,7 @@ protected:
     void onMouseLeftButtonRelease(int status, const LC_MouseEvent* e) override;
     void onMouseRightButtonRelease(int status, const LC_MouseEvent* e) override;
     void onMouseMoveEvent(int status, const LC_MouseEvent* e) override;
+    bool isInVisualSnapStatus(int status) override;
     void setDimSourceEntity(RS_Entity* en, bool controlPressed, const RS_Vector& pos);
     bool doProcessCommand(int status, const QString &c) override;
     void onCoordinateEvent(int status, bool isZero, const RS_Vector &coord) override;

--- a/librecad/src/actions/drawing/draw/dimensions/lc_actiondimarc.cpp
+++ b/librecad/src/actions/drawing/draw/dimensions/lc_actiondimarc.cpp
@@ -74,6 +74,12 @@ void LC_ActionDimArc::doTriggerCompletion([[maybe_unused]]bool success) {
     RS_Snapper::finish();
 }
 
+// SetEntity picks an arc; only SetPos takes a point through the snapper
+// (LibreCAD#2824).
+bool LC_ActionDimArc::isInVisualSnapStatus(int status) {
+    return status == SetPos;
+}
+
 void LC_ActionDimArc::onMouseMoveEvent(const int status, const LC_MouseEvent* e) {
     RS_Vector snap = e->snapPoint;
     switch (status) {

--- a/librecad/src/actions/drawing/draw/dimensions/lc_actiondimarc.h
+++ b/librecad/src/actions/drawing/draw/dimensions/lc_actiondimarc.h
@@ -53,6 +53,7 @@ protected:
     void onMouseLeftButtonRelease(int status, const LC_MouseEvent* e) override;
     void onMouseRightButtonRelease(int status, const LC_MouseEvent* e) override;
     void onMouseMoveEvent(int status, const LC_MouseEvent* e) override;
+    bool isInVisualSnapStatus(int status) override;
    void setArcEntity(RS_Entity* entity);
    void onCoordinateEvent(int status, bool isZero, const RS_Vector &pos) override;
    RS_Entity* doTriggerCreateEntity() override;

--- a/librecad/src/actions/drawing/draw/dimensions/lc_actiondimlinearbase.cpp
+++ b/librecad/src/actions/drawing/draw/dimensions/lc_actiondimlinearbase.cpp
@@ -63,6 +63,15 @@ void LC_ActionDimLinearBase::doInitWithContextEntity(RS_Entity* contextEntity, c
     }
 }
 
+// Both extension points and the dimension-line position are picked with the
+// mouse through the snapper, so the snap indicator belongs on all three
+// (LibreCAD#2824). SetText and SetAngle read from the command line and stay
+// excluded - suppressing the indicator where no point is being picked is what
+// isInVisualSnapStatus() was added for (LibreCAD#2143).
+bool LC_ActionDimLinearBase::isInVisualSnapStatus(int status) {
+    return status == SetExtPoint1 || status == SetExtPoint2 || status == SetDefPoint;
+}
+
 void LC_ActionDimLinearBase::onMouseMoveEvent(const int status, const LC_MouseEvent* e) {
     RS_Vector mouse = e->snapPoint;
 

--- a/librecad/src/actions/drawing/draw/dimensions/lc_actiondimlinearbase.h
+++ b/librecad/src/actions/drawing/draw/dimensions/lc_actiondimlinearbase.h
@@ -69,6 +69,7 @@ protected:
     void onMouseLeftButtonRelease(int status, const LC_MouseEvent* e) override;
     void onMouseRightButtonRelease(int status, const LC_MouseEvent* e) override;
     void onMouseMoveEvent(int status, const LC_MouseEvent* e) override;
+    bool isInVisualSnapStatus(int status) override;
     void onCoordinateEvent(int status, bool isZero, const RS_Vector& pos) override;
     void updateActionPrompt() override;
     RS_Entity* doTriggerCreateEntity() override;

--- a/librecad/src/actions/drawing/draw/dimensions/lc_actiondimordinate.cpp
+++ b/librecad/src/actions/drawing/draw/dimensions/lc_actiondimordinate.cpp
@@ -113,6 +113,12 @@ LC_DimOrdinate*  LC_ActionDimOrdinate::createDim(const RS_Vector& leaderEndPoint
     return dimOrdinate;
 }
 
+// SetText reads from the command line; the feature point and the leader end
+// are both picked through the snapper (LibreCAD#2824).
+bool LC_ActionDimOrdinate::isInVisualSnapStatus(int status) {
+    return status == SetFeaturePoint || status == SetLeaderEnd;
+}
+
 void LC_ActionDimOrdinate::onMouseMoveEvent(const int status, const LC_MouseEvent* e) {
     RS_Vector mouse = e->snapPoint;
     switch (status) {

--- a/librecad/src/actions/drawing/draw/dimensions/lc_actiondimordinate.h
+++ b/librecad/src/actions/drawing/draw/dimensions/lc_actiondimordinate.h
@@ -50,6 +50,7 @@ protected:
     void onCoordinateEvent(int status, bool isZero, const RS_Vector& pos) override;
     LC_DimOrdinate* createDim(const RS_Vector& leaderEndPoint, bool alternateOrdinate, RS_EntityContainer * container) const;
     void onMouseMoveEvent(int status, const LC_MouseEvent* e) override;
+    bool isInVisualSnapStatus(int status) override;
     void onMouseLeftButtonRelease(int status, const LC_MouseEvent* e) override;
     void onMouseRightButtonRelease(int status, const LC_MouseEvent* e) override;
     QStringList doGetAvailableCommands(int status) override;

--- a/librecad/src/actions/drawing/draw/dimensions/lc_actiondrawgdtfeaturecontrolframe.cpp
+++ b/librecad/src/actions/drawing/draw/dimensions/lc_actiondrawgdtfeaturecontrolframe.cpp
@@ -103,6 +103,12 @@ void LC_ActionDrawGDTFeatureControlFrame::onCoordinateEvent(const int status, [[
     }
 }
 
+// ShowDialog waits on a modal dialog; SetInsertionPoint is the one status that
+// picks a point through the snapper (LibreCAD#2824).
+bool LC_ActionDrawGDTFeatureControlFrame::isInVisualSnapStatus(int status) {
+    return status == SetInsertionPoint;
+}
+
 void LC_ActionDrawGDTFeatureControlFrame::onMouseMoveEvent(const int status, const LC_MouseEvent* event) {
     auto snap = event->snapPoint;
     if (status == SetInsertionPoint){

--- a/librecad/src/actions/drawing/draw/dimensions/lc_actiondrawgdtfeaturecontrolframe.h
+++ b/librecad/src/actions/drawing/draw/dimensions/lc_actiondrawgdtfeaturecontrolframe.h
@@ -62,6 +62,7 @@ protected:
     void doTriggerCompletion(bool success) override;
     RS_Entity* doTriggerCreateEntity() override;
     void onMouseMoveEvent(int status, const LC_MouseEvent* event) override;
+    bool isInVisualSnapStatus(int status) override;
     void onMouseLeftButtonRelease(int status, const LC_MouseEvent* e) override;
     void onMouseRightButtonRelease(int status, const LC_MouseEvent* e) override;
     QStringList doGetAvailableCommands(int status) override;

--- a/librecad/src/actions/drawing/draw/dimensions/rs_actiondimangular.cpp
+++ b/librecad/src/actions/drawing/draw/dimensions/rs_actiondimangular.cpp
@@ -70,6 +70,12 @@ void RS_ActionDimAngular::doTriggerCompletion([[maybe_unused]]bool success) {
     RS_Snapper::finish();
 }
 
+// SetLine1 and SetLine2 pick entities and SetText reads from the command
+// line; only SetPos takes a point through the snapper (LibreCAD#2824).
+bool RS_ActionDimAngular::isInVisualSnapStatus(int status) {
+    return status == SetPos;
+}
+
 void RS_ActionDimAngular::onMouseMoveEvent(const int status, const LC_MouseEvent* e) {
     RS_Vector snap = e->snapPoint;
     switch (status) {

--- a/librecad/src/actions/drawing/draw/dimensions/rs_actiondimangular.h
+++ b/librecad/src/actions/drawing/draw/dimensions/rs_actiondimangular.h
@@ -66,6 +66,7 @@ protected:
     bool setData(const RS_Vector& dimPos, bool calcCenter = false);
     void onMouseLeftButtonRelease(int status, const LC_MouseEvent* e) override;
     void onMouseMoveEvent(int status, const LC_MouseEvent* e) override;
+    bool isInVisualSnapStatus(int status) override;
     void setFirstLine(RS_Entity* en, const RS_Vector& pos);
     void onMouseRightButtonRelease(int status, const LC_MouseEvent* e) override;
     bool doProcessCommand(int status, const QString &command) override;

--- a/librecad/src/actions/drawing/draw/dimensions/rs_actiondimleader.cpp
+++ b/librecad/src/actions/drawing/draw/dimensions/rs_actiondimleader.cpp
@@ -61,6 +61,12 @@ RS_Entity* RS_ActionDimLeader::doTriggerCreateEntity() {
     return nullptr;
 }
 
+// Every status of this action picks a point through the snapper
+// (LibreCAD#2824).
+bool RS_ActionDimLeader::isInVisualSnapStatus(int status) {
+    return status == SetStartpoint || status == SetEndpoint;
+}
+
 void RS_ActionDimLeader::onMouseMoveEvent(const int status, const LC_MouseEvent* e) {
     RS_Vector mouse = e->snapPoint;
     switch (status) {

--- a/librecad/src/actions/drawing/draw/dimensions/rs_actiondimleader.h
+++ b/librecad/src/actions/drawing/draw/dimensions/rs_actiondimleader.h
@@ -61,6 +61,7 @@ protected:
     struct ActionData;
     std::unique_ptr<ActionData> m_actionData;
     RS2::CursorType doGetMouseCursor(int status) override;
+    bool isInVisualSnapStatus(int status) override;
     void reset() const;
     void onMouseMoveEvent(int status, const LC_MouseEvent* e) override;
     void onMouseLeftButtonRelease(int status, const LC_MouseEvent* e) override;


### PR DESCRIPTION
Fixes #2824.

### The gate

The AutoSnap indicator is drawn by `RS_Snapper::drawSnapper()` only when
`isSnapExpected()` is true, and `RS_ActionInterface` routes that to
`isInVisualSnapStatus(getStatus())`, whose `RS_Snapper` default is `false`:

```
RS_Snapper::drawSnapper()               rs_snapper.cpp:1211
  → isSnapExpected()                    rs_actioninterface.h:212
  → isInVisualSnapStatus(getStatus())
  → RS_Snapper::isInVisualSnapStatus()  rs_snapper.cpp:357  →  false
```

So an action has to name the statuses in which it picks a point. Most drawing
actions do — line, circle, rect, polyline, point, curve, polygon, image all
carry overrides — but **no dimension action did**: none of the files under
`actions/drawing/draw/dimensions/` overrode it, and neither does any of their
bases (`LC_SingleEntityCreationAction` → `LC_UndoableDocumentModificationAction`
→ `RS_PreviewActionInterface`). Dimensions were the only family at zero.

The indicator was therefore off for **every** dimension status, not only the
first extension point the report names.

### Why the second point looked like it worked

A different marker. `LC_ActionDimLinearBase::onMouseMoveEvent()` draws nothing
at the cursor in `SetExtPoint1` — only a hover highlight, and only while Ctrl
is held — but in `SetExtPoint2` it calls `previewRefLine(extPoint1, mouse)` and
`previewRefSelectablePoint(mouse)`. That reference-point preview is what is
visible at the second point, and it is not the AutoSnap indicator.

### The change

Six overrides, each placed on the highest class that shares a status set, so
they cover all eleven dimension tools:

| class | statuses | tools covered |
| --- | --- | --- |
| `LC_ActionDimLinearBase` | `SetExtPoint1`, `SetExtPoint2`, `SetDefPoint` | aligned, linear, baseline, continue |
| `LC_ActionCircleDimBase` | `SetPos` | radial, diametric |
| `LC_ActionDimArc` | `SetPos` | arc |
| `RS_ActionDimAngular` | `SetPos` | angular |
| `RS_ActionDimLeader` | `SetStartpoint`, `SetEndpoint` | leader |
| `LC_ActionDimOrdinate` | `SetFeaturePoint`, `SetLeaderEnd` | ordinate |
| `LC_ActionDrawGDTFeatureControlFrame` | `SetInsertionPoint` | GDT feature control frame |

Statuses that select an entity (`SetEntity`, `SetLine1`, `SetLine2`) or read
from the command line (`SetText`, `SetAngle`) stay excluded — suppressing the
indicator where no point is being picked is the distinction
`isInVisualSnapStatus()` exists to draw (#2143).

`LC_ActionDrawDimBaseline` needs no override of its own — it derives from
`LC_ActionDimLinearBase` and reuses its statuses. `LC_ActionDimOrdinateRebase`
and `LC_ActionSelectDimOrdinateSameOrigin` are excluded deliberately: neither
takes a point (the rebase action has no `onMouseMoveEvent` at all).

52 lines added, none deleted, no behaviour touched outside the predicate.

### Relationship to #2777

This is the same gap that #2777 closed for `RS_ActionDefault` in Modify mode,
one class at a time. Worth noting: the reporter's build string,
`2.2.2_alpha1-628-g3c028612d`, is exactly the #2777 merge commit — so they are
running the build where Modify mode was fixed, which is consistent with them
noticing the same marker missing in Dimension mode.

### Verification

Built both ways at this branch's tip: cmake/Ninja links `LibreCAD.app` with
0 errors and no warning in any changed file, and the qmake build recompiles all
six actions with 0 errors and 0 warnings in them.

Test suite is unchanged against master `8cfaadf9a`, measured by reverting only
the `dimensions/` directory in the same build tree:

| | cases | assertions |
| --- | --- | --- |
| master `8cfaadf9a` | 22 failed | 72928 / 26 failed |
| this branch | 2431 / 2340 passed / 22 failed / 69 skipped | 72928 / 26 failed |

One limitation stated plainly: I cannot drive a native GUI from my environment,
so I have not reproduced the recording myself. The diagnosis is read from the
call chain above, and the `SetExtPoint1`/`SetExtPoint2` asymmetry independently
predicts exactly the behaviour in the video.

### Same gap elsewhere, left for a follow-up

Sweeping every action that consumes a snapped point turned up three more
without the override, all outside this issue's scope and all pre-existing:
`LC_ActionDrawLineFreehand` (`SetStartpoint`/`Dragging`),
`RS_ActionDrawLineHorVert` (`SetStartpoint`/`SetEndpoint`) and
`LC_ActionDrawDual`. They deserve the same treatment, but not in a PR about
dimensions.

### Unrelated, spotted while reading

`rs_snapper.cpp:1211` initialises a variable from itself:

```cpp
bool showSnapIndicator = showSnapIndicator = isSnapExpected(); // LibreCAD#2520
```

It evaluates to the right value, so it is not the bug here, and I left it alone
to keep this change to the predicate — but it is worth cleaning up.

