### PR TITLE
Fix end angle editing and minor-axis picking in the ellipse properties dialog

### DIFF
--- a/librecad/src/ui/dialogs/entity/lc_propertieseditingwidget_ellipse.cpp
+++ b/librecad/src/ui/dialogs/entity/lc_propertieseditingwidget_ellipse.cpp
@@ -105,7 +105,7 @@ void LC_PropertiesEditingWidgetEllipse::onAngle1EditingFinished() const {
 
 void LC_PropertiesEditingWidgetEllipse::onAngle2EditingFinished() const {
     const double angle = toRawAngleValue(ui->leAngle2, m_entity->getAngle2());
-    m_entity->setAngle1(angle);
+    m_entity->setAngle2(angle);
 }
 
 void LC_PropertiesEditingWidgetEllipse::onReversedToggled([[maybe_unused]]bool checked) const {
@@ -115,7 +115,7 @@ void LC_PropertiesEditingWidgetEllipse::onReversedToggled([[maybe_unused]]bool c
 void LC_PropertiesEditingWidgetEllipse::setupInteractiveInputWidgets() {
     pickPointSetup(ui->wPickPointCenter, "center", ui->leCenterX, ui->leCenterY);
     pickDistanceSetup(ui->tbPickMajor, "major", ui->leMajor);
-    pickDistanceSetup(ui->tbPickMajor, "minor", ui->leMinor);
+    pickDistanceSetup(ui->tbPickMinor, "minor", ui->leMinor);
     pickAngleSetup(ui->tbPickRotation, "rotation", ui->leRotation);
     pickAngleSetup(ui->tbPickStartAngle, "angle1", ui->leAngle1);
     pickAngleSetup(ui->tbPickEndAngle, "angle2", ui->leAngle2);


### PR DESCRIPTION
## Summary
Two wiring bugs in the entity properties dialog for ellipses (`LC_PropertiesEditingWidgetEllipse`):

- **End angle:** editing the end angle of an elliptic arc called `setAngle1()`. It overwrote the start angle and never changed the end angle. It now calls `setAngle2()`.
- **Minor-axis pick:** the minor axis was set up on the major-axis pick button, `tbPickMajor`. That replaced the button's tag with "minor" and connected its click a second time. Picking the major axis therefore filled in the minor axis, and the minor-axis button, `tbPickMinor`, did nothing. The minor axis is now set up on `tbPickMinor`, which the `.ui` file already has.

## Testing
- Compiled `lc_propertieseditingwidget_ellipse.cpp` with the `librecad_lib` flags of an existing build.
- Not exercised in the running application; the entity properties widgets have no unit tests.
