### PR TITLE
Stop the console converters and PDF/SVG export from failing silently

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2557,6 +2557,7 @@ if (BUILD_TESTS)
         librecad/src/lib/engine/settings/tests/rs_settings_migration_tests.cpp
         librecad/src/lib/gui/tests/rs_graphicview_close_tests.cpp
         librecad/src/main/tests/console_command_utils_tests.cpp
+        librecad/src/main/tests/lc_pdfprintlooptests.cpp
         # Shapelib safety-net tests.  shapelib sources are compiled into
         # librecad_lib (SHARED_SOURCES) since Phase 1b, so the test target
         # only needs the test file itself.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2484,6 +2484,7 @@ if (BUILD_TESTS)
         librecad/src/lib/math/tests/lc_quadratic_tests.cpp
         librecad/src/lib/creation/tests/rs_creation_null_entity_tests.cpp
         librecad/src/actions/print_preview/tests/rs_actionprintpreview_tests.cpp
+        librecad/src/lib/printing/tests/lc_printingtests.cpp
         librecad/src/lib/modification/tests/lc_division_tests.cpp
         librecad/src/lib/modification/tests/rs_modification_trim_tests.cpp
         librecad/src/lib/filters/tests/dwg_buffer_round_trip_tests.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2559,6 +2559,7 @@ if (BUILD_TESTS)
         librecad/src/lib/gui/tests/rs_graphicview_close_tests.cpp
         librecad/src/main/tests/console_command_utils_tests.cpp
         librecad/src/main/tests/lc_pdfprintlooptests.cpp
+        librecad/src/main/tests/lc_consoleimporttests.cpp
         # Shapelib safety-net tests.  shapelib sources are compiled into
         # librecad_lib (SHARED_SOURCES) since Phase 1b, so the test target
         # only needs the test file itself.

--- a/librecad/src/actions/file/lc_actionfileexportmakercam.cpp
+++ b/librecad/src/actions/file/lc_actionfileexportmakercam.cpp
@@ -24,7 +24,7 @@
 
 #include "lc_actionfileexportmakercam.h"
 
-#include <QFile>
+#include <QSaveFile>
 #include <QTextStream>
 
 #include "lc_makercamsvg.h"
@@ -74,16 +74,27 @@ bool LC_ActionFileExportMakerCam::writeSvg(const QString& fileName, RS_Graphic& 
     }
 
     const auto generator = getGenerator();
-    if (generator->generate(&graphic)) {
-        QFile file{fileName};
-        if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
-            LC_ERR << __func__ << "(): failed in creating file " << fileName << ", no SVG is generated";
-            return false;
-        }
-
-        QTextStream out(&file);
-        out << QString::fromStdString(generator->resultAsString());
+    if (!generator->generate(&graphic)) {
+        LC_ERR << __func__ << "(): failed in generating the SVG for " << fileName;
+        return false;
     }
+
+    // QSaveFile reports a write that fails after the file is open, and leaves an
+    // existing file alone until the new one is complete.
+    QSaveFile file{fileName};
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        LC_ERR << __func__ << "(): failed in creating file " << fileName << ", no SVG is generated";
+        return false;
+    }
+
+    QTextStream out(&file);
+    out << QString::fromStdString(generator->resultAsString());
+    out.flush();
+    if (out.status() != QTextStream::Ok || !file.commit()) {
+        LC_ERR << __func__ << "(): failed in writing file " << fileName;
+        return false;
+    }
+
     return true;
 }
 
@@ -95,7 +106,11 @@ void LC_ActionFileExportMakerCam::trigger() {
 
         if (accepted) {
             const QString filename = RS_DIALOGFACTORY->requestFileSaveAsDialog(tr("Export as"), "", "Scalable Vector Graphics (*.svg)");
-            writeSvg(filename, *m_graphic);
+            // An empty name means the dialog was cancelled
+            if (!filename.isEmpty() && !writeSvg(filename, *m_graphic)) {
+                RS_DIALOGFACTORY->requestWarningDialog(
+                    tr("Cannot write the file\n%1\nPlease check the filename and permissions.").arg(filename));
+            }
         }
     }
 

--- a/librecad/src/lib/printing/lc_printing.cpp
+++ b/librecad/src/lib/printing/lc_printing.cpp
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "lc_printing.h"
 
 #include <QApplication>
+#include <QDir>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QMessageBox>
@@ -115,6 +116,86 @@ void LC_Printing::setupPageLayout(QPrinter& printer, bool landscape, QPageSize::
     printer.setPageLayout(layout);
 }
 
+bool LC_Printing::printGraphic(QPrinter& printer, RS_Graphic& graphic, const RS2::DrawingMode drawingMode,
+                               const bool scaleLineWidth) {
+    // The printer opens the output file, or starts the print job, when painting begins
+    RS_Painter painter(&printer);
+    if (!painter.isActive()) {
+        return false;
+    }
+    painter.setDrawingMode(drawingMode);
+
+    QMarginsF margins = printer.pageLayout().margins(QPageLayout::Millimeter);
+    //        LC_ERR << "Printer margins (mm): " << margins.left()<<": "<<margins.top()<<" : "<<margins.right()<<" : "<<margins.bottom();
+
+    double printerWidth = printer.width();
+    double printerHeight = printer.height();
+
+    double printerFx = printerWidth / printer.widthMM();
+    double printerFy = printerHeight / printer.heightMM();
+
+    painter.setClipRect(margins.left() * printerFx, margins.top() * printerFy,
+                        printerWidth - (margins.left() + margins.right()) * printerFx,
+                        printerHeight - (margins.top() + margins.bottom()) * printerFy);
+
+    LC_GraphicViewport viewport;
+    viewport.setDocument(&graphic);
+    viewport.setBorders(0, 0, 0, 0);
+    viewport.setSize(printerWidth, printerHeight);
+
+    LC_PrintViewportRenderer renderer(&viewport, &painter);
+    viewport.loadSettings();
+    renderer.loadSettings();
+
+    renderer.setLineWidthScaling(scaleLineWidth);
+
+    RS2::Unit unit = graphic.getUnit();
+    double fx = printerFx * RS_Units::getFactorToMM(unit);
+    double fy = printerFy * RS_Units::getFactorToMM(unit);
+    //RS_DEBUG->print(RS_Debug::D_ERROR, "paper size=(%d, %d)\n",
+    //                printer.widthMM(),printer.heightMM());
+
+    double f = (fx + fy) / 2.0;
+
+    LC_PlotSettings* ps = graphic.getPlotSettings();
+    double scale = ps->getPaperScale();
+    double factor = f * scale;
+
+    //RS_DEBUG->print(RS_Debug::D_ERROR, "PaperSize=(%d, %d)\n",printer.widthMM(), printer.heightMM());
+
+    double baseX = graphic.getPaperInsertionBase().x;
+    double baseY = graphic.getPaperInsertionBase().y;
+
+    int numX = ps->getPagesNumHoriz();
+    int numY = ps->getPagesNumVert();
+    RS_Vector printArea = ps->getPrintAreaSize(false);
+
+    for (int pY = 0; pY < numY; pY++) {
+        double offsetY = printArea.y * pY;
+        for (int pX = 0; pX < numX; pX++) {
+            double offsetX = printArea.x * pX;
+            // First page is created automatically.
+            // Extra pages must be created manually.
+            if (pX > 0 || pY > 0) {
+                printer.newPage();
+            }
+
+            viewport.justSetOffsetAndFactor(static_cast<int>((baseX - offsetX) * f), static_cast<int>((baseY - offsetY) * f), factor);
+
+            painter.setViewPort(&viewport); // update offset
+            renderer.render();
+
+            //                painter.setDrawSelectedOnly(true);
+            //                gv.drawEntity(&painter, graphic);
+            //                painter.setDrawSelectedOnly(false);
+            //                gv.drawEntity(&painter, graphic);
+        }
+    }
+
+    // Calling QPainter::end() is automatic at QPainter destructor
+    return true;
+}
+
 void LC_Printing::print(QC_MDIWindow &mdiWindow, PrinterType printerType) {
     RS_Graphic* graphic = mdiWindow.getDocument()->getGraphic();
 
@@ -159,14 +240,15 @@ void LC_Printing::print(QC_MDIWindow &mdiWindow, PrinterType printerType) {
         QPageLayout pdfLayout = printer.pageLayout();
         pdfLayout.setMinimumMargins({});
         printer.setPageLayout(pdfLayout);
-        QString pdfFie = QFileDialog::getSaveFileName(
+        const QString pdfFile = QFileDialog::getSaveFileName(
             &mdiWindow,
             QObject::tr("Export to PDF"),
             defaultFile,
             QObject::tr("PDF files (*.pdf);;All files (*.*)"));
-        if (pdfFie.isEmpty())
-            pdfFie = defaultFile;
-        printer.setOutputFileName(pdfFie);
+        // An empty name means the dialog was cancelled
+        if (pdfFile.isEmpty())
+            return;
+        printer.setOutputFileName(pdfFile);
         bStartPrinting = true;
     }
     else {
@@ -258,104 +340,39 @@ void LC_Printing::print(QC_MDIWindow &mdiWindow, PrinterType printerType) {
         }
     }
 
-    if (bStartPrinting) {
-        RS_DEBUG->print(RS_Debug::D_INFORMATIONAL, "QC_ApplicationWindow::slotFilePrint: resolution is %d", printer.resolution());
-        QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
+    if (!bStartPrinting)
+        return;
 
-        RS_Painter painter(&printer);
-        // RAII style to restore cursor. Not really a shared pointer for ownership
-        std::shared_ptr<RS_Painter> painterPtr{
-            &painter,
-            []([[maybe_unused]] RS_Painter* p) {
-                QApplication::restoreOverrideCursor();
-            }
-        };
+    RS_DEBUG->print(RS_Debug::D_INFORMATIONAL, "QC_ApplicationWindow::slotFilePrint: resolution is %d", printer.resolution());
 
-        // fixme - sand rework this later - it seems that printing in general should be refined.
-        QG_GraphicView* graphicView = mdiWindow.getGraphicView();
-        RS2::DrawingMode drawingMode = RS2::DrawingMode::ModeAuto;
-        if (graphicView->isPrintPreview()) {
-            auto printPreview = dynamic_cast<LC_PrintPreviewView*>(graphicView);
-            if (printPreview != nullptr) {
-                drawingMode = printPreview->getDrawingMode();
-            }
+    // fixme - sand rework this later - it seems that printing in general should be refined.
+    QG_GraphicView* graphicView = mdiWindow.getGraphicView();
+    RS2::DrawingMode drawingMode = RS2::DrawingMode::ModeAuto;
+    if (graphicView->isPrintPreview()) {
+        auto printPreview = dynamic_cast<LC_PrintPreviewView*>(graphicView);
+        if (printPreview != nullptr) {
+            drawingMode = printPreview->getDrawingMode();
         }
-        painter.setDrawingMode(drawingMode);
+    }
 
-        QMarginsF margins = printer.pageLayout().margins(QPageLayout::Millimeter);
-        //        LC_ERR << "Printer margins (mm): " << margins.left()<<": "<<margins.top()<<" : "<<margins.right()<<" : "<<margins.bottom();
+    QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
+    const bool printed = printGraphic(printer, *graphic, drawingMode, graphicView->getLineWidthScaling());
+    QApplication::restoreOverrideCursor();
 
-        double printerWidth = printer.width();
-        double printerHeight = printer.height();
-
-        double printerFx = printerWidth / printer.widthMM();
-        double printerFy = printerHeight / printer.heightMM();
-
-        painter.setClipRect(margins.left() * printerFx, margins.top() * printerFy,
-                            printerWidth - (margins.left() + margins.right()) * printerFx,
-                            printerHeight - (margins.top() + margins.bottom()) * printerFy);
-
-        LC_GraphicViewport viewport;
-        viewport.setDocument(graphic);
-        viewport.setBorders(0, 0, 0, 0);
-        viewport.setSize(printerWidth, printerHeight);
-
-        LC_PrintViewportRenderer renderer(&viewport, &painter);
-        viewport.loadSettings();
-        renderer.loadSettings();
-
-        bool scaleLineWidth = mdiWindow.getGraphicView()->getLineWidthScaling();
-        renderer.setLineWidthScaling(scaleLineWidth);
-
-        double fx = printerFx * RS_Units::getFactorToMM(unit);
-        double fy = printerFy * RS_Units::getFactorToMM(unit);
-        //RS_DEBUG->print(RS_Debug::D_ERROR, "paper size=(%d, %d)\n",
-        //                printer.widthMM(),printer.heightMM());
-
-        double f = (fx + fy) / 2.0;
-
-        double scale = ps->getPaperScale();
-        double factor = f * scale;
-
-        //RS_DEBUG->print(RS_Debug::D_ERROR, "PaperSize=(%d, %d)\n",printer.widthMM(), printer.heightMM());
-
-        double baseX = graphic->getPaperInsertionBase().x;
-        double baseY = graphic->getPaperInsertionBase().y;
-
-        int numX = ps->getPagesNumHoriz();
-        int numY = ps->getPagesNumVert();
-        RS_Vector printArea = ps->getPrintAreaSize(false);
-
-        for (int pY = 0; pY < numY; pY++) {
-            double offsetY = printArea.y * pY;
-            for (int pX = 0; pX < numX; pX++) {
-                double offsetX = printArea.x * pX;
-                // First page is created automatically.
-                // Extra pages must be created manually.
-                if (pX > 0 || pY > 0) {
-                    printer.newPage();
-                }
-
-                viewport.justSetOffsetAndFactor(static_cast<int>((baseX - offsetX) * f), static_cast<int>((baseY - offsetY) * f), factor);
-
-                painter.setViewPort(&viewport); // update offset
-                renderer.render();
-
-                //                painter.setDrawSelectedOnly(true);
-                //                gv.drawEntity(&painter, graphic);
-                //                painter.setDrawSelectedOnly(false);
-                //                gv.drawEntity(&painter, graphic);
-            }
-        }
-
-        // GraphicView deletes painter
-        // Calling QPainter::end() is automatic at QPainter destructor
-        // painter.end();
-
+    {
         LC_GROUP_GUARD("Print");
-        {
-            LC_SET("ColorMode", printer.colorMode());
-            LC_SET("FileName", printer.outputFileName());
-        }
+        LC_SET("ColorMode", printer.colorMode());
+        LC_SET("FileName", printer.outputFileName());
+    }
+
+    if (!printed) {
+        // The output file could not be opened, or the print job could not start
+        const QString message = printer.outputFileName().isEmpty()
+            ? QObject::tr("Cannot start printing on %1.").arg(printer.printerName())
+            : QObject::tr("Cannot write the file\n%1\nPlease check the filename and permissions.")
+                  .arg(QDir::toNativeSeparators(printer.outputFileName()));
+        QMessageBox::critical(&mdiWindow,
+                              printerType == PrinterType::PDF ? QObject::tr("Export to PDF") : QObject::tr("Print"),
+                              message);
     }
 }

--- a/librecad/src/lib/printing/lc_printing.h
+++ b/librecad/src/lib/printing/lc_printing.h
@@ -40,6 +40,16 @@ namespace LC_Printing
                          const RS_Vector& paperSize, RS2::Unit unit, const QMarginsF& paperMargins);
 
     /**
+     * @brief printGraphic - draws the graphic on the printer's pages, as its plot settings lay them out
+     * @param printer - a printer set up for its output: a print job or a PDF file
+     * @param graphic - the graphic to print
+     * @param drawingMode - the drawing mode of the painter
+     * @param scaleLineWidth - whether line widths scale with the drawing
+     * @return false if the printer could not start, as when the output file cannot be opened
+     */
+    bool printGraphic(QPrinter& printer, RS_Graphic& graphic, RS2::DrawingMode drawingMode, bool scaleLineWidth);
+
+    /**
      * @brief Print - the implementation of drawing printing
      * @param mdiWindow - the mdiWindow to print
      * @param printerType - whether printing to a printer or a PDF file

--- a/librecad/src/lib/printing/tests/lc_printingtests.cpp
+++ b/librecad/src/lib/printing/tests/lc_printingtests.cpp
@@ -1,0 +1,81 @@
+// File: lc_printingtests.cpp
+
+/*
+ * ********************************************************************************
+ * This file is part of the LibreCAD project, a 2D CAD program
+ *
+ * Copyright (C) 2026 LibreCAD.org
+ * Copyright (C) 2026 Dongxu Li (github.com/dxli)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ * ********************************************************************************
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <QFileInfo>
+#include <QPrinter>
+#include <QTemporaryDir>
+
+#include "lc_actiontestsupport.h"
+#include "lc_printing.h"
+#include "rs_graphic.h"
+#include "rs_line.h"
+
+namespace {
+
+// A new drawing holding one line.
+struct LineDrawing {
+    RS_Graphic graphic;
+
+    LineDrawing() {
+        graphic.initForNewDocument();
+        graphic.addEntity(new RS_Line{&graphic, RS_LineData{RS_Vector{0., 0.}, RS_Vector{100., 50.}}});
+    }
+};
+
+// Prints the drawing into a PDF file, as Export to PDF does.
+bool printToPdf(LineDrawing& drawing, const QString& fileName) {
+    QPrinter printer{QPrinter::HighResolution};
+    printer.setOutputFormat(QPrinter::PdfFormat);
+    printer.setOutputFileName(fileName);
+    return LC_Printing::printGraphic(printer, drawing.graphic, RS2::ModeAuto, false);
+}
+
+} // namespace
+
+TEST_CASE("Export to PDF reports a file it cannot write", "[printing][pdf]") {
+    REQUIRE(lc::test::application() != nullptr);
+    const QTemporaryDir dir;
+    REQUIRE(dir.isValid());
+    LineDrawing drawing;
+
+    // A file in a directory that does not exist cannot be opened, even by root.
+    const QString fileName = dir.filePath("missing/drawing.pdf");
+    CHECK_FALSE(printToPdf(drawing, fileName));
+    CHECK_FALSE(QFileInfo::exists(fileName));
+}
+
+TEST_CASE("Export to PDF writes a file it can write", "[printing][pdf]") {
+    REQUIRE(lc::test::application() != nullptr);
+    const QTemporaryDir dir;
+    REQUIRE(dir.isValid());
+    LineDrawing drawing;
+
+    const QString fileName = dir.filePath("drawing.pdf");
+    CHECK(printToPdf(drawing, fileName));
+    CHECK(QFileInfo(fileName).size() > 0);
+}

--- a/librecad/src/main/console_command_utils.cpp
+++ b/librecad/src/main/console_command_utils.cpp
@@ -29,6 +29,10 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QSet>
+
+#include "rs_fileio.h"
+#include "rs_graphic.h"
 
 namespace LC_Console {
 namespace {
@@ -47,6 +51,14 @@ bool hasAcceptedExtension(const QString& fileName, const QStringList& extensions
             return true;
     }
     return false;
+}
+
+// A path two names can be compared by: the same file reached two ways compares
+// equal, and a file that does not exist yet still compares by where it would be.
+QString comparablePath(const QString& path) {
+    const QFileInfo info(path);
+    const QString canonical = info.canonicalFilePath();
+    return canonical.isEmpty() ? QDir::cleanPath(info.absoluteFilePath()) : canonical;
 }
 
 } // namespace
@@ -155,11 +167,14 @@ QString extensionDescription(const QStringList& extensions) {
 }
 
 QStringList collectInputFiles(const QStringList& positionalArgs,
-                              const QStringList& extensions) {
+                              const QStringList& extensions,
+                              QStringList* skippedArgs) {
     QStringList files;
     for (const QString& arg : positionalArgs) {
         if (hasAcceptedExtension(arg, extensions))
             files.append(arg);
+        else if (skippedArgs != nullptr)
+            skippedArgs->append(arg);
     }
     return files;
 }
@@ -240,6 +255,68 @@ bool validateOutputOptions(int inputCount, const QString& outputFile,
         return false;
     }
 
+    return true;
+}
+
+bool validateOutputTargets(const QStringList& inputFiles, const QStringList& outputFiles,
+                           QString* errorMessage) {
+    const auto fail = [errorMessage](const QString& message) {
+        if (errorMessage != nullptr)
+            *errorMessage = message;
+        return false;
+    };
+
+    QSet<QString> inputPaths;
+    for (const QString& inputFile : inputFiles)
+        inputPaths.insert(comparablePath(inputFile));
+
+    QSet<QString> outputPaths;
+    for (const QString& outputFile : outputFiles) {
+        if (QFileInfo(outputFile).isDir())
+            return fail(QStringLiteral("output '%1' is a directory.").arg(outputFile));
+
+        const QString path = comparablePath(outputFile);
+        if (inputPaths.contains(path))
+            return fail(QStringLiteral("output '%1' would overwrite an input file.").arg(outputFile));
+        if (outputPaths.contains(path))
+            return fail(QStringLiteral("more than one input would be written to '%1'.").arg(outputFile));
+        outputPaths.insert(path);
+    }
+
+    return true;
+}
+
+bool importGraphic(RS_Graphic& graphic, const QString& inputFile, RS2::FormatType type) {
+    if (!QFileInfo::exists(inputFile)) {
+        qCritical("ERROR: input file does not exist: '%s'", qPrintable(inputFile));
+        return false;
+    }
+
+    graphic.initForNewDocument();
+
+    bool reported = false;
+    const bool imported = RS_FileIO::instance()->fileImport(
+        graphic, inputFile, type,
+        [&reported, &inputFile](bool partial, const QString& error) {
+            reported = true;
+            if (partial) {
+                qWarning("WARNING: partial import of '%s': %s",
+                         qPrintable(inputFile), qPrintable(error));
+                return true;
+            }
+            qCritical("ERROR: import failed for '%s': %s",
+                      qPrintable(inputFile), qPrintable(error));
+            return false;
+        });
+
+    if (!imported) {
+        // the format was not recognised, so the import never reached a filter
+        if (!reported)
+            qCritical("ERROR: cannot read '%s'", qPrintable(inputFile));
+        return false;
+    }
+
+    graphic.onLoadingCompleted();
     return true;
 }
 

--- a/librecad/src/main/console_command_utils.h
+++ b/librecad/src/main/console_command_utils.h
@@ -34,6 +34,8 @@
 
 #include "rs.h"
 
+class RS_Graphic;
+
 namespace LC_Console {
 
 struct CommandContext {
@@ -63,8 +65,13 @@ CommandContext contextForCommand(int argc, char** argv, const QString& commandNa
 QStringList acceptedExtensions(const QString& primaryExt,
                                const QStringList& compatibilityExts = {});
 QString extensionDescription(const QStringList& extensions);
+/**
+ * @brief collectInputFiles picks the arguments that name input files
+ * @param skippedArgs if given, receives the arguments that were left out
+ */
 QStringList collectInputFiles(const QStringList& positionalArgs,
-                              const QStringList& extensions);
+                              const QStringList& extensions,
+                              QStringList* skippedArgs = nullptr);
 bool containsDwgInput(const QStringList& files);
 bool dwgSupportAvailable();
 RS2::FormatType dwgFormatForVersion(const QString& version);
@@ -77,6 +84,25 @@ bool validateOutputOptions(int inputCount, const QString& outputFile,
                            bool allowOutputWithMultipleInputs,
                            bool allowOutputAndDirectory,
                            QString* errorMessage = nullptr);
+
+/**
+ * @brief validateOutputTargets refuses output paths that would destroy data: an
+ *        existing directory, one of the input files, or the same file twice
+ * @return false and a message naming the path, when the outputs are not safe
+ */
+bool validateOutputTargets(const QStringList& inputFiles, const QStringList& outputFiles,
+                           QString* errorMessage = nullptr);
+
+/**
+ * @brief importGraphic reads a drawing for a console command
+ *
+ * Import errors are reported on stderr. Without this, the import opens a
+ * message box that a console command can never close.
+ *
+ * @return false if the file cannot be read; a partial import is accepted
+ */
+bool importGraphic(RS_Graphic& graphic, const QString& inputFile,
+                   RS2::FormatType type = RS2::FormatUnknown);
 
 } // namespace LC_Console
 

--- a/librecad/src/main/console_dxf2dwg.cpp
+++ b/librecad/src/main/console_dxf2dwg.cpp
@@ -57,34 +57,9 @@ RS2::FormatType parseDxfVersion(const QString& ver) {
 }
 
 bool convertFile(const QString& inputFile, const QString& outputFile, RS2::FormatType outFmt) {
-    // Fix 7: check existence before hitting the parser with a cryptic error
-    if (!QFileInfo::exists(inputFile)) {
-        qCritical("ERROR: input file does not exist: '%s'", qPrintable(inputFile));
-        return false;
-    }
-
     RS_Graphic graphic;
-    graphic.initForNewDocument();
-
-    // Fix 3: pass callback so partial/full failures print to stderr, no dialog
-    bool imported = RS_FileIO::instance()->fileImport(
-        graphic, inputFile, RS2::FormatUnknown,
-        [&](bool partial, const QString& errMsg) -> bool {
-            if (partial) {
-                qWarning("WARNING: partial import of '%s': %s",
-                         qPrintable(inputFile), qPrintable(errMsg));
-                return true;
-            }
-            qCritical("ERROR: import failed for '%s': %s",
-                      qPrintable(inputFile), qPrintable(errMsg));
-            return false;
-        });
-
-    if (!imported)
+    if (!LC_Console::importGraphic(graphic, inputFile))
         return false;
-
-    // Fix 2: finalise dimension styles before export
-    graphic.onLoadingCompleted();
 
     if (!RS_FileIO::instance()->fileExport(graphic, outputFile, outFmt)) {
         qCritical("ERROR: failed to export '%s'", qPrintable(outputFile));
@@ -293,13 +268,18 @@ int runConversion(int argc, char** argv,
     QString outFile = parser.value(outFileOpt);
     QString outDir  = parser.value(outDirOpt);
 
+    QStringList skippedArgs;
     const QStringList inputFiles =
-        LC_Console::collectInputFiles(args, LC_Console::acceptedExtensions(inputExt));
+        LC_Console::collectInputFiles(args, LC_Console::acceptedExtensions(inputExt), &skippedArgs);
 
     // Fix 8: clear diagnostic instead of dumping the full help page
     if (inputFiles.isEmpty()) {
         qCritical("ERROR: no .%s files found in arguments.", qPrintable(inputExt));
         return EXIT_FAILURE;
+    }
+    for (const QString& skipped : skippedArgs) {
+        qWarning("WARNING: '%s' is not a .%s file and was skipped.", qPrintable(skipped),
+                 qPrintable(inputExt));
     }
 
     if (inputExt == "dwg" && !LC_Console::dwgSupportAvailable()) {
@@ -334,16 +314,22 @@ int runConversion(int argc, char** argv,
         return EXIT_FAILURE;
     }
 
-    int failed = 0;
+    QStringList outputFiles;
     for (const auto& inputFile : inputFiles) {
-        QString outputFile;
-        if (!outFile.isEmpty()) {
-            outputFile = outFile;
-        } else {
-            outputFile = LC_Console::defaultOutputPath(inputFile, outputExt, outDir);
-        }
+        outputFiles.append(outFile.isEmpty()
+            ? LC_Console::defaultOutputPath(inputFile, outputExt, outDir)
+            : outFile);
+    }
 
-        if (!convertFile(inputFile, outputFile, outFmt))
+    QString outputTargetsError;
+    if (!LC_Console::validateOutputTargets(inputFiles, outputFiles, &outputTargetsError)) {
+        qCritical("ERROR: %s", qPrintable(outputTargetsError));
+        return EXIT_FAILURE;
+    }
+
+    int failed = 0;
+    for (int i = 0; i < inputFiles.size(); ++i) {
+        if (!convertFile(inputFiles.at(i), outputFiles.at(i), outFmt))
             ++failed;
     }
 

--- a/librecad/src/main/console_dxf2pdf/console_dxf2pdf.cpp
+++ b/librecad/src/main/console_dxf2pdf/console_dxf2pdf.cpp
@@ -46,9 +46,9 @@
 #include "pdf_print_loop.h"
 
 
-static RS_Vector parsePageSizeArg(const QString& arg);
-static void parsePagesNumArg(const QString&, PdfPrintParams&);
-static void parseMarginsArg(const QString&, PdfPrintParams&);
+static bool parsePageSizeArg(const QString& arg, RS_Vector& pageSize);
+static bool parsePagesNumArg(const QString&, PdfPrintParams&);
+static bool parseMarginsArg(const QString&, PdfPrintParams&);
 
 namespace {
 
@@ -162,32 +162,63 @@ int runPdfCommand(int argc, char* argv[], const PdfCommandSpec& spec) {
     params.centerOnPage = parser.isSet(centerOpt);
     params.grayscale = parser.isSet(grayOpt);
     params.monochrome = parser.isSet(monoOpt);
-    params.pageSize = parsePageSizeArg(parser.value(pageSizeOpt));
 
-    bool resOk = false;
-    int res = parser.value(resOpt).toInt(&resOk);
-    if (resOk) {
+    // An option value that cannot be read is refused rather than ignored: a
+    // silently dropped value prints the drawing at the wrong size or scale.
+    if (!parsePageSizeArg(parser.value(pageSizeOpt), params.pageSize)) {
+        qCritical("ERROR: invalid paper size '%s'; use WxH in mm, such as 210x297.",
+                  qPrintable(parser.value(pageSizeOpt)));
+        return EXIT_FAILURE;
+    }
+
+    if (parser.isSet(resOpt)) {
+        bool resOk = false;
+        const int res = parser.value(resOpt).toInt(&resOk);
+        if (!resOk || res <= 0) {
+            qCritical("ERROR: invalid resolution '%s'; use a positive number of DPI.",
+                      qPrintable(parser.value(resOpt)));
+            return EXIT_FAILURE;
+        }
         params.resolution = res;
     }
 
-    bool scaleOk = false;
-    double scale = parser.value(scaleOpt).toDouble(&scaleOk);
-    if (scaleOk) {
+    if (parser.isSet(scaleOpt)) {
+        bool scaleOk = false;
+        const double scale = parser.value(scaleOpt).toDouble(&scaleOk);
+        if (!scaleOk || scale <= 0.0) {
+            qCritical("ERROR: invalid scale '%s'; use a positive number, such as 0.01 for 1:100.",
+                      qPrintable(parser.value(scaleOpt)));
+            return EXIT_FAILURE;
+        }
         params.scale = scale;
     }
 
-    parseMarginsArg(parser.value(marginsOpt), params);
-    parsePagesNumArg(parser.value(pagesNumOpt), params);
+    if (!parseMarginsArg(parser.value(marginsOpt), params)) {
+        qCritical("ERROR: invalid margins '%s'; use L,T,R,B in mm, such as 10,10,10,10.",
+                  qPrintable(parser.value(marginsOpt)));
+        return EXIT_FAILURE;
+    }
+
+    if (!parsePagesNumArg(parser.value(pagesNumOpt), params)) {
+        qCritical("ERROR: invalid number of pages '%s'; use HxV, such as 2x1.",
+                  qPrintable(parser.value(pagesNumOpt)));
+        return EXIT_FAILURE;
+    }
 
     params.outFile = parser.value(outFileOpt);
     params.outDir = parser.value(outDirOpt);
 
-    params.inputFiles = LC_Console::collectInputFiles(args, spec.acceptedExts);
+    QStringList skippedArgs;
+    params.inputFiles = LC_Console::collectInputFiles(args, spec.acceptedExts, &skippedArgs);
 
     if (params.inputFiles.isEmpty()) {
         qCritical("ERROR: no %s files found in arguments.",
                   qPrintable(LC_Console::extensionDescription(spec.acceptedExts)));
         return EXIT_FAILURE;
+    }
+    for (const QString& skipped : skippedArgs) {
+        qWarning("WARNING: '%s' is not a %s file and was skipped.", qPrintable(skipped),
+                 qPrintable(LC_Console::extensionDescription(spec.acceptedExts)));
     }
 
     if (LC_Console::containsDwgInput(params.inputFiles) &&
@@ -196,9 +227,33 @@ int runPdfCommand(int argc, char* argv[], const PdfCommandSpec& spec) {
         return EXIT_FAILURE;
     }
 
+    // -o names the single PDF every input is printed into, so it is allowed
+    // with several inputs, but not together with an output directory.
+    QString outputOptionsError;
+    if (!LC_Console::validateOutputOptions(params.inputFiles.size(), params.outFile,
+                                           params.outDir, true, false,
+                                           &outputOptionsError)) {
+        qCritical("ERROR: %s", qPrintable(outputOptionsError));
+        return EXIT_FAILURE;
+    }
+
     QString dirError;
     if (!LC_Console::ensureOutputDirectory(params.outDir, &dirError)) {
         qCritical("ERROR: %s.", qPrintable(dirError));
+        return EXIT_FAILURE;
+    }
+
+    QStringList outputFiles;
+    if (params.outFile.isEmpty()) {
+        for (const QString& inputFile : params.inputFiles)
+            outputFiles.append(LC_Console::defaultOutputPath(inputFile, "pdf", params.outDir));
+    } else {
+        outputFiles.append(params.outFile);
+    }
+
+    QString outputTargetsError;
+    if (!LC_Console::validateOutputTargets(params.inputFiles, outputFiles, &outputTargetsError)) {
+        qCritical("ERROR: %s", qPrintable(outputTargetsError));
         return EXIT_FAILURE;
     }
 
@@ -237,49 +292,43 @@ int console_dwg2pdf(int argc, char* argv[])
 }
 
 
-static RS_Vector parsePageSizeArg(const QString& arg){
-    RS_Vector v(0.0, 0.0);
+static bool parsePageSizeArg(const QString& arg, RS_Vector& pageSize){
+    pageSize = RS_Vector(0.0, 0.0);
 
     if (arg.isEmpty()) {
-        return v;
+        return true;
     }
 
-    const QRegularExpression re("^(?<width>\\d+)[x|X]{1}(?<height>\\d+)$");
+    const QRegularExpression re("^(?<width>\\d+)[xX](?<height>\\d+)$");
     const QRegularExpressionMatch match = re.match(arg);
-
-    if (match.hasMatch()) {
-        const QString width = match.captured("width");
-        const QString height = match.captured("height");
-        v.x = width.toDouble();
-        v.y = height.toDouble();
-    } else {
-        qDebug() << "WARNING: Ignoring bad page size:" << arg;
+    if (!match.hasMatch()) {
+        return false;
     }
 
-    return v;
+    pageSize.x = match.captured("width").toDouble();
+    pageSize.y = match.captured("height").toDouble();
+    return pageSize.x > 0.0 && pageSize.y > 0.0;
 }
 
-static void parsePagesNumArg(const QString& arg, PdfPrintParams& params){
+static bool parsePagesNumArg(const QString& arg, PdfPrintParams& params){
     if (arg.isEmpty()) {
-        return;
+        return true;
     }
 
-    const QRegularExpression re("^(?<horiz>\\d+)[x|X](?<vert>\\d+)$");
+    const QRegularExpression re("^(?<horiz>\\d+)[xX](?<vert>\\d+)$");
     const QRegularExpressionMatch match = re.match(arg);
-
-    if (match.hasMatch()) {
-        const QString h = match.captured("horiz");
-        const QString v = match.captured("vert");
-        params.pagesH = h.toInt();
-        params.pagesV = v.toInt();
-    } else {
-        qDebug() << "WARNING: Ignoring bad number of pages:" << arg;
+    if (!match.hasMatch()) {
+        return false;
     }
+
+    params.pagesH = match.captured("horiz").toInt();
+    params.pagesV = match.captured("vert").toInt();
+    return params.pagesH > 0 && params.pagesV > 0;
 }
 
-static void parseMarginsArg(const QString& arg, PdfPrintParams& params){
+static bool parseMarginsArg(const QString& arg, PdfPrintParams& params){
     if (arg.isEmpty()) {
-        return;
+        return true;
     }
 
     const QRegularExpression re("^(?<left>\\d+(?:\\.\\d+)?),"
@@ -288,16 +337,13 @@ static void parseMarginsArg(const QString& arg, PdfPrintParams& params){
                           "(?<bottom>\\d+(?:\\.\\d+)?)$");
     const QRegularExpressionMatch match = re.match(arg);
 
-    if (match.hasMatch()) {
-        const QString left = match.captured("left");
-        const QString top = match.captured("top");
-        const QString right = match.captured("right");
-        const QString bottom = match.captured("bottom");
-        params.margins.left = left.toDouble();
-        params.margins.top = top.toDouble();
-        params.margins.right = right.toDouble();
-        params.margins.bottom = bottom.toDouble();
-    } else {
-        qDebug() << "WARNING: Ignoring bad paper margins:" << arg;
+    if (!match.hasMatch()) {
+        return false;
     }
+
+    params.margins.left = match.captured("left").toDouble();
+    params.margins.top = match.captured("top").toDouble();
+    params.margins.right = match.captured("right").toDouble();
+    params.margins.bottom = match.captured("bottom").toDouble();
+    return true;
 }

--- a/librecad/src/main/console_dxf2pdf/pdf_print_loop.cpp
+++ b/librecad/src/main/console_dxf2pdf/pdf_print_loop.cpp
@@ -42,6 +42,7 @@ static bool openDocAndSetGraphic(RS_Document**, RS_Graphic**, const QString&);
 static void touchGraphic(RS_Graphic*, const PdfPrintParams&);
 static void setupPrinterAndPaper(const RS_Graphic*, QPrinter&, PdfPrintParams&);
 static void drawGraphic(RS_Graphic *graphic, QPrinter &printer, RS_Painter &painter);
+static void reportWriteFailure(const QString& outFile);
 
 void PdfPrintLoop::run(){
     int failed = 0;
@@ -82,7 +83,13 @@ bool PdfPrintLoop::printOneFileToOnePdf(const QString& inputFile) {
 
     setupPrinterAndPaper(graphic, printer, m_params);
 
+    // the printer opens the output file when painting begins
     RS_Painter painter(&printer);
+    if (!painter.isActive()) {
+        reportWriteFailure(m_params.outFile);
+        delete doc;
+        return false;
+    }
 
     if (m_params.monochrome) {
         painter.setDrawingMode(RS2::ModeBW);
@@ -90,11 +97,15 @@ bool PdfPrintLoop::printOneFileToOnePdf(const QString& inputFile) {
 
     drawGraphic(graphic, printer, painter);
 
-    painter.end();
+    // ending the painter flushes the PDF
+    const bool written = painter.end();
+    delete doc;
+    if (!written) {
+        reportWriteFailure(m_params.outFile);
+        return false;
+    }
 
     qDebug() << "Printing" << inputFile << "to" << m_params.outFile << "DONE";
-
-    delete doc;
     return true;
 }
 
@@ -148,7 +159,15 @@ int PdfPrintLoop::printManyFilesToOnePdf() {
         setupPrinterAndPaper(contentItems.at(0).graphic, printer, m_params);
     }
 
+    // the printer opens the output file when painting begins
     RS_Painter painter(&printer);
+    if (!painter.isActive()) {
+        reportWriteFailure(m_params.outFile);
+        for (const auto &item : contentItems) {
+            delete item.doc;
+        }
+        return failed + static_cast<int>(contentItems.size());
+    }
 
     if (m_params.monochrome) {
         painter.setDrawingMode(RS2::ModeBW);
@@ -173,8 +192,16 @@ int PdfPrintLoop::printManyFilesToOnePdf() {
         }
     }
 
-    painter.end();
+    // ending the painter flushes the PDF
+    if (!painter.end()) {
+        reportWriteFailure(m_params.outFile);
+        return failed + static_cast<int>(contentItems.size());
+    }
     return failed;
+}
+
+static void reportWriteFailure(const QString& outFile){
+    qCritical("ERROR: failed to write '%s'", qPrintable(outFile));
 }
 
 static bool openDocAndSetGraphic(RS_Document** doc, RS_Graphic** graphic,

--- a/librecad/src/main/console_dxf2pdf/pdf_print_loop.cpp
+++ b/librecad/src/main/console_dxf2pdf/pdf_print_loop.cpp
@@ -83,7 +83,8 @@ bool PdfPrintLoop::printOneFileToOnePdf(const QString& inputFile) {
 
     setupPrinterAndPaper(graphic, printer, m_params);
 
-    // the printer opens the output file when painting begins
+    // The printer opens the output file when painting begins. That is the only
+    // write failure Qt reports: its PDF engine ignores errors once the file is open.
     RS_Painter painter(&printer);
     if (!painter.isActive()) {
         reportWriteFailure(m_params.outFile);
@@ -97,15 +98,11 @@ bool PdfPrintLoop::printOneFileToOnePdf(const QString& inputFile) {
 
     drawGraphic(graphic, printer, painter);
 
-    // ending the painter flushes the PDF
-    const bool written = painter.end();
-    delete doc;
-    if (!written) {
-        reportWriteFailure(m_params.outFile);
-        return false;
-    }
+    painter.end();
 
     qDebug() << "Printing" << inputFile << "to" << m_params.outFile << "DONE";
+
+    delete doc;
     return true;
 }
 
@@ -159,7 +156,7 @@ int PdfPrintLoop::printManyFilesToOnePdf() {
         setupPrinterAndPaper(contentItems.at(0).graphic, printer, m_params);
     }
 
-    // the printer opens the output file when painting begins
+    // The printer opens the output file when painting begins.
     RS_Painter painter(&printer);
     if (!painter.isActive()) {
         reportWriteFailure(m_params.outFile);
@@ -192,11 +189,7 @@ int PdfPrintLoop::printManyFilesToOnePdf() {
         }
     }
 
-    // ending the painter flushes the PDF
-    if (!painter.end()) {
-        reportWriteFailure(m_params.outFile);
-        return failed + static_cast<int>(contentItems.size());
-    }
+    painter.end();
     return failed;
 }
 

--- a/librecad/src/main/console_dxf2pdf/pdf_print_loop.cpp
+++ b/librecad/src/main/console_dxf2pdf/pdf_print_loop.cpp
@@ -29,7 +29,7 @@
 #include <QPrinter>
 #include <QtCore>
 
-#include "lc_documentsstorage.h"
+#include "console_command_utils.h"
 #include "lc_graphicviewport.h"
 #include "lc_printing.h"
 #include "lc_printviewportrenderer.h"
@@ -199,22 +199,17 @@ static void reportWriteFailure(const QString& outFile){
 
 static bool openDocAndSetGraphic(RS_Document** doc, RS_Graphic** graphic,
     const QString& dxfFile){
-    *doc = new RS_Graphic();
-    const LC_DocumentsStorage storage;
-    if (!storage.loadDocument((*doc)->getGraphic(), dxfFile, RS2::FormatUnknown)) {
-    // if (!(*doc)->open(dxfFile, RS2::FormatUnknown)) {
-        qDebug() << "ERROR: Failed to open document" << dxfFile;
+    auto* newGraphic = new RS_Graphic();
+    *doc = newGraphic;
+    // LC_Console::importGraphic() reports on stderr. Importing through the
+    // document storage opens a message box no console command can close.
+    if (!LC_Console::importGraphic(*newGraphic, dxfFile)) {
         delete *doc;
+        *doc = nullptr;
         return false;
     }
 
-    *graphic = (*doc)->getGraphic();
-    if (*graphic == nullptr) {
-        qDebug() << "ERROR: No graphic in" << dxfFile;
-        delete *doc;
-        return false;
-    }
-
+    *graphic = newGraphic;
     return true;
 }
 

--- a/librecad/src/main/console_dxf2png.cpp
+++ b/librecad/src/main/console_dxf2png.cpp
@@ -28,6 +28,7 @@
 #include <QApplication>
 #include <QCoreApplication>
 #include <QImageWriter>
+#include <QSaveFile>
 #include <QtCore>
 #include <QtSvg>
 
@@ -38,7 +39,6 @@
 #include "qg_dialogfactory.h"
 
 #include "lc_actionfileexportmakercam.h"
-#include "lc_documentsstorage.h"
 #include "lc_graphicviewport.h"
 #include "lc_printviewportrenderer.h"
 #include "main.h"
@@ -64,7 +64,7 @@ static std::unique_ptr<RS_Document> openDocAndSetGraphic(const QString&);
 
 static void touchGraphic(RS_Graphic*);
 
-static QSize parsePngSizeArg(const QString&);
+static bool parsePngSizeArg(const QString& arg, QSize& size);
 
 bool slotFileExport(RS_Graphic* graphic,
                     const QString& name,
@@ -108,9 +108,13 @@ bool exportOneImageFile(const ImageCommandSpec& spec, const QString& inputFile,
                              borders, black, bw);
             }
 
-    qDebug() << "Printing" << inputFile << "to" << outputFile
-             << (ret ? "Done" : "Failed");
-    return ret;
+    if (!ret) {
+        qCritical("ERROR: failed to write '%s'", qPrintable(outputFile));
+        return false;
+    }
+
+    qDebug() << "Printing" << inputFile << "to" << outputFile << "Done";
+    return true;
 }
 
 int runImageCommand(int argc, char* argv[], const ImageCommandSpec& spec) {
@@ -181,13 +185,24 @@ int runImageCommand(int argc, char* argv[], const ImageCommandSpec& spec) {
         parser.showHelp(EXIT_FAILURE);
 
     // Set PNG size from user input
-    const QSize pngSize = parsePngSizeArg(parser.value(pngSizeOpt)); // If nothing, use default values.
+    QSize pngSize;
+    if (!parsePngSizeArg(parser.value(pngSizeOpt), pngSize)) {
+        qCritical("ERROR: invalid output size '%s'; use WxH in pixels, such as 1920x1080.",
+                  qPrintable(parser.value(pngSizeOpt)));
+        return EXIT_FAILURE;
+    }
 
-    const QStringList inputFiles = LC_Console::collectInputFiles(args, spec.acceptedExts);
+    QStringList skippedArgs;
+    const QStringList inputFiles =
+        LC_Console::collectInputFiles(args, spec.acceptedExts, &skippedArgs);
     if (inputFiles.isEmpty()) {
         qCritical("ERROR: no %s files found in arguments.",
                   qPrintable(LC_Console::extensionDescription(spec.acceptedExts)));
         return EXIT_FAILURE;
+    }
+    for (const QString& skipped : skippedArgs) {
+        qWarning("WARNING: '%s' is not a %s file and was skipped.", qPrintable(skipped),
+                 qPrintable(LC_Console::extensionDescription(spec.acceptedExts)));
     }
 
     if (LC_Console::containsDwgInput(inputFiles) &&
@@ -212,15 +227,25 @@ int runImageCommand(int argc, char* argv[], const ImageCommandSpec& spec) {
         return EXIT_FAILURE;
     }
 
+    QStringList outputFiles;
+    for (const QString& inputFile : inputFiles) {
+        outputFiles.append(outFile.isEmpty()
+            ? LC_Console::defaultOutputPath(inputFile, spec.outputExt, outDir)
+            : outFile);
+    }
+
+    QString outputTargetsError;
+    if (!LC_Console::validateOutputTargets(inputFiles, outputFiles, &outputTargetsError)) {
+        qCritical("ERROR: %s", qPrintable(outputTargetsError));
+        return EXIT_FAILURE;
+    }
+
     RS_FONTLIST->init();
     RS_PATTERNLIST->init();
 
     int failed = 0;
-    for (const QString& inputFile : inputFiles) {
-        const QString outputFile = outFile.isEmpty()
-            ? LC_Console::defaultOutputPath(inputFile, spec.outputExt, outDir)
-            : outFile;
-        if (!exportOneImageFile(spec, inputFile, outputFile, pngSize))
+    for (int i = 0; i < inputFiles.size(); ++i) {
+        if (!exportOneImageFile(spec, inputFiles.at(i), outputFiles.at(i), pngSize))
             ++failed;
     }
 
@@ -263,17 +288,14 @@ int console_dwg2svg(int argc, char* argv[])
 
 static std::unique_ptr<RS_Document> openDocAndSetGraphic(const QString& dxfFile){
     auto doc = std::make_unique<RS_Graphic>();
-    const LC_DocumentsStorage storage;
-    if (!storage.loadDocument(doc.get(), dxfFile, RS2::FormatUnknown)) {
-    // if (!doc->open(dxfFile, RS2::FormatUnknown)) {
-        qDebug() << "ERROR: Failed to open document" << dxfFile;
-        qDebug() << "Check if file exists";
+    // LC_Console::importGraphic() reports on stderr. Importing through the
+    // document storage opens a message box no console command can close.
+    if (!LC_Console::importGraphic(*doc, dxfFile))
         return {};
-    }
 
     const RS_Graphic* graphic = doc->getGraphic();
     if (graphic == nullptr) {
-        qDebug() << "ERROR: No graphic in" << dxfFile;
+        qCritical("ERROR: no drawing in '%s'", qPrintable(dxfFile));
         return {};
     }
 
@@ -374,17 +396,14 @@ bool slotFileExport(RS_Graphic* graphic, const QString& name,
 
     // end the picture output
     if(format.toLower() != "svg")  {
-        // RVT_PORT QImageIO iio;
-        QImageWriter iio;
         const QImage img = picture->toImage();
-        // RVT_PORT iio.setImage(img);
-        iio.setFileName(name);
-        iio.setFormat(format.toLatin1());
-        // RVT_PORT if (iio.write()) {
-        if (iio.write(img)) {
-            ret = true;
+        // QSaveFile reports a write that fails after the file is open, and
+        // leaves an existing file alone until the new one is complete.
+        QSaveFile file{name};
+        if (file.open(QIODevice::WriteOnly)) {
+            QImageWriter iio{&file, format.toLatin1()};
+            ret = iio.write(img) && file.commit();
         }
-//        QString error=iio.errorString();
     }
     QApplication::restoreOverrideCursor();
 
@@ -398,29 +417,30 @@ bool slotFileExport(RS_Graphic* graphic, const QString& name,
 }
 
 /////////////////
-/// \brief Parses the user input of PNG output resolution and
-/// converts it to a vector value
-/// \param arg - input string
-/// \return
+/// \brief Parses the user input of PNG output resolution
+/// \param arg - input string, empty for the default size
+/// \param size - receives the output size in pixels
+/// \return false if the input is not a positive WxH size
 ///
-static QSize parsePngSizeArg(const QString& arg) {
-    QSize v(2000, 1000); // default resolution
+static bool parsePngSizeArg(const QString& arg, QSize& size) {
+    size = QSize(2000, 1000); // default resolution
 
     if (arg.isEmpty()) {
-        return v;
+        return true;
     }
 
-    const QRegularExpression re("^(?<width>\\d+)[x|X]{1}(?<height>\\d+)$");
+    const QRegularExpression re("^(?<width>\\d+)[xX](?<height>\\d+)$");
     const QRegularExpressionMatch match = re.match(arg);
-
-    if (match.hasMatch()) {
-        const QString width = match.captured("width");
-        const QString height = match.captured("height");
-        v.setWidth(width.toDouble());
-        v.setHeight(height.toDouble());
-    } else {
-        qDebug() << "WARNING: Ignoring incorrect PNG resolution:" << arg;
+    if (!match.hasMatch()) {
+        return false;
     }
 
-    return v;
+    const int width = match.captured("width").toInt();
+    const int height = match.captured("height").toInt();
+    if (width <= 0 || height <= 0) {
+        return false;
+    }
+
+    size = QSize(width, height);
+    return true;
 }

--- a/librecad/src/main/tests/console_command_utils_tests.cpp
+++ b/librecad/src/main/tests/console_command_utils_tests.cpp
@@ -27,7 +27,9 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <QDir>
+#include <QFile>
 #include <QStringList>
+#include <QTemporaryDir>
 
 #include "console_command_utils.h"
 
@@ -146,3 +148,37 @@ TEST_CASE("console helper maps every supported DWG output version",
     CHECK(LC_Console::dwgFormatForVersion("2011") == RS2::FormatUnknown);
 }
 #endif
+
+TEST_CASE("console helper refuses output paths that would destroy data",
+          "[console][output]") {
+    const QTemporaryDir dir;
+    REQUIRE(dir.isValid());
+    const QString input = dir.filePath("drawing.dxf");
+    QFile file{input};
+    REQUIRE(file.open(QIODevice::WriteOnly));
+    file.close();
+    QString error;
+
+    CHECK(LC_Console::validateOutputTargets({input}, {dir.filePath("drawing.pdf")}, &error));
+
+    CHECK_FALSE(LC_Console::validateOutputTargets({input}, {input}, &error));
+    CHECK(error.contains("overwrite"));
+
+    CHECK_FALSE(LC_Console::validateOutputTargets({input}, {dir.path()}, &error));
+    CHECK(error.contains("directory"));
+
+    CHECK_FALSE(LC_Console::validateOutputTargets({dir.filePath("a/x.dxf"), dir.filePath("b/x.dxf")},
+                                                  {dir.filePath("out/x.png"), dir.filePath("out/x.png")},
+                                                  &error));
+    CHECK(error.contains("more than one"));
+}
+
+TEST_CASE("console helper reports the arguments it leaves out",
+          "[console][commands]") {
+    QStringList skipped;
+    const QStringList inputs =
+        LC_Console::collectInputFiles({"a.dxf", "typo.dfx", "notes.txt"}, {"dxf"}, &skipped);
+
+    CHECK(inputs == QStringList({"a.dxf"}));
+    CHECK(skipped == QStringList({"typo.dfx", "notes.txt"}));
+}

--- a/librecad/src/main/tests/lc_consoleimporttests.cpp
+++ b/librecad/src/main/tests/lc_consoleimporttests.cpp
@@ -1,0 +1,77 @@
+// File: lc_consoleimporttests.cpp
+
+/*
+ * ********************************************************************************
+ * This file is part of the LibreCAD project, a 2D CAD program
+ *
+ * Copyright (C) 2026 LibreCAD.org
+ * Copyright (C) 2026 Dongxu Li (github.com/dxli)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ * ********************************************************************************
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <QFile>
+#include <QTemporaryDir>
+
+#include "console_command_utils.h"
+#include "lc_actiontestsupport.h"
+#include "rs_graphic.h"
+
+namespace {
+
+// A drawing holding one line.
+constexpr const char* kLineDxf =
+    "0\nSECTION\n2\nENTITIES\n"
+    "0\nLINE\n8\n0\n10\n0.0\n20\n0.0\n30\n0.0\n11\n100.0\n21\n50.0\n31\n0.0\n"
+    "0\nENDSEC\n0\nEOF\n";
+
+QString writeFile(const QTemporaryDir& dir, const QString& name, const char* content) {
+    const QString path = dir.filePath(name);
+    QFile file{path};
+    REQUIRE(file.open(QIODevice::WriteOnly));
+    REQUIRE(file.write(content) > 0);
+    return path;
+}
+
+} // namespace
+
+TEST_CASE("console import reads a drawing", "[console][import]") {
+    REQUIRE(lc::test::application() != nullptr);
+    const QTemporaryDir dir;
+    REQUIRE(dir.isValid());
+
+    RS_Graphic graphic;
+    CHECK(LC_Console::importGraphic(graphic, writeFile(dir, "line.dxf", kLineDxf)));
+    CHECK(graphic.count() == 1);
+}
+
+// Before the import reported errors itself, a file it could not read opened a
+// message box, and a console command waited for it forever. This test would
+// hang rather than fail.
+TEST_CASE("console import fails on a file it cannot read", "[console][import]") {
+    REQUIRE(lc::test::application() != nullptr);
+    const QTemporaryDir dir;
+    REQUIRE(dir.isValid());
+
+    RS_Graphic fromGarbage;
+    CHECK_FALSE(LC_Console::importGraphic(fromGarbage, writeFile(dir, "garbage.dxf", "this is not a drawing\n")));
+
+    RS_Graphic fromMissing;
+    CHECK_FALSE(LC_Console::importGraphic(fromMissing, dir.filePath("missing.dxf")));
+}

--- a/librecad/src/main/tests/lc_pdfprintlooptests.cpp
+++ b/librecad/src/main/tests/lc_pdfprintlooptests.cpp
@@ -1,0 +1,116 @@
+// File: lc_pdfprintlooptests.cpp
+
+/*
+ * ********************************************************************************
+ * This file is part of the LibreCAD project, a 2D CAD program
+ *
+ * Copyright (C) 2026 LibreCAD.org
+ * Copyright (C) 2026 Dongxu Li (github.com/dxli)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ * ********************************************************************************
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdlib>
+
+#include <QFile>
+#include <QFileInfo>
+#include <QTemporaryDir>
+
+#include "lc_actiontestsupport.h"
+#include "pdf_print_loop.h"
+
+namespace {
+
+// a drawing holding one line
+constexpr const char* kLineDxf =
+    "0\nSECTION\n2\nENTITIES\n"
+    "0\nLINE\n8\n0\n10\n0.0\n20\n0.0\n30\n0.0\n11\n100.0\n21\n50.0\n31\n0.0\n"
+    "0\nENDSEC\n0\nEOF\n";
+
+QString writeLineDxf(const QTemporaryDir& dir, const QString& name) {
+    const QString path = dir.filePath(name);
+    QFile file{path};
+    REQUIRE(file.open(QIODevice::WriteOnly));
+    REQUIRE(file.write(kLineDxf) > 0);
+    return path;
+}
+
+// the exit code the console command returns for these parameters
+int printAndGetExitCode(const PdfPrintParams& params) {
+    PdfPrintLoop loop{params};
+    int exitCode = -1;
+    QObject::connect(&loop, &PdfPrintLoop::finished, &loop,
+                     [&exitCode](const int code) { exitCode = code; });
+    loop.run();
+    return exitCode;
+}
+
+} // namespace
+
+TEST_CASE("PDF printing fails when the output file cannot be written",
+          "[console][pdf]") {
+    REQUIRE(lc::test::application() != nullptr);
+    const QTemporaryDir dir;
+    REQUIRE(dir.isValid());
+    const QString missingDir = dir.filePath("missing");
+
+    PdfPrintParams params;
+    params.inputFiles = {writeLineDxf(dir, "first.dxf")};
+
+    SECTION("one input into a named file") {
+        params.outFile = missingDir + "/out.pdf";
+        CHECK(printAndGetExitCode(params) == EXIT_FAILURE);
+        CHECK_FALSE(QFileInfo::exists(params.outFile));
+    }
+
+    SECTION("several inputs into one named file") {
+        params.inputFiles.append(writeLineDxf(dir, "second.dxf"));
+        params.outFile = missingDir + "/out.pdf";
+        CHECK(printAndGetExitCode(params) == EXIT_FAILURE);
+        CHECK_FALSE(QFileInfo::exists(params.outFile));
+    }
+
+    SECTION("each input to its own file in the output directory") {
+        params.outDir = missingDir;
+        CHECK(printAndGetExitCode(params) == EXIT_FAILURE);
+        CHECK_FALSE(QFileInfo::exists(missingDir + "/first.pdf"));
+    }
+}
+
+TEST_CASE("PDF printing succeeds when the output file can be written",
+          "[console][pdf]") {
+    REQUIRE(lc::test::application() != nullptr);
+    const QTemporaryDir dir;
+    REQUIRE(dir.isValid());
+
+    PdfPrintParams params;
+    params.inputFiles = {writeLineDxf(dir, "first.dxf")};
+
+    SECTION("one input into a named file") {
+        params.outFile = dir.filePath("out.pdf");
+        CHECK(printAndGetExitCode(params) == EXIT_SUCCESS);
+        CHECK(QFileInfo(params.outFile).size() > 0);
+    }
+
+    SECTION("each input to its own file in the output directory") {
+        params.outDir = dir.path();
+        CHECK(printAndGetExitCode(params) == EXIT_SUCCESS);
+        CHECK(QFileInfo(dir.filePath("first.pdf")).size() > 0);
+    }
+}

--- a/librecad/src/main/tests/lc_pdfprintlooptests.cpp
+++ b/librecad/src/main/tests/lc_pdfprintlooptests.cpp
@@ -37,7 +37,7 @@
 
 namespace {
 
-// a drawing holding one line
+// A drawing holding one line.
 constexpr const char* kLineDxf =
     "0\nSECTION\n2\nENTITIES\n"
     "0\nLINE\n8\n0\n10\n0.0\n20\n0.0\n30\n0.0\n11\n100.0\n21\n50.0\n31\n0.0\n"
@@ -51,7 +51,7 @@ QString writeLineDxf(const QTemporaryDir& dir, const QString& name) {
     return path;
 }
 
-// the exit code the console command returns for these parameters
+// The exit code the console command returns for these parameters.
 int printAndGetExitCode(const PdfPrintParams& params) {
     PdfPrintLoop loop{params};
     int exitCode = -1;
@@ -87,6 +87,9 @@ TEST_CASE("PDF printing fails when the output file cannot be written",
     }
 
     SECTION("each input to its own file in the output directory") {
+        // dxf2pdf creates the output directory before printing. A missing one
+        // stands in here for a directory that cannot be written, since a test
+        // running as root can write to any directory.
         params.outDir = missingDir;
         CHECK(printAndGetExitCode(params) == EXIT_FAILURE);
         CHECK_FALSE(QFileInfo::exists(missingDir + "/first.pdf"));


### PR DESCRIPTION
A follow-up to #2801 and #2802, for `master`. It started with `dxf2pdf` exiting 0 after writing nothing, and grew into a review of every console converter — `dxf2pdf`, `dwg2pdf`, `dxf2png`, `dwg2png`, `dxf2svg`, `dwg2svg`, `dxf2dwg`, `dwg2dxf` — and of the GUI's **Export as PDF** and **Export as CAM/plain SVG**. The common thread: work that failed, or destroyed a file, without saying so.

## What was wrong

Measured on `b0debaf69`, with the inputs in one directory and the working directory in another.

| case | before | after |
| --- | --- | --- |
| a file that cannot be parsed, given to `dxf2png`, `dxf2svg` or `dxf2pdf` | **hangs for good** | exit 1, `ERROR: import failed for '…'` |
| `dxf2pdf`/`dwg2pdf` cannot write the PDF | exit 0, nothing written | exit 1, `ERROR: failed to write '…'` |
| `dxf2png`/`dxf2svg` write fails after the file is open | exit 0, truncated file | exit 1, no half-written file left |
| the output path names an input file | the input is overwritten | refused before anything is converted |
| two inputs, one `-t` directory, same file name | one silently overwrites the other | refused |
| `dxf2dwg -o <a directory>` | the directory is **replaced** by a DWG file | refused |
| an argument that names no input file | skipped in silence | `WARNING: '…' is not a .dxf file and was skipped.` |
| `dxf2png -r abc`, `-r 0x0` | default size, or a generic failure | refused, naming the accepted form |
| `dxf2pdf -r`, `-s`, `-p`, `-f`, `-z` with an unreadable value | ignored in silence | refused, naming the accepted form |
| `dxf2pdf -o` together with `-t` | the directory in `-o` is dropped | refused, as the other commands already did |
| GUI **Export as PDF** cannot write the file | nothing happens, no message | an error box naming the file |
| GUI **Export as PDF**, dialog cancelled | exports anyway, to the default name | nothing is written |
| GUI **Export as CAM/plain SVG** cannot write | nothing happens, no message | an error box naming the file |

The hang has a single cause: `RS_FileIO::fileImport()` reports an error in a message box unless it is given a callback, and nobody can close a message box that a console command opened. `dxf2dwg` and `dwg2dxf` passed a callback; the image and PDF commands went through `LC_DocumentsStorage`, which does not.

## The fixes

**Shared helpers** (`console_command_utils`), so every converter behaves the same way:

- `importGraphic()` reads a drawing and reports import errors on stderr, accepting a partial import as the DWG commands already did.
- `validateOutputTargets()` refuses output paths that would destroy data — a directory, an input file, or the same file twice — before any conversion starts.
- `collectInputFiles()` now reports the arguments it left out, and each command warns about them.

**PDF** (`PdfPrintLoop`): check `painter.isActive()` as soon as the painter is created; the printer opens the output file there. On failure, report the file, free what was opened, and count the inputs as failed.

**PNG and SVG**: write through `QSaveFile`, so a write that fails after the file is open is reported and no half-written file replaces an existing one. `writeSvg()` also checks the generator and the stream; it used to return success whether or not anything reached the disk.

**Options**: a value that cannot be read is refused instead of ignored, and the size separator no longer accepts `210|297`.

**GUI**: **Export as PDF** returns on Cancel and reports a file it cannot write; **Export as CAM/plain SVG** reports a failed write. The drawing code moved unchanged into `LC_Printing::printGraphic()` so the failure is visible to a test.

## What is still not caught

Qt's PDF engine ignores write errors once the file is open, and `QPdfPrintEngine::end()` returns `true` unconditionally, so a PDF write that fails partway — a full disk — still exits 0: with the output size capped at 1 KB, `dxf2pdf` left a truncated PDF and exited 0. PNG and SVG are covered, because they write through `QSaveFile`. Catching it for PDF would mean printing through a `QPdfWriter` on a file the caller owns, which is beyond this PR.

## Tests

- `librecad/src/main/tests/lc_pdfprintlooptests.cpp` (`[console][pdf]`) drives `PdfPrintLoop`: it fails and writes nothing for one input into a named file, several inputs into one named file, and one PDF per input into a directory that does not exist; it succeeds with a non-empty PDF otherwise.
- `librecad/src/main/tests/lc_consoleimporttests.cpp` (`[console][import]`) reads a drawing, and fails on a file it cannot parse and on one that does not exist. Before the fix this test would hang rather than fail.
- `librecad/src/lib/printing/tests/lc_printingtests.cpp` (`[printing][pdf]`) calls `LC_Printing::printGraphic()`: `false` and no file for a directory that does not exist, `true` and a non-empty PDF otherwise.
- `librecad/src/main/tests/console_command_utils_tests.cpp` gains the output-target rules and the skipped-argument list.

The dialogs are not driven by the tests: Cancel and the error boxes are covered by review only.

## Verification

Built from `b0debaf69` on macOS with Qt 6.

- `librecad_tests "[console],[pdf],[printing]"`: 95 assertions in 14 test cases pass.
- Fast suite (`librecad_tests` with the CTest exclusion tags): 116,438 assertions in 2,425 test cases. The only failures are 22 assertions in 18 test cases of `dwg_write_smoke_tests.cpp`, which fail the same way on `b0debaf69` without this change.
- Every row of the table above was measured with the rebuilt `LibreCAD` binary, before and after.
- Ordinary conversions still work: `dxf2png`, `dxf2svg`, `dxf2pdf` and `dxf2dwg` each write their file and exit 0, as does `dxf2pdf -p 210x297 -r 300 -s 0.01`.

The PDF loop on `2.2.1` has the same silent failure; this PR does not change that branch.
